### PR TITLE
remove project path as it was a misleading but unused flag

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -3,7 +3,7 @@ testdata_dir = "testdata"
 tmp_dir = "tmp"
 
 [build]
-  args_bin = ["monolith", "--project-path", "."]
+  args_bin = ["monolith"]
   bin = "./dist/reliant"
   # Build to temp file then atomically rename to prevent race condition where
   # Temporal SDK tries to read the binary while it's being rebuilt.

--- a/.air.windows.toml
+++ b/.air.windows.toml
@@ -3,7 +3,7 @@ testdata_dir = "testdata"
 tmp_dir = "tmp"
 
 [build]
-  args_bin = ["monolith", "--project-path", "."]
+  args_bin = ["monolith"]
   bin = "dist/reliant.exe"
   # Windows version: Build to temp file then rename using move command
   # Using cmd /c to properly chain commands on Windows

--- a/cmd/reliant/commands/daemon.go
+++ b/cmd/reliant/commands/daemon.go
@@ -150,16 +150,15 @@ After registering, run 'reliant daemon start' to connect.`,
 
 func newDaemonStartCmd() *cobra.Command {
 	var (
-		port        string
-		grpcURL     string
-		projectPath string
-		dataDir     string
-		token       string
-		userID      string
-		background  bool
-		tlsCert     string
-		tlsKey      string
-		tlsMode     string
+		port       string
+		grpcURL    string
+		dataDir    string
+		token      string
+		userID     string
+		background bool
+		tlsCert    string
+		tlsKey     string
+		tlsMode    string
 	)
 
 	cmd := &cobra.Command{
@@ -258,14 +257,12 @@ Credential resolution order:
 
 			err := daemonruntime.Start(ctx, daemonruntime.StartOptions{
 				BootstrapConfig: bootstrap.DaemonBootstrapConfig{
-					UserID:      userID,
-					AuthToken:   token,
-					GRPCURL:     grpcURL,
-					TLSMode:     parsedTLSMode,
-					ProjectRoot: projectPath,
-					DataDir:     dataDir,
+					UserID:    userID,
+					AuthToken: token,
+					GRPCURL:   grpcURL,
+					TLSMode:   parsedTLSMode,
+					DataDir:   dataDir,
 				},
-				WorkingDir: projectPath,
 			})
 			if err != nil {
 				return fmt.Errorf("tools-daemon exited with error: %w", err)
@@ -278,7 +275,6 @@ Credential resolution order:
 
 	cmd.Flags().StringVar(&port, "port", envOrDefault("TOOLS_DAEMON_PORT", "9190"), "Daemon listen port")
 	cmd.Flags().StringVar(&grpcURL, "grpc-url", envOrDefault("DAEMON_GRPC_URL", ""), "gRPC server URL to connect to")
-	cmd.Flags().StringVar(&projectPath, "project-path", envOrDefault("DAEMON_WORKING_DIR", "."), "Project root directory")
 	cmd.Flags().StringVar(&dataDir, "data-dir", envOrDefault("DAEMON_DATA_DIR", "./data"), "Data directory")
 	cmd.Flags().StringVar(&token, "token", envOrDefault("DAEMON_PAT", ""), "Personal access token (overrides daemon credentials file)")
 	cmd.Flags().StringVar(&userID, "user-id", envOrDefault("DAEMON_AUTH_USER_ID", ""), "User ID (overrides daemon credentials file)")

--- a/cmd/reliant/commands/monolith.go
+++ b/cmd/reliant/commands/monolith.go
@@ -33,7 +33,6 @@ import (
 	"github.com/reliant-labs/reliant/internal/logging"
 	"github.com/reliant-labs/reliant/internal/monolith"
 	"github.com/reliant-labs/reliant/internal/pidlock"
-	skillcatalog "github.com/reliant-labs/reliant/internal/skills/catalog"
 	"github.com/reliant-labs/reliant/internal/streaming"
 	"github.com/reliant-labs/reliant/internal/telemetry"
 	"github.com/reliant-labs/reliant/internal/temporal"
@@ -42,7 +41,6 @@ import (
 
 func newMonolithCmd() *cobra.Command {
 	var dataDir string
-	var projectPath string
 
 	cmd := &cobra.Command{
 		Use:   "monolith",
@@ -52,17 +50,16 @@ SQLite database, HTTP API, gRPC server, and in-process tools daemon.
 
 This is the local development mode used by the Electron desktop app.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runMonolith(cmd, args, &dataDir, &projectPath)
+			return runMonolith(cmd, args, &dataDir)
 		},
 	}
 
 	cmd.Flags().StringVar(&dataDir, "data-dir", envOrDefault("RELIANT_DATA_DIR", "./data"), "Base data directory (default: ./data or RELIANT_DATA_DIR)")
-	cmd.Flags().StringVar(&projectPath, "project-path", envOrDefault("RELIANT_PROJECT_PATH", "."), "Path to project root")
 
 	return cmd
 }
 
-func runMonolith(_ *cobra.Command, _ []string, dataDir, projectPath *string) error {
+func runMonolith(_ *cobra.Command, _ []string, dataDir *string) error {
 	// Load configuration from environment
 	// Frontend port 0 means auto-assign (find free consecutive ports)
 	frontendPort := envutil.GetEnvInt("TEMPORAL_FRONTEND_PORT", 0)
@@ -135,7 +132,6 @@ func runMonolith(_ *cobra.Command, _ []string, dataDir, projectPath *string) err
 			LogLevel:     temporalLogLevel,
 		},
 		AnthropicAPIKey: os.Getenv("ANTHROPIC_API_KEY"),
-		ProjectPath:     *projectPath,
 		// MCPServers are loaded per-project on-demand
 	}
 
@@ -167,10 +163,6 @@ func runMonolith(_ *cobra.Command, _ []string, dataDir, projectPath *string) err
 		logging.Info("[Sentry] Skipping initialization in development mode")
 		telemetry.SetReporter(telemetry.NewNoopReporter())
 	}
-
-	// Warm skills metadata index for the configured project root at startup so
-	// request-time discovery does not pay initial scan cost.
-	skillcatalog.DefaultCatalogIndex().PreloadProject(context.Background(), *projectPath)
 
 	// Start integration server (Temporal + Workers)
 	ctx := context.Background()
@@ -330,7 +322,6 @@ func runMonolith(_ *cobra.Command, _ []string, dataDir, projectPath *string) err
 		TLSCertFile:          tlsCertFile,
 		TLSKeyFile:           tlsKeyFile,
 		ToolsDaemonPort:      toolsDaemonPort,
-		ProjectPath:          *projectPath,
 		DataDir:              *dataDir,
 	})
 

--- a/cmd/reliant/commands/open.go
+++ b/cmd/reliant/commands/open.go
@@ -124,19 +124,17 @@ This is the "reliant ." command.`,
 					}
 
 					bootCfg := bootstrap.DaemonBootstrapConfig{
-						UserID:      userID,
-						AuthToken:   accessToken,
-						GRPCURL:     grpcURL,
-						TLSMode:     tlsMode,
-						ProjectRoot: projectPath,
-						DataDir:     dataDir,
+						UserID:    userID,
+						AuthToken: accessToken,
+						GRPCURL:   grpcURL,
+						TLSMode:   tlsMode,
+						DataDir:   dataDir,
 					}
 
 					fmt.Println("Starting tools daemon...")
 					go func() {
 						if err := daemonruntime.Start(daemonCtx, daemonruntime.StartOptions{
 							BootstrapConfig: bootCfg,
-							WorkingDir:      projectPath,
 						}); err != nil && daemonCtx.Err() == nil {
 							fmt.Fprintf(os.Stderr, "Daemon error: %v\n", err)
 						}

--- a/docs/architecture/monolith.mdx
+++ b/docs/architecture/monolith.mdx
@@ -12,7 +12,6 @@ reliant monolith [flags]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--data-dir` | `./data` or `RELIANT_DATA_DIR` | Base directory for databases, logs, and certificates |
-| `--project-path` | `.` or `RELIANT_PROJECT_PATH` | Path to the project root the backend serves |
 
 When the process starts, it initializes each embedded component in sequence, prints a status banner with the active ports, and blocks until it receives `SIGTERM`, `SIGINT`, or detects its parent process has exited (the "suicide pact" pattern used when launched by Electron).
 
@@ -84,7 +83,6 @@ The log level is controlled by the standard `LOG_LEVEL` environment variable. In
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `RELIANT_DATA_DIR` | `./data` | Base data directory for databases, logs, and certs |
-| `RELIANT_PROJECT_PATH` | `.` | Path to the project root |
 | `API_PORT` | `8080` | HTTP API server port |
 | `GRPC_PORT` | `9090` | gRPC/ConnectRPC server port |
 | `TOOLS_DAEMON_PORT` | `9190` | In-process tools daemon port |

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -96,9 +96,6 @@ type Config struct {
 	// Worktree
 	WorktreeBaseDir string // Base directory for worktrees (defaults to ~/.reliant/worktrees)
 
-	// Project
-	ProjectPath string // Path to project root (for loading .reliant.json, etc.) - only used in development
-
 	// Testing overrides - when set, these will be used instead of creating real executors
 	// This allows e2e tests to inject mocks without modifying the server code
 	ToolExecutorOverride toolexec.ToolExecutor // Mock tool executor for testing
@@ -498,11 +495,6 @@ func (s *Server) Reconciler() *reconciliation.Reconciler {
 // SharedTaskQueueName returns the shared task queue name (with optional test suffix)
 func (s *Server) SharedTaskQueueName() string {
 	return workersetup.TaskQueueName(s.config.TaskQueueSuffix)
-}
-
-// ProjectPath returns the project path from config
-func (s *Server) ProjectPath() string {
-	return s.config.ProjectPath
 }
 
 // DataDir returns the data directory path where databases and state files are stored

--- a/internal/monolith/daemon_starter.go
+++ b/internal/monolith/daemon_starter.go
@@ -32,7 +32,6 @@ type LazyDaemonStarter struct {
 	remoteToolExecutor      *toolexec.RemoteExecutor
 	tlsCertFile, tlsKeyFile string
 	toolsDaemonPort         int
-	projectPath             string
 	dataDir                 string
 
 	// Runtime state (protected by mu)
@@ -49,7 +48,6 @@ type LazyDaemonStarterConfig struct {
 	RemoteToolExecutor      *toolexec.RemoteExecutor
 	TLSCertFile, TLSKeyFile string
 	ToolsDaemonPort         int
-	ProjectPath             string
 	DataDir                 string
 }
 
@@ -62,7 +60,6 @@ func NewLazyDaemonStarter(cfg LazyDaemonStarterConfig) *LazyDaemonStarter {
 		tlsCertFile:          cfg.TLSCertFile,
 		tlsKeyFile:           cfg.TLSKeyFile,
 		toolsDaemonPort:      cfg.ToolsDaemonPort,
-		projectPath:          cfg.ProjectPath,
 		dataDir:              cfg.DataDir,
 	}
 }
@@ -93,7 +90,7 @@ func (s *LazyDaemonStarter) startLocked(userID string) error {
 	logging.Info("Starting in-process daemon (lazy)", "userID", userID)
 
 	// Preload skills catalog for known projects
-	projectPaths := []string{s.projectPath}
+	var projectPaths []string
 	projects, listErr := s.repo.ListProjects(context.Background(), db.ProjectFilters{UserID: userID, Limit: 100000, Offset: 0})
 	if listErr != nil {
 		logging.Warn("Failed listing projects for startup skills catalog preload", "error", listErr, "user_id", userID)
@@ -151,14 +148,12 @@ func (s *LazyDaemonStarter) startLocked(userID string) error {
 	go func() {
 		err := daemonruntime.Start(daemonCtx, daemonruntime.StartOptions{
 			BootstrapConfig: bootstrap.DaemonBootstrapConfig{
-				UserID:      userID,
-				AuthToken:   rawPAT,
-				GRPCURL:     daemonURL,
-				TLSMode:     daemonTLSMode,
-				ProjectRoot: s.projectPath,
-				DataDir:     s.dataDir,
+				UserID:    userID,
+				AuthToken: rawPAT,
+				GRPCURL:   daemonURL,
+				TLSMode:   daemonTLSMode,
+				DataDir:   s.dataDir,
 			},
-			WorkingDir: s.projectPath,
 		})
 		if err != nil && err != context.Canceled {
 			logging.Error("In-process daemon runtime exited", "error", err)

--- a/internal/toolexec/bootstrap/config.go
+++ b/internal/toolexec/bootstrap/config.go
@@ -17,12 +17,11 @@ const (
 
 // DaemonBootstrapConfig is the explicit launcher-provided config for tools-daemon.
 type DaemonBootstrapConfig struct {
-	UserID      string
-	AuthToken   string
-	GRPCURL     string
-	TLSMode     TLSMode
-	ProjectRoot string
-	DataDir     string
+	UserID    string
+	AuthToken string
+	GRPCURL   string
+	TLSMode   TLSMode
+	DataDir   string
 }
 
 func (c DaemonBootstrapConfig) Validate() error {

--- a/internal/toolexec/daemonruntime/runtime.go
+++ b/internal/toolexec/daemonruntime/runtime.go
@@ -66,7 +66,6 @@ type daemonClient struct {
 
 type StartOptions struct {
 	BootstrapConfig bootstrap.DaemonBootstrapConfig
-	WorkingDir      string
 }
 
 func Start(ctx context.Context, opts StartOptions) error {
@@ -74,7 +73,7 @@ func Start(ctx context.Context, opts StartOptions) error {
 		return fmt.Errorf("daemon runtime bootstrap config invalid: %w", err)
 	}
 
-	client, err := newDaemonClient(opts.BootstrapConfig, opts.WorkingDir)
+	client, err := newDaemonClient(opts.BootstrapConfig)
 	if err != nil {
 		return err
 	}
@@ -91,8 +90,9 @@ func Start(ctx context.Context, opts StartOptions) error {
 	return nil
 }
 
-func newDaemonClient(bootCfg bootstrap.DaemonBootstrapConfig, workingDir string) (*daemonClient, error) {
-	cwd := strings.TrimSpace(workingDir)
+func newDaemonClient(bootCfg bootstrap.DaemonBootstrapConfig) (*daemonClient, error) {
+	// Resolve CWD: prefer DAEMON_WORKING_DIR env var (used in Docker), else os.Getwd().
+	cwd := strings.TrimSpace(os.Getenv("DAEMON_WORKING_DIR"))
 	if cwd == "" {
 		resolvedCwd, err := os.Getwd()
 		if err != nil {


### PR DESCRIPTION
## Description

remove project path as it was a misleading but unused flag

## Type of Change

<!-- Add the appropriate label to this PR -->

- [ ] 🚀 Feature (`changelog:feature`)
- [ ] 🐛 Bug fix (`changelog:fix`)
- [ ] ⚡ Performance (`changelog:perf`)
- [ ] 📚 Documentation (`changelog:docs`)
- [x] 🔧 Improvement/Refactor (`changelog:improvement`)
- [ ] ⚠️ Breaking change (`changelog:breaking`)
- [ ] 🔒 Security (`changelog:security`)
- [ ] 🏗️ Infrastructure/CI (`changelog:infra`)
- [ ] 🚫 Skip changelog (`changelog:skip`)

## Changelog Entry

remove project path as it was a misleading but unused flag

## Testing

<!-- How was this tested? -->

## Screenshots

<!-- If applicable, add screenshots -->
