### PR TITLE
reliant provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,18 @@ VITE_SENTRY_REPLAYS_ERROR_SAMPLE_RATE=1.0
 # CORS_ALLOWED_ORIGINS=https://reliant-prod.web.app,https://reliantlabs.io
 
 # =============================================================================
+# Reliant Managed Access (optional, disabled by default)
+# =============================================================================
+# Opt-in gate for Reliant-managed provider access. When false or unset, the
+# Reliant managed-access provider stays hidden and inert in settings/runtime.
+RELIANT_FEATURE_RELIANT_MANAGED_ACCESS_ENABLED=false
+# Control-plane base URL used for Reliant token management and runtime access exchange.
+# RELIANT_CONTROLPLANE_URL=https://controlplane.reliantlabs.io
+# Runtime base URL used by the synthetic `@reliant` driver after the control-plane
+# returns a short-lived runtime key.
+# RELIANT_RUNTIME_BASE_URL=https://runtime.reliantlabs.io/v1
+
+# =============================================================================
 # Supabase Edge Functions (set via `supabase secrets set` or Dashboard)
 # =============================================================================
 # These are NOT .env variables - they're set as Supabase secrets.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,18 @@ nodes:
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and the [`contributing/`](contributing/) directory for detailed guides.
 
+### Optional: Reliant managed access for local development
+
+Reliant-managed provider access is disabled by default. To opt in locally, set these environment variables:
+
+```bash
+RELIANT_FEATURE_RELIANT_MANAGED_ACCESS_ENABLED=true
+RELIANT_CONTROLPLANE_URL=https://controlplane.reliantlabs.io
+RELIANT_RUNTIME_BASE_URL=https://runtime.reliantlabs.io/v1
+```
+
+With the feature flag unset or `false`, Reliant-specific managed-access settings and synthetic `@reliant` runtime models stay hidden and inactive.
+
 ## License
 
 Copyright (c) 2026 Reliant Labs, Inc. Licensed under the [Business Source License 1.1](LICENSE).

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -11,6 +11,7 @@ const (
 	UserIDContextKey    contextKey = "user_id"
 	UserRoleContextKey  contextKey = "user_role"
 	UserEmailContextKey contextKey = "user_email"
+	UserJWTContextKey   contextKey = "user_jwt"
 )
 
 // GetUserIDFromContext extracts the user ID from the context
@@ -27,4 +28,19 @@ func MustGetUserID(ctx context.Context) string {
 		panic("user_id not found in context - auth middleware not applied?")
 	}
 	return userID
+}
+
+// GetUserJWTFromContext extracts the raw user JWT from the context.
+func GetUserJWTFromContext(ctx context.Context) (string, bool) {
+	jwt, ok := ctx.Value(UserJWTContextKey).(string)
+	return jwt, ok
+}
+
+// MustGetUserJWT extracts the raw user JWT from context and panics if not found.
+func MustGetUserJWT(ctx context.Context) string {
+	jwt, ok := GetUserJWTFromContext(ctx)
+	if !ok || jwt == "" {
+		panic("user_jwt not found in context - auth middleware not applied?")
+	}
+	return jwt
 }

--- a/internal/controlplane/client.go
+++ b/internal/controlplane/client.go
@@ -1,0 +1,242 @@
+package controlplane
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultBaseURL       = ""
+	defaultTimeout       = 10 * time.Second
+	userTokenServicePath = "/controlplane.v1.UserModelTokenService"
+	llmAccessServicePath = "/controlplane.v1.LLMAccessService"
+)
+
+var ErrNotConfigured = fmt.Errorf("control-plane client is not configured")
+
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+type Config struct {
+	BaseURL string
+	Timeout time.Duration
+}
+
+type RPCError struct {
+	StatusCode int
+	Code       string
+	Message    string
+}
+
+func (e *RPCError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Code == "" {
+		return fmt.Sprintf("control-plane request failed with status %d: %s", e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("control-plane %s (%d): %s", e.Code, e.StatusCode, e.Message)
+}
+
+func IsCode(err error, code string) bool {
+	rpcErr, ok := err.(*RPCError)
+	return ok && rpcErr.Code == code
+}
+
+func LoadConfigFromEnv() Config {
+	cfg := Config{
+		BaseURL: strings.TrimRight(strings.TrimSpace(os.Getenv("RELIANT_CONTROLPLANE_URL")), "/"),
+		Timeout: defaultTimeout,
+	}
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = defaultBaseURL
+	}
+	if raw := strings.TrimSpace(os.Getenv("RELIANT_CONTROLPLANE_TIMEOUT")); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+			cfg.Timeout = d
+		} else if secs, err := strconv.Atoi(raw); err == nil && secs > 0 {
+			cfg.Timeout = time.Duration(secs) * time.Second
+		}
+	}
+	return cfg
+}
+
+func NewClientFromEnv() *Client {
+	return NewClient(LoadConfigFromEnv())
+}
+
+func NewClient(cfg Config) *Client {
+	if strings.TrimSpace(cfg.BaseURL) == "" {
+		return nil
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = defaultTimeout
+	}
+	return &Client{
+		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
+		httpClient: &http.Client{
+			Timeout: cfg.Timeout,
+		},
+	}
+}
+
+func (c *Client) Enabled() bool {
+	return c != nil && c.baseURL != ""
+}
+
+type CreateUserTokenRequest struct {
+	Name             string `json:"name,omitempty"`
+	DaemonID         string `json:"daemonId,omitempty"`
+	Ephemeral        bool   `json:"ephemeral"`
+	ExpiresInSeconds int64  `json:"expiresInSeconds"`
+}
+
+type DaemonToken struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	TokenPrefix string `json:"tokenPrefix"`
+	Ephemeral   bool   `json:"ephemeral"`
+	CreatedAt   string `json:"createdAt"`
+	LastUsedAt  string `json:"lastUsedAt"`
+	ExpiresAt   string `json:"expiresAt"`
+	RevokedAt   string `json:"revokedAt"`
+}
+
+type CreateUserTokenResponse struct {
+	Token       string      `json:"token"`
+	DaemonToken DaemonToken `json:"daemonToken"`
+}
+
+type ListUserTokensResponse struct {
+	DaemonTokens []DaemonToken `json:"daemonTokens"`
+	Tokens       []DaemonToken `json:"tokens"`
+}
+
+type RevokeUserTokenRequest struct {
+	TokenID string `json:"tokenId"`
+}
+
+type GetCurrentLLMAccessRequest struct {
+	AllowAnonymous bool `json:"allowAnonymous"`
+}
+
+type GetCurrentLLMAccessResponse struct {
+	Key                 string   `json:"key"`
+	KeyAlias            string   `json:"keyAlias"`
+	UserID              string   `json:"userId"`
+	OwnerID             string   `json:"ownerId"`
+	OwnerType           string   `json:"ownerType"`
+	PlanID              string   `json:"planId"`
+	PlanCode            string   `json:"planCode"`
+	AllowedModels       []string `json:"allowedModels"`
+	RequestTags         []string `json:"requestTags"`
+	Spend               float64  `json:"spend"`
+	HardBudgetUSD       float64  `json:"hardBudgetUsd"`
+	BudgetDuration      string   `json:"budgetDuration"`
+	RPMLimit            int64    `json:"rpmLimit"`
+	TPMLimit            int64    `json:"tpmLimit"`
+	MaxParallelRequests int64    `json:"maxParallelRequests"`
+	KeyDuration         string   `json:"keyDuration"`
+}
+
+type connectErrorBody struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Error   string `json:"error"`
+}
+
+func (c *Client) CreateUserToken(ctx context.Context, userJWT string, req CreateUserTokenRequest) (*CreateUserTokenResponse, error) {
+	if !c.Enabled() {
+		return nil, ErrNotConfigured
+	}
+	var resp CreateUserTokenResponse
+	if err := c.postJSON(ctx, userTokenServicePath+"/CreateUserToken", userJWT, req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *Client) ListUserTokens(ctx context.Context, userJWT string) ([]DaemonToken, error) {
+	if !c.Enabled() {
+		return nil, ErrNotConfigured
+	}
+	var resp ListUserTokensResponse
+	if err := c.postJSON(ctx, userTokenServicePath+"/ListUserTokens", userJWT, map[string]any{}, &resp); err != nil {
+		return nil, err
+	}
+	if len(resp.DaemonTokens) > 0 {
+		return resp.DaemonTokens, nil
+	}
+	return resp.Tokens, nil
+}
+
+func (c *Client) RevokeUserToken(ctx context.Context, userJWT string, tokenID string) error {
+	if !c.Enabled() {
+		return ErrNotConfigured
+	}
+	return c.postJSON(ctx, userTokenServicePath+"/RevokeUserToken", userJWT, RevokeUserTokenRequest{TokenID: tokenID}, nil)
+}
+
+func (c *Client) GetCurrentLLMAccess(ctx context.Context, token string) (*GetCurrentLLMAccessResponse, error) {
+	if !c.Enabled() {
+		return nil, ErrNotConfigured
+	}
+	var resp GetCurrentLLMAccessResponse
+	if err := c.postJSON(ctx, llmAccessServicePath+"/GetCurrentLLMAccess", token, GetCurrentLLMAccessRequest{AllowAnonymous: false}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *Client) postJSON(ctx context.Context, path string, bearerToken string, body any, out any) error {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(bearerToken))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("perform request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var bodyErr connectErrorBody
+		_ = json.Unmarshal(respBody, &bodyErr)
+		msg := strings.TrimSpace(bodyErr.Message)
+		if msg == "" {
+			msg = strings.TrimSpace(bodyErr.Error)
+		}
+		if msg == "" {
+			msg = strings.TrimSpace(string(respBody))
+		}
+		return &RPCError{StatusCode: resp.StatusCode, Code: strings.TrimSpace(bodyErr.Code), Message: msg}
+	}
+	if out == nil || len(respBody) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}

--- a/internal/features/reliant_gate.go
+++ b/internal/features/reliant_gate.go
@@ -1,0 +1,39 @@
+package features
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/reliant-labs/reliant/internal/db"
+)
+
+const (
+	ReliantManagedAccessEnabledKey     = "reliant_managed_access_enabled"
+	ReliantManagedAccessEnabledSetting = "features.reliant_managed_access_enabled"
+	ReliantManagedAccessEnabledEnvVar  = "RELIANT_FEATURE_RELIANT_MANAGED_ACCESS_ENABLED"
+)
+
+// IsReliantManagedAccessEnabledForContext evaluates whether Reliant managed access is enabled for a user context.
+//
+// Precedence:
+// 1) RELIANT_FEATURE_RELIANT_MANAGED_ACCESS_ENABLED env override
+// 2) user setting features.reliant_managed_access_enabled
+// 3) feature registry/static default
+func IsReliantManagedAccessEnabledForContext(ctx context.Context, repo db.Repository, userID string) bool {
+	if envValue := strings.TrimSpace(os.Getenv(ReliantManagedAccessEnabledEnvVar)); envValue != "" {
+		if parsed, err := strconv.ParseBool(envValue); err == nil {
+			return parsed
+		}
+	}
+
+	if userID != "" && repo != nil {
+		enabled, err := repo.GetBoolOrDefault(ctx, userID, nil, ReliantManagedAccessEnabledSetting, false)
+		if err == nil {
+			return enabled
+		}
+	}
+
+	return GetGlobalRegistry().EvaluateBool(ctx, ReliantManagedAccessEnabledKey, false)
+}

--- a/internal/features/reliant_gate_test.go
+++ b/internal/features/reliant_gate_test.go
@@ -1,0 +1,28 @@
+package features
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reliant-labs/reliant/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsReliantManagedAccessEnabledForContext_PreferenceOrder(t *testing.T) {
+	repo, cleanup := db.SetupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	const userID = "test-user"
+
+	t.Setenv(ReliantManagedAccessEnabledEnvVar, "")
+	require.False(t, IsReliantManagedAccessEnabledForContext(ctx, repo, userID))
+
+	require.NoError(t, repo.SetString(ctx, userID, nil, ReliantManagedAccessEnabledSetting, "true"))
+	require.True(t, IsReliantManagedAccessEnabledForContext(ctx, repo, userID))
+
+	t.Setenv(ReliantManagedAccessEnabledEnvVar, "false")
+	require.False(t, IsReliantManagedAccessEnabledForContext(ctx, repo, userID))
+	t.Setenv(ReliantManagedAccessEnabledEnvVar, "true")
+	require.True(t, IsReliantManagedAccessEnabledForContext(ctx, repo, userID))
+}

--- a/internal/grpc/interceptors/auth.go
+++ b/internal/grpc/interceptors/auth.go
@@ -145,58 +145,66 @@ func (i *AuthInterceptor) authenticateRequest(ctx context.Context, procedure str
 		return ctx, nil, "", nil
 	}
 
-	// Dev mode bypass - use hardcoded dev user
+	// Prefer a real bearer token when one is present, even in development mode.
+	authHeader := strings.TrimSpace(header("Authorization"))
+	if authHeader != "" {
+		tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+		if tokenString == authHeader {
+			logging.Warn("[gRPC Auth] Invalid authorization header format",
+				"procedure", procedure)
+			return nil, nil, "", connect.NewError(connect.CodeUnauthenticated,
+				fmt.Errorf("invalid authorization header format"))
+		}
+		if i.validator == nil {
+			logging.Warn("[gRPC Auth] Authorization header provided but JWT validator unavailable",
+				"procedure", procedure,
+				"dev_mode", i.devMode)
+			return nil, nil, "", connect.NewError(connect.CodeUnauthenticated,
+				fmt.Errorf("authorization token cannot be validated in this environment"))
+		}
+
+		claims, err := i.validator.ValidateToken(tokenString)
+		if err != nil {
+			logging.Warn("[gRPC Auth] Invalid token",
+				"error", err,
+				"procedure", procedure,
+				"dev_mode", i.devMode)
+			return nil, nil, "", connect.NewError(connect.CodeUnauthenticated,
+				fmt.Errorf("invalid or expired token"))
+		}
+
+		ctx = context.WithValue(ctx, auth.UserIDContextKey, claims.Sub)
+		ctx = context.WithValue(ctx, auth.UserRoleContextKey, claims.Role)
+		ctx = context.WithValue(ctx, auth.UserEmailContextKey, claims.Email)
+		ctx = context.WithValue(ctx, auth.UserJWTContextKey, tokenString)
+
+		logging.Debug("[gRPC Auth] Authenticated request",
+			"user_id", claims.Sub,
+			"role", claims.Role,
+			"email", claims.Email,
+			"procedure", procedure,
+			"dev_mode", i.devMode)
+
+		return ctx, claims, tokenString, nil
+	}
+
+	// Development fallback - use hardcoded dev user only when no bearer token is present.
 	if i.devMode {
 		ctx = context.WithValue(ctx, auth.UserIDContextKey, DevUser.Sub)
 		ctx = context.WithValue(ctx, auth.UserRoleContextKey, DevUser.Role)
 		ctx = context.WithValue(ctx, auth.UserEmailContextKey, DevUser.Email)
 
-		logging.Debug("[gRPC Auth] Dev mode - using dev user",
+		logging.Debug("[gRPC Auth] Dev mode - using dev user fallback",
 			"user_id", DevUser.Sub,
 			"procedure", procedure)
 
 		return ctx, DevUser, "", nil
 	}
 
-	// Extract token from Authorization header
-	authHeader := header("Authorization")
-	if authHeader == "" {
-		logging.Warn("[gRPC Auth] Missing authorization token",
-			"procedure", procedure)
-		return nil, nil, "", connect.NewError(connect.CodeUnauthenticated,
-			fmt.Errorf("missing authorization token"))
-	}
-
-	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
-	if tokenString == authHeader {
-		logging.Warn("[gRPC Auth] Invalid authorization header format",
-			"procedure", procedure)
-		return nil, nil, "", connect.NewError(connect.CodeUnauthenticated,
-			fmt.Errorf("invalid authorization header format"))
-	}
-
-	// Validate token
-	claims, err := i.validator.ValidateToken(tokenString)
-	if err != nil {
-		logging.Warn("[gRPC Auth] Invalid token",
-			"error", err,
-			"procedure", procedure)
-		return nil, nil, "", connect.NewError(connect.CodeUnauthenticated,
-			fmt.Errorf("invalid or expired token"))
-	}
-
-	// Add claims to context
-	ctx = context.WithValue(ctx, auth.UserIDContextKey, claims.Sub)
-	ctx = context.WithValue(ctx, auth.UserRoleContextKey, claims.Role)
-	ctx = context.WithValue(ctx, auth.UserEmailContextKey, claims.Email)
-
-	logging.Debug("[gRPC Auth] Authenticated request",
-		"user_id", claims.Sub,
-		"role", claims.Role,
-		"email", claims.Email,
+	logging.Warn("[gRPC Auth] Missing authorization token",
 		"procedure", procedure)
-
-	return ctx, claims, tokenString, nil
+	return nil, nil, "", connect.NewError(connect.CodeUnauthenticated,
+		fmt.Errorf("missing authorization token"))
 }
 
 // trackSession handles analytics session tracking for authenticated users
@@ -309,9 +317,13 @@ func NewTimeoutInterceptor() *TimeoutInterceptor {
 			"/reliant.v1.MCPService/CallTool":    60 * time.Second,
 			// Attachment uploads - depends on file size
 			"/reliant.v1.AttachmentService/Upload": 60 * time.Second,
-			// Provider API key validation - Gemini requires minimum 10s deadline
-			"/reliant.v1.SettingsService/ValidateProviderAPIKey": 20 * time.Second,
-			"/reliant.v1.SettingsService/UpdateProviderAPIKey":   20 * time.Second,
+			// Provider settings and control-plane operations
+			"/reliant.v1.SettingsService/ValidateProviderAPIKey":     20 * time.Second,
+			"/reliant.v1.SettingsService/UpdateProviderAPIKey":       20 * time.Second,
+			"/reliant.v1.SettingsService/CreateReliantProviderToken": 20 * time.Second,
+			"/reliant.v1.SettingsService/ListReliantProviderTokens":  20 * time.Second,
+			"/reliant.v1.SettingsService/RevokeReliantProviderToken": 20 * time.Second,
+			"/reliant.v1.SettingsService/GetReliantProviderStatus":   20 * time.Second,
 			// Worktree operations - involve git commands that can take 10-30s
 			"/reliant.v1.WorktreeService/CreateWorktree":       30 * time.Second,
 			"/reliant.v1.WorktreeService/DeleteWorktree":       30 * time.Second,

--- a/internal/grpc/interceptors/auth.go
+++ b/internal/grpc/interceptors/auth.go
@@ -156,6 +156,18 @@ func (i *AuthInterceptor) authenticateRequest(ctx context.Context, procedure str
 				fmt.Errorf("invalid authorization header format"))
 		}
 		if i.validator == nil {
+			if i.devMode {
+				ctx = context.WithValue(ctx, auth.UserIDContextKey, DevUser.Sub)
+				ctx = context.WithValue(ctx, auth.UserRoleContextKey, DevUser.Role)
+				ctx = context.WithValue(ctx, auth.UserEmailContextKey, DevUser.Email)
+				ctx = context.WithValue(ctx, auth.UserJWTContextKey, tokenString)
+
+				logging.Info("[gRPC Auth] JWT validator unavailable in dev mode; using dev claims and preserving raw bearer token",
+					"procedure", procedure)
+
+				return ctx, DevUser, tokenString, nil
+			}
+
 			logging.Warn("[gRPC Auth] Authorization header provided but JWT validator unavailable",
 				"procedure", procedure,
 				"dev_mode", i.devMode)

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/net/http2/h2c"
 
 	"github.com/reliant-labs/reliant/internal/auth"
+	"github.com/reliant-labs/reliant/internal/controlplane"
 	"github.com/reliant-labs/reliant/internal/db"
 	"github.com/reliant-labs/reliant/internal/gen/reliant/v1/reliantv1connect"
 	"github.com/reliant-labs/reliant/internal/grpc/interceptors"
@@ -61,6 +62,7 @@ type Config struct {
 	ToolExecutor       *toolexec.RemoteExecutor     // Optional remote tool executor to bind to daemon service
 	ToolsDaemonService *services.ToolsDaemonService // Optional pre-created daemon service to share across startup wiring
 	DaemonRouter       toolexec.DaemonRouter        // Optional pre-created daemon router; built from ToolsDaemonService if nil
+	ControlPlaneClient *controlplane.Client         // Optional Reliant control-plane client; defaults from env when nil
 
 	BackgroundProvider services.BackgroundProcessProvider // Provider for background process state
 
@@ -125,6 +127,11 @@ func NewServer(cfg *Config) (*Server, error) {
 		router = toolexec.NewLocalDaemonRouter(toolsDaemonService)
 	}
 
+	controlPlaneClient := cfg.ControlPlaneClient
+	if controlPlaneClient == nil {
+		controlPlaneClient = controlplane.NewClientFromEnv()
+	}
+
 	// Create services
 	systemService := services.NewSystemService(database, cfg.TemporalClient, cfg.NATSChecker, cfg.StreamingHub, cfg.LocalMode)
 	planService := services.NewPlanService(database)
@@ -136,7 +143,7 @@ func NewServer(cfg *Config) (*Server, error) {
 	yieldService := services.NewYieldService(database, cfg.PauseService)
 	chatService := services.NewChatService(database, cfg.TemporalClient, cfg.PauseService, cfg.SharedTaskQueue)
 	messageService := services.NewMessageService(database)
-	settingsService := services.NewSettingsService(database, router)
+	settingsService := services.NewSettingsService(database, router, controlPlaneClient)
 	mcpService := services.NewMCPService(database, router)
 	workflowService := services.NewWorkflowService(database, router)
 	scenarioService := services.NewScenarioService(database, router)

--- a/internal/grpc/services/catalog.go
+++ b/internal/grpc/services/catalog.go
@@ -55,14 +55,44 @@ func (s *CatalogService) ListModels(
 
 	logging.Info("[ListModels] Building model list for user", "userID", userID, "totalModels", len(allModels), "availableDrivers", len(availableDrivers.Drivers))
 
-	// Build list of all model+driver combinations
-	// Key: "modelID@driverID" to ensure uniqueness
+	// Build list of all model+driver combinations.
+	// Key: "modelID@driverID" to ensure uniqueness when drivers are synthesized.
 	var modelList []*reliantv1.ModelInfo
+	seenModels := make(map[string]struct{})
+	appendModelForDriver := func(model *models.ModelDefinition, driverID string) {
+		uniqueID := model.ID + "@" + driverID
+		if _, seen := seenModels[uniqueID]; seen {
+			return
+		}
+		seenModels[uniqueID] = struct{}{}
 
+		driverDisplayName := getDriverDisplayName(driverID)
+		modelList = append(modelList, &reliantv1.ModelInfo{
+			Id:                  uniqueID,
+			Name:                model.Name,
+			Provider:            driverDisplayName,
+			DriverId:            driverID,
+			Capabilities:        capabilitiesToStrings(model.Capabilities),
+			ContextWindow:       int64(model.Capabilities.MaxContextWindow),
+			DefaultMaxTokens:    int64(model.Capabilities.MaxOutputTokens),
+			CostPer_1MIn:        model.Cost.InputPer1M,
+			CostPer_1MOut:       model.Cost.OutputPer1M,
+			CanReason:           model.Capabilities.CanReason,
+			SupportsAttachments: model.Capabilities.SupportsAttachments,
+			Tags:                model.Tags,
+			SupportsTools:       model.Capabilities.SupportsTools,
+			SupportsCaching:     model.Capabilities.SupportsCaching,
+			SupportedThinkingLevels: models.SupportedThinkingLevelsForModelDriver(
+				model.Capabilities.CanReason,
+				model.ID,
+				driverID,
+			),
+		})
+	}
+
+	reliantConfig, hasReliantDriver := availableDrivers.Drivers[models.DriverID("reliant")]
 	for _, model := range allModels {
-		// For each provider the model supports, check if user has that provider configured
 		for _, provider := range model.Providers {
-			// Local models don't need API keys - they're available if they exist in the registry
 			isLocalDriver := provider.Driver == "local"
 			if isLocalDriver {
 				logging.Info("[ListModels] Found local model", "modelID", model.ID, "driver", provider.Driver)
@@ -73,37 +103,11 @@ func (s *CatalogService) ListModels(
 					continue
 				}
 			}
+			appendModelForDriver(model, provider.Driver)
+		}
 
-			driverID := provider.Driver
-
-			// Create a unique ID that includes the driver
-			// Format: "claude-4.5-sonnet@openrouter"
-			uniqueID := model.ID + "@" + driverID
-
-			// Get display name for the driver (used for grouping in UI)
-			driverDisplayName := getDriverDisplayName(driverID)
-
-			modelList = append(modelList, &reliantv1.ModelInfo{
-				Id:                  uniqueID,
-				Name:                model.Name,
-				Provider:            driverDisplayName, // For UI grouping
-				DriverId:            driverID,          // For routing
-				Capabilities:        capabilitiesToStrings(model.Capabilities),
-				ContextWindow:       int64(model.Capabilities.MaxContextWindow),
-				DefaultMaxTokens:    int64(model.Capabilities.MaxOutputTokens),
-				CostPer_1MIn:        model.Cost.InputPer1M,
-				CostPer_1MOut:       model.Cost.OutputPer1M,
-				CanReason:           model.Capabilities.CanReason,
-				SupportsAttachments: model.Capabilities.SupportsAttachments,
-				Tags:                model.Tags,
-				SupportsTools:       model.Capabilities.SupportsTools,
-				SupportsCaching:     model.Capabilities.SupportsCaching,
-				SupportedThinkingLevels: models.SupportedThinkingLevelsForModelDriver(
-					model.Capabilities.CanReason,
-					model.ID,
-					driverID,
-				),
-			})
+		if hasReliantDriver && reliantConfig.IsConfigured() && len(reliantConfig.AllowedModels) > 0 && reliantConfig.AllowsModel(models.ModelID(model.ID)) {
+			appendModelForDriver(model, "reliant")
 		}
 	}
 
@@ -146,6 +150,7 @@ func getDriverDisplayName(driverID string) string {
 		"gemini":     "Google AI",
 		"openrouter": "OpenRouter",
 		"local":      "Local",
+		"reliant":    "reliant",
 	}
 	if name, ok := displayNames[driverID]; ok {
 		return name
@@ -164,6 +169,7 @@ func sortModelsByProvider(modelList []*reliantv1.ModelInfo) {
 		"Google AI":  4,
 		"OpenRouter": 5,
 		"Local":      6,
+		"reliant":    7,
 	}
 
 	reg := models.MustGetRegistry()

--- a/internal/grpc/services/catalog_list_models_test.go
+++ b/internal/grpc/services/catalog_list_models_test.go
@@ -1,0 +1,62 @@
+package services
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/reliant-labs/reliant/internal/auth"
+	"github.com/reliant-labs/reliant/internal/controlplane"
+	"github.com/reliant-labs/reliant/internal/db"
+	"github.com/reliant-labs/reliant/internal/features"
+	reliantv1 "github.com/reliant-labs/reliant/internal/gen/reliant/v1"
+	driverspkg "github.com/reliant-labs/reliant/internal/llm/drivers"
+)
+
+func TestCatalogService_ListModels_SynthesizesReliantModelsFromAllowlist(t *testing.T) {
+	repo, cleanup := db.SetupTestDB(t)
+	defer cleanup()
+
+	t.Setenv(features.ReliantManagedAccessEnabledEnvVar, "true")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/controlplane.v1.LLMAccessService/GetCurrentLLMAccess", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"key":"sk-reliant-runtime","allowedModels":["claude-4.5-sonnet"]}`))
+	}))
+	defer server.Close()
+
+	driverspkg.InitializeAPIKeyProvider(
+		repo,
+		driverspkg.WithControlPlaneClient(controlplane.NewClient(controlplane.Config{BaseURL: server.URL})),
+		driverspkg.WithReliantRuntimeBaseURL("https://runtime.reliant.test/v1"),
+	)
+
+	ctx := context.WithValue(context.Background(), auth.UserIDContextKey, "test-user")
+	require.NoError(t, repo.SetProviderAPIKey(ctx, "test-user", "reliant", "cpat_test_token"))
+
+	svc := NewCatalogService(nil)
+	resp, err := svc.ListModels(ctx, connect.NewRequest(&reliantv1.ListModelsRequest{}))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	var reliantModel *reliantv1.ModelInfo
+	for _, model := range resp.Msg.Models {
+		if model.Id == "claude-4.5-sonnet@reliant" {
+			reliantModel = model
+			break
+		}
+	}
+	require.NotNil(t, reliantModel, "expected allowlisted Reliant model to be exposed")
+	assert.Equal(t, "reliant", reliantModel.DriverId)
+	assert.Equal(t, "reliant", reliantModel.Provider)
+
+	for _, model := range resp.Msg.Models {
+		assert.NotEqual(t, "gpt-5.4@reliant", model.Id, "non-allowlisted models should not be exposed for Reliant")
+	}
+}

--- a/internal/grpc/services/settings.go
+++ b/internal/grpc/services/settings.go
@@ -105,11 +105,22 @@ func skillsFeatureDisabledError() error {
 	return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("skills feature is disabled"))
 }
 
+func reliantManagedAccessDisabledError() error {
+	return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("reliant managed access feature is disabled"))
+}
+
 func (s *SettingsService) ensureSkillsFeatureEnabled(ctx context.Context, userID string) error {
 	if features.IsSkillsEnabledForContext(ctx, s.database, userID) {
 		return nil
 	}
 	return skillsFeatureDisabledError()
+}
+
+func (s *SettingsService) ensureReliantManagedAccessEnabled(ctx context.Context, userID string) error {
+	if features.IsReliantManagedAccessEnabledForContext(ctx, s.database, userID) {
+		return nil
+	}
+	return reliantManagedAccessDisabledError()
 }
 
 // upsertSetting creates or updates a setting
@@ -183,6 +194,170 @@ func (s *SettingsService) validateAPIKey(ctx context.Context, provider models.Fa
 	}
 
 	return true, "API key is valid"
+}
+
+func stringPtr(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func maskStoredCredential(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	masked := "***"
+	if len(value) > 8 {
+		masked = value[:4] + "..." + value[len(value)-4:]
+	}
+	return &masked
+}
+
+func (s *SettingsService) hasControlPlaneClient() bool {
+	return s.controlPlaneClient != nil && s.controlPlaneClient.Enabled()
+}
+
+func (s *SettingsService) getReliantStoredToken(ctx context.Context, userID string) (string, error) {
+	token, err := s.database.GetProviderAPIKey(ctx, userID, "reliant")
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(token), nil
+}
+
+func requireUserJWT(ctx context.Context) (string, error) {
+	jwt, ok := auth.GetUserJWTFromContext(ctx)
+	jwt = strings.TrimSpace(jwt)
+	if !ok || jwt == "" {
+		return "", connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("signed-in session required"))
+	}
+	return jwt, nil
+}
+
+func controlPlaneErrorMessage(err error, fallback string) string {
+	if errors.Is(err, controlplane.ErrNotConfigured) {
+		return "Reliant control-plane client is not configured"
+	}
+	var rpcErr *controlplane.RPCError
+	if errors.As(err, &rpcErr) {
+		if message := strings.TrimSpace(rpcErr.Message); message != "" {
+			return message
+		}
+	}
+	if err != nil {
+		if message := strings.TrimSpace(err.Error()); message != "" {
+			return message
+		}
+	}
+	return fallback
+}
+
+func controlPlaneErrorCode(err error) string {
+	if errors.Is(err, controlplane.ErrNotConfigured) {
+		return "failed_precondition"
+	}
+	var rpcErr *controlplane.RPCError
+	if errors.As(err, &rpcErr) {
+		return strings.ToLower(strings.TrimSpace(rpcErr.Code))
+	}
+	return ""
+}
+
+func controlPlaneConnectCode(err error) connect.Code {
+	switch controlPlaneErrorCode(err) {
+	case "unauthenticated":
+		return connect.CodeUnauthenticated
+	case "failed_precondition":
+		return connect.CodeFailedPrecondition
+	case "resource_exhausted":
+		return connect.CodeResourceExhausted
+	case "unavailable":
+		return connect.CodeUnavailable
+	case "internal":
+		return connect.CodeInternal
+	}
+
+	var rpcErr *controlplane.RPCError
+	if errors.As(err, &rpcErr) && rpcErr.StatusCode >= 500 {
+		return connect.CodeUnavailable
+	}
+	if err != nil {
+		return connect.CodeUnavailable
+	}
+	return connect.CodeInternal
+}
+
+func mapControlPlaneError(err error, fallback string) error {
+	return connect.NewError(controlPlaneConnectCode(err), fmt.Errorf("%s", controlPlaneErrorMessage(err, fallback)))
+}
+
+func reliantProviderTokenToProto(token controlplane.DaemonToken) *reliantv1.ReliantProviderToken {
+	return &reliantv1.ReliantProviderToken{
+		Id:          token.ID,
+		Name:        token.Name,
+		TokenPrefix: token.TokenPrefix,
+		Ephemeral:   token.Ephemeral,
+		CreatedAt:   token.CreatedAt,
+		LastUsedAt:  stringPtr(token.LastUsedAt),
+		ExpiresAt:   stringPtr(token.ExpiresAt),
+		RevokedAt:   stringPtr(token.RevokedAt),
+	}
+}
+
+func reliantAccessStatusFromGrant(access *controlplane.GetCurrentLLMAccessResponse) *reliantv1.ReliantProviderAccessStatus {
+	if access == nil {
+		return nil
+	}
+	message := "Connected to Reliant"
+	if planCode := strings.TrimSpace(access.PlanCode); planCode != "" {
+		message = fmt.Sprintf("Connected to Reliant (%s)", planCode)
+	}
+	return &reliantv1.ReliantProviderAccessStatus{
+		State:               "connected",
+		Message:             message,
+		PlanId:              stringPtr(access.PlanID),
+		PlanCode:            stringPtr(access.PlanCode),
+		AllowedModels:       append([]string(nil), access.AllowedModels...),
+		RequestTags:         append([]string(nil), access.RequestTags...),
+		Spend:               access.Spend,
+		HardBudgetUsd:       access.HardBudgetUSD,
+		BudgetDuration:      access.BudgetDuration,
+		RpmLimit:            access.RPMLimit,
+		TpmLimit:            access.TPMLimit,
+		MaxParallelRequests: access.MaxParallelRequests,
+		KeyDuration:         access.KeyDuration,
+	}
+}
+
+func reliantAccessStatusFromError(err error, fallback string) *reliantv1.ReliantProviderAccessStatus {
+	if err == nil {
+		return nil
+	}
+	state := controlPlaneErrorCode(err)
+	if state == "" {
+		switch controlPlaneConnectCode(err) {
+		case connect.CodeUnauthenticated:
+			state = "unauthenticated"
+		case connect.CodeFailedPrecondition:
+			state = "failed_precondition"
+		case connect.CodeResourceExhausted:
+			state = "resource_exhausted"
+		case connect.CodeUnavailable:
+			state = "unavailable"
+		default:
+			state = "internal"
+		}
+	}
+	return &reliantv1.ReliantProviderAccessStatus{
+		State:   state,
+		Message: controlPlaneErrorMessage(err, fallback),
+	}
 }
 
 func isReliantSkillScope(scope skills.Scope) bool {
@@ -1302,26 +1477,19 @@ func (s *SettingsService) SavePrompts(ctx context.Context, req *connect.Request[
 func (s *SettingsService) GetProviderStatuses(ctx context.Context, req *connect.Request[reliantv1.GetProviderStatusesRequest]) (*connect.Response[reliantv1.GetProviderStatusesResponse], error) {
 	userID := auth.MustGetUserID(ctx)
 
-	// Get all API keys from dedicated table
 	keys, err := s.database.GetProviderAPIKeys(ctx, userID)
 	if err != nil {
 		logging.Error("Failed to get provider API keys", "error", err)
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get provider statuses"))
 	}
 
-	// Mask the keys for display
-	apiKeys := make(map[string]string)
+	apiKeys := make(map[string]string, len(keys))
 	for provider, key := range keys {
-		maskedKey := ""
-		if len(key) > 8 {
-			maskedKey = key[:4] + "..." + key[len(key)-4:]
-		} else if len(key) > 0 {
-			maskedKey = "***"
+		if masked := maskStoredCredential(key); masked != nil {
+			apiKeys[provider] = *masked
 		}
-		apiKeys[provider] = maskedKey
 	}
 
-	// Supported providers
 	providers := []models.Family{
 		"claude",
 		"codex",
@@ -1330,8 +1498,12 @@ func (s *SettingsService) GetProviderStatuses(ctx context.Context, req *connect.
 		"openai",
 		"gemini",
 	}
+	if features.IsReliantManagedAccessEnabledForContext(ctx, s.database, userID) {
+		providers = append([]models.Family{"reliant"}, providers...)
+	}
 
 	providerDisplayNames := map[models.Family]string{
+		"reliant":    "Reliant",
 		"claude":     "Claude Code",
 		"codex":      "Codex (ChatGPT)",
 		"openrouter": "OpenRouter",
@@ -1347,56 +1519,116 @@ func (s *SettingsService) GetProviderStatuses(ctx context.Context, req *connect.
 			DisplayName: providerDisplayNames[provider],
 		}
 
-		// Claude uses OAuth tokens persisted by Reliant.
 		switch provider {
+		case "reliant":
+			status.AuthMethod = stringPtr("reliant")
+			token, tokenErr := s.getReliantStoredToken(ctx, userID)
+			if tokenErr != nil {
+				logging.Warn("Failed to load Reliant provider token", "error", tokenErr)
+				status.Status = stringPtr("internal")
+				status.StatusMessage = stringPtr("Failed to load Reliant token")
+				statuses = append(statuses, status)
+				continue
+			}
+
+			status.Configured = token != ""
+			status.HasApiKey = token != ""
+			status.MaskedKey = maskStoredCredential(token)
+			if token == "" {
+				status.Status = stringPtr("not_configured")
+				status.StatusMessage = stringPtr("Reliant is not configured")
+				statuses = append(statuses, status)
+				continue
+			}
+
+			if !s.hasControlPlaneClient() {
+				status.Status = stringPtr("failed_precondition")
+				status.StatusMessage = stringPtr(controlPlaneErrorMessage(controlplane.ErrNotConfigured, "Reliant control-plane client is not configured"))
+				statuses = append(statuses, status)
+				continue
+			}
+
+			access, accessErr := s.controlPlaneClient.GetCurrentLLMAccess(ctx, token)
+			if accessErr != nil {
+				accessStatus := reliantAccessStatusFromError(accessErr, "Failed to load Reliant access")
+				status.Status = stringPtr(accessStatus.State)
+				status.StatusMessage = stringPtr(accessStatus.Message)
+			} else {
+				accessStatus := reliantAccessStatusFromGrant(access)
+				status.Status = stringPtr(accessStatus.State)
+				status.StatusMessage = stringPtr(accessStatus.Message)
+			}
 		case "claude":
+			status.AuthMethod = stringPtr("oauth")
 			tokens, tokenErr := s.database.GetClaudeAuthTokens(ctx, userID)
 			if tokenErr != nil {
 				logging.Warn("Failed to load Claude auth tokens", "error", tokenErr)
+				status.Status = stringPtr("internal")
+				status.StatusMessage = stringPtr("Failed to load Claude credentials")
+				statuses = append(statuses, status)
+				continue
 			}
-
-			configured := tokenErr == nil && tokens != nil && strings.TrimSpace(tokens.AccessToken) != ""
-			if configured {
-				if claude.IsTokenExpired(tokens.ExpiresAt) {
-					configured = false
-				}
+			if tokens == nil || strings.TrimSpace(tokens.AccessToken) == "" {
+				status.Status = stringPtr("not_configured")
+				status.StatusMessage = stringPtr("Claude is not connected")
+				statuses = append(statuses, status)
+				continue
 			}
-
-			status.Configured = configured
-			status.HasApiKey = configured
-			// Don't set MaskedKey for Claude - no API key to display
+			if claude.IsTokenExpired(tokens.ExpiresAt) {
+				status.Status = stringPtr("expired")
+				status.StatusMessage = stringPtr("Claude session expired. Please reconnect Claude.")
+				statuses = append(statuses, status)
+				continue
+			}
+			status.Configured = true
+			status.HasApiKey = true
+			status.Status = stringPtr("connected")
+			status.StatusMessage = stringPtr("Connected to Claude")
 		case "codex":
-			// Codex uses OAuth tokens persisted by Reliant.
+			status.AuthMethod = stringPtr("oauth")
 			tokens, tokenErr := s.database.GetCodexAuthTokens(ctx, userID)
 			if tokenErr != nil {
 				logging.Warn("Failed to load Codex auth tokens", "error", tokenErr)
+				status.Status = stringPtr("internal")
+				status.StatusMessage = stringPtr("Failed to load Codex credentials")
+				statuses = append(statuses, status)
+				continue
 			}
-
-			configured := tokenErr == nil && tokens != nil && strings.TrimSpace(tokens.AccessToken) != ""
-			if configured {
-				if codex.IsTokenExpired(tokens.AccessToken) {
-					configured = false
-				}
+			if tokens == nil || strings.TrimSpace(tokens.AccessToken) == "" {
+				status.Status = stringPtr("not_configured")
+				status.StatusMessage = stringPtr("Codex is not connected")
+				statuses = append(statuses, status)
+				continue
 			}
-
-			status.Configured = configured
-			status.HasApiKey = configured
-			// Don't set MaskedKey for Codex - no API key to display
+			if codex.IsTokenExpired(tokens.AccessToken) {
+				status.Status = stringPtr("expired")
+				status.StatusMessage = stringPtr("Codex session expired. Please reconnect Codex.")
+				statuses = append(statuses, status)
+				continue
+			}
+			status.Configured = true
+			status.HasApiKey = true
+			status.Status = stringPtr("connected")
+			status.StatusMessage = stringPtr("Connected to Codex")
 		default:
+			status.AuthMethod = stringPtr("api_key")
 			maskedKey, hasKey := apiKeys[string(provider)]
 			status.Configured = hasKey
 			status.HasApiKey = hasKey
 			if hasKey {
 				status.MaskedKey = &maskedKey
+				status.Status = stringPtr("connected")
+				status.StatusMessage = stringPtr("API key configured")
+			} else {
+				status.Status = stringPtr("not_configured")
+				status.StatusMessage = stringPtr("API key not configured")
 			}
 		}
 
 		statuses = append(statuses, status)
 	}
 
-	return connect.NewResponse(&reliantv1.GetProviderStatusesResponse{
-		Providers: statuses,
-	}), nil
+	return connect.NewResponse(&reliantv1.GetProviderStatusesResponse{Providers: statuses}), nil
 }
 
 // UpdateProviderAPIKey updates or deletes an API key for a provider
@@ -1410,8 +1642,6 @@ func (s *SettingsService) UpdateProviderAPIKey(ctx context.Context, req *connect
 			Action:     action,
 			AuthMethod: authMethod,
 		})
-
-		// Also fire api_key_configured for connect/update actions
 		if action == "connected" || action == "updated" {
 			existingKeys, err := s.database.GetProviderAPIKeys(ctx, userID)
 			totalProviders := 0
@@ -1431,8 +1661,8 @@ func (s *SettingsService) UpdateProviderAPIKey(ctx context.Context, req *connect
 		}
 	}
 
-	// Only supported providers
 	validProviders := map[string]bool{
+		"reliant":    true,
 		"claude":     true,
 		"codex":      true,
 		"anthropic":  true,
@@ -1440,42 +1670,32 @@ func (s *SettingsService) UpdateProviderAPIKey(ctx context.Context, req *connect
 		"gemini":     true,
 		"openrouter": true,
 	}
-
 	if !validProviders[provider] {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("unsupported provider: %s", provider))
 	}
 
 	if provider == "claude" {
 		if strings.TrimSpace(req.Msg.ApiKey) != "" {
-			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("claude does not use manual API keys; use Login with Claude in Settings"))
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Claude does not use manual API keys. Use Login with Claude in Settings"))
 		}
-
 		if err := s.database.DeleteClaudeAuthTokens(ctx, userID); err != nil {
 			logging.Error("Failed to delete Claude auth tokens", "error", err)
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to disconnect from Claude"))
 		}
-
 		if err := s.database.DeleteProviderAPIKey(ctx, userID, "claude"); err != nil {
 			logging.Warn("Failed to remove Claude provider marker", "error", err)
 		}
-
 		trackProviderEvent("disconnected", "oauth")
-
 		if err := s.database.EmitUserRefetch(ctx, userID, db.RefetchConfigHealth, db.RefetchOpts{}); err != nil {
 			logging.Warn("Failed to emit config_health refetch after Claude disconnect", "error", err)
 		}
-
-		return connect.NewResponse(&reliantv1.UpdateProviderAPIKeyResponse{
-			Success: true,
-			Message: "Disconnected from Claude",
-		}), nil
+		return connect.NewResponse(&reliantv1.UpdateProviderAPIKeyResponse{Success: true, Message: "Disconnected from Claude"}), nil
 	}
 
 	if provider == "codex" {
 		if strings.TrimSpace(req.Msg.ApiKey) != "" {
 			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("codex does not use manual API keys. Use Login with Codex in Settings"))
 		}
-
 		if err := s.database.DeleteCodexAuthTokens(ctx, userID); err != nil {
 			logging.Error("Failed to delete Codex auth tokens", "error", err)
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to disconnect from Codex"))
@@ -1485,32 +1705,78 @@ func (s *SettingsService) UpdateProviderAPIKey(ctx context.Context, req *connect
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to disconnect from Codex"))
 		}
 		trackProviderEvent("disconnected", "oauth")
-
 		if err := s.database.EmitUserRefetch(ctx, userID, db.RefetchConfigHealth, db.RefetchOpts{}); err != nil {
 			logging.Warn("Failed to emit config_health refetch after codex disconnect", "error", err)
 		}
+		return connect.NewResponse(&reliantv1.UpdateProviderAPIKeyResponse{Success: true, Message: "Disconnected from Codex"}), nil
+	}
 
-		return connect.NewResponse(&reliantv1.UpdateProviderAPIKeyResponse{
-			Success: true,
-			Message: "Disconnected from Codex",
-		}), nil
+	if provider == "reliant" {
+		if err := s.ensureReliantManagedAccessEnabled(ctx, userID); err != nil {
+			return nil, err
+		}
+		existingToken, err := s.getReliantStoredToken(ctx, userID)
+		if err != nil {
+			logging.Error("Failed to load existing Reliant token", "error", err)
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to update Reliant token"))
+		}
+		token := strings.TrimSpace(req.Msg.ApiKey)
+		if token == "" {
+			if err := s.database.DeleteProviderAPIKey(ctx, userID, "reliant"); err != nil {
+				logging.Error("Failed to delete Reliant provider token", "error", err)
+				return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to disconnect from Reliant"))
+			}
+			trackProviderEvent("disconnected", "reliant")
+			if err := s.database.EmitUserRefetch(ctx, userID, db.RefetchConfigHealth, db.RefetchOpts{}); err != nil {
+				logging.Warn("Failed to emit config_health refetch after Reliant disconnect", "error", err)
+			}
+			return connect.NewResponse(&reliantv1.UpdateProviderAPIKeyResponse{Success: true, Message: "Disconnected from Reliant"}), nil
+		}
+		if !strings.HasPrefix(token, "cpat_") {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Reliant tokens must start with cpat_"))
+		}
+
+		message := "Reliant token updated successfully"
+		if s.hasControlPlaneClient() {
+			access, accessErr := s.controlPlaneClient.GetCurrentLLMAccess(ctx, token)
+			if accessErr != nil {
+				if controlPlaneConnectCode(accessErr) == connect.CodeUnauthenticated {
+					return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("%s", controlPlaneErrorMessage(accessErr, "Invalid Reliant token")))
+				}
+				message = fmt.Sprintf("Reliant token saved. Current access status: %s", controlPlaneErrorMessage(accessErr, "Access unavailable"))
+			} else if accessStatus := reliantAccessStatusFromGrant(access); accessStatus != nil {
+				message = accessStatus.Message
+			}
+		} else {
+			message = "Reliant token saved. Reliant control-plane client is not configured"
+		}
+
+		if err := s.database.SetProviderAPIKey(ctx, userID, "reliant", token); err != nil {
+			logging.Error("Failed to save Reliant provider token", "error", err)
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to save Reliant token"))
+		}
+		if existingToken == "" {
+			trackProviderEvent("connected", "reliant")
+		} else {
+			trackProviderEvent("updated", "reliant")
+		}
+		if err := s.database.EmitUserRefetch(ctx, userID, db.RefetchConfigHealth, db.RefetchOpts{}); err != nil {
+			logging.Warn("Failed to emit config_health refetch after Reliant token update", "error", err)
+		}
+		return connect.NewResponse(&reliantv1.UpdateProviderAPIKeyResponse{Success: true, Message: message}), nil
 	}
 
 	if len(req.Msg.ApiKey) == 0 {
-		// Delete the API key
 		if err := s.database.DeleteProviderAPIKey(ctx, userID, provider); err != nil {
 			logging.Error("Failed to delete provider API key", "provider", provider, "error", err)
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to delete API key"))
 		}
 		trackProviderEvent("deleted", "api_key")
 	} else {
-		// Validate the API key first
 		valid, message := s.validateAPIKey(ctx, models.Family(provider), req.Msg.ApiKey)
 		if !valid {
 			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("%s", message))
 		}
-
-		// Save the API key to dedicated table
 		if err := s.database.SetProviderAPIKey(ctx, userID, provider, req.Msg.ApiKey); err != nil {
 			logging.Error("Failed to set provider API key", "provider", provider, "error", err)
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to save API key"))
@@ -1522,10 +1788,7 @@ func (s *SettingsService) UpdateProviderAPIKey(ctx context.Context, req *connect
 		logging.Warn("Failed to emit config_health refetch after UpdateProviderAPIKey", "error", err)
 	}
 
-	return connect.NewResponse(&reliantv1.UpdateProviderAPIKeyResponse{
-		Success: true,
-		Message: "API key updated successfully",
-	}), nil
+	return connect.NewResponse(&reliantv1.UpdateProviderAPIKeyResponse{Success: true, Message: "API key updated successfully"}), nil
 }
 
 // ValidateProviderAPIKey validates an API key for a provider
@@ -1533,64 +1796,237 @@ func (s *SettingsService) ValidateProviderAPIKey(ctx context.Context, req *conne
 	provider := models.Family(req.Msg.Provider)
 	userID := auth.MustGetUserID(ctx)
 
+	if provider == "reliant" {
+		if err := s.ensureReliantManagedAccessEnabled(ctx, userID); err != nil {
+			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{Valid: false, Message: "reliant managed access feature is disabled"}), nil
+		}
+		token := strings.TrimSpace(req.Msg.ApiKey)
+		if token == "" {
+			storedToken, err := s.getReliantStoredToken(ctx, userID)
+			if err != nil {
+				return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{Valid: false, Message: "Failed to load Reliant token"}), nil
+			}
+			token = storedToken
+		}
+		if token == "" {
+			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{Valid: false, Message: "Reliant is not configured"}), nil
+		}
+		if !strings.HasPrefix(token, "cpat_") {
+			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{Valid: false, Message: "Reliant tokens must start with cpat_"}), nil
+		}
+		if !s.hasControlPlaneClient() {
+			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{Valid: false, Message: "Reliant control-plane client is not configured"}), nil
+		}
+		access, err := s.controlPlaneClient.GetCurrentLLMAccess(ctx, token)
+		if err != nil {
+			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{Valid: false, Message: controlPlaneErrorMessage(err, "Failed to validate Reliant token")}), nil
+		}
+		if accessStatus := reliantAccessStatusFromGrant(access); accessStatus != nil {
+			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{Valid: true, Message: accessStatus.Message}), nil
+		}
+		return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{Valid: true, Message: "Connected to Reliant"}), nil
+	}
+
 	if provider == "claude" {
 		tokens, err := s.database.GetClaudeAuthTokens(ctx, userID)
 		if err != nil {
-			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{
-				Valid:   false,
-				Message: "Failed to load Claude credentials",
-			}), nil
+			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{Valid: false, Message: "Failed to load Claude credentials"}), nil
 		}
 		if tokens == nil || strings.TrimSpace(tokens.AccessToken) == "" {
-			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{
-				Valid:   false,
-				Message: "Claude is not connected",
-			}), nil
+			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{Valid: false, Message: "Claude is not connected"}), nil
 		}
 		if claude.IsTokenExpired(tokens.ExpiresAt) {
-			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{
-				Valid:   false,
-				Message: "Claude session expired. Please reconnect Claude.",
-			}), nil
+			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{Valid: false, Message: "Claude session expired. Please reconnect Claude."}), nil
 		}
-		return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{
-			Valid:   true,
-			Message: "Connected to Claude",
-		}), nil
+		return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{Valid: true, Message: "Connected to Claude"}), nil
 	}
 
 	if provider == "codex" {
 		tokens, err := s.database.GetCodexAuthTokens(ctx, userID)
 		if err != nil {
-			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{
-				Valid:   false,
-				Message: "Failed to load Codex credentials",
-			}), nil
+			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{Valid: false, Message: "Failed to load Codex credentials"}), nil
 		}
 		if tokens == nil || strings.TrimSpace(tokens.AccessToken) == "" {
-			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{
-				Valid:   false,
-				Message: "Codex is not connected",
-			}), nil
+			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{Valid: false, Message: "Codex is not connected"}), nil
 		}
 		if codex.IsTokenExpired(tokens.AccessToken) {
-			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{
-				Valid:   false,
-				Message: "Codex session expired. Please reconnect Codex.",
-			}), nil
+			return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{Valid: false, Message: "Codex session expired. Please reconnect Codex."}), nil
 		}
-		return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{
-			Valid:   true,
-			Message: "Connected to Codex",
-		}), nil
+		return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{Valid: true, Message: "Connected to Codex"}), nil
 	}
 
 	valid, message := s.validateAPIKey(ctx, provider, req.Msg.ApiKey)
+	return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{Valid: valid, Message: message}), nil
+}
 
-	return connect.NewResponse(&reliantv1.ValidateProviderAPIKeyResponse{
-		Valid:   valid,
-		Message: message,
+func (s *SettingsService) CreateReliantProviderToken(ctx context.Context, req *connect.Request[reliantv1.CreateReliantProviderTokenRequest]) (*connect.Response[reliantv1.CreateReliantProviderTokenResponse], error) {
+	userID := auth.MustGetUserID(ctx)
+	if err := s.ensureReliantManagedAccessEnabled(ctx, userID); err != nil {
+		return nil, err
+	}
+	userJWT, err := requireUserJWT(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !s.hasControlPlaneClient() {
+		return nil, mapControlPlaneError(controlplane.ErrNotConfigured, "Reliant control-plane client is not configured")
+	}
+	if req.Msg.ExpiresInSeconds != nil && req.Msg.GetExpiresInSeconds() < 0 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("expires_in_seconds must be >= 0"))
+	}
+
+	cpReq := controlplane.CreateUserTokenRequest{}
+	if req.Msg.Name != nil {
+		cpReq.Name = strings.TrimSpace(req.Msg.GetName())
+	}
+	if req.Msg.Ephemeral != nil {
+		cpReq.Ephemeral = req.Msg.GetEphemeral()
+	}
+	if req.Msg.ExpiresInSeconds != nil {
+		cpReq.ExpiresInSeconds = req.Msg.GetExpiresInSeconds()
+	}
+
+	cpResp, err := s.controlPlaneClient.CreateUserToken(ctx, userJWT, cpReq)
+	if err != nil {
+		return nil, mapControlPlaneError(err, "failed to create Reliant token")
+	}
+	if cpResp == nil || strings.TrimSpace(cpResp.Token) == "" {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("control-plane returned an empty Reliant token"))
+	}
+
+	token := strings.TrimSpace(cpResp.Token)
+	if err := s.database.SetProviderAPIKey(ctx, userID, "reliant", token); err != nil {
+		logging.Error("Failed to persist Reliant provider token", "error", err)
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to save Reliant token"))
+	}
+
+	analyticsClient := analytics.GetClientForUser(ctx, userID)
+	analyticsClient.TrackProviderSettingsUpdated(analytics.ProviderSettingsUpdatedMetrics{Provider: "reliant", Action: "connected", AuthMethod: "reliant"})
+	if existingKeys, err := s.database.GetProviderAPIKeys(ctx, userID); err == nil {
+		totalProviders := 0
+		for _, value := range existingKeys {
+			if value != "" {
+				totalProviders++
+			}
+		}
+		analyticsClient.TrackAPIKeyConfigured(analytics.APIKeyConfiguredMetrics{Provider: "reliant", AuthMethod: "reliant", IsFirstKey: totalProviders <= 1, TotalProviders: totalProviders})
+	}
+	if err := s.database.EmitUserRefetch(ctx, userID, db.RefetchConfigHealth, db.RefetchOpts{}); err != nil {
+		logging.Warn("Failed to emit config_health refetch after Reliant token create", "error", err)
+	}
+
+	return connect.NewResponse(&reliantv1.CreateReliantProviderTokenResponse{
+		Success:     true,
+		Message:     "Reliant token created successfully",
+		Token:       token,
+		DaemonToken: reliantProviderTokenToProto(cpResp.DaemonToken),
 	}), nil
+}
+
+func (s *SettingsService) ListReliantProviderTokens(ctx context.Context, req *connect.Request[reliantv1.ListReliantProviderTokensRequest]) (*connect.Response[reliantv1.ListReliantProviderTokensResponse], error) {
+	userID := auth.MustGetUserID(ctx)
+	if err := s.ensureReliantManagedAccessEnabled(ctx, userID); err != nil {
+		return nil, err
+	}
+	userJWT, err := requireUserJWT(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !s.hasControlPlaneClient() {
+		return nil, mapControlPlaneError(controlplane.ErrNotConfigured, "Reliant control-plane client is not configured")
+	}
+
+	tokens, err := s.controlPlaneClient.ListUserTokens(ctx, userJWT)
+	if err != nil {
+		return nil, mapControlPlaneError(err, "failed to list Reliant tokens")
+	}
+	protoTokens := make([]*reliantv1.ReliantProviderToken, 0, len(tokens))
+	for _, token := range tokens {
+		protoTokens = append(protoTokens, reliantProviderTokenToProto(token))
+	}
+	return connect.NewResponse(&reliantv1.ListReliantProviderTokensResponse{Tokens: protoTokens}), nil
+}
+
+func (s *SettingsService) RevokeReliantProviderToken(ctx context.Context, req *connect.Request[reliantv1.RevokeReliantProviderTokenRequest]) (*connect.Response[reliantv1.RevokeReliantProviderTokenResponse], error) {
+	userID := auth.MustGetUserID(ctx)
+	if err := s.ensureReliantManagedAccessEnabled(ctx, userID); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(req.Msg.TokenId) == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("token_id is required"))
+	}
+	userJWT, err := requireUserJWT(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !s.hasControlPlaneClient() {
+		return nil, mapControlPlaneError(controlplane.ErrNotConfigured, "Reliant control-plane client is not configured")
+	}
+	if err := s.controlPlaneClient.RevokeUserToken(ctx, userJWT, strings.TrimSpace(req.Msg.TokenId)); err != nil {
+		return nil, mapControlPlaneError(err, "failed to revoke Reliant token")
+	}
+
+	message := "Reliant token revoked"
+	if req.Msg.DeleteLocalCredential {
+		if err := s.database.DeleteProviderAPIKey(ctx, userID, "reliant"); err != nil {
+			logging.Error("Failed to delete local Reliant credential", "error", err)
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to remove local Reliant credential"))
+		}
+		analytics.GetClientForUser(ctx, userID).TrackProviderSettingsUpdated(analytics.ProviderSettingsUpdatedMetrics{Provider: "reliant", Action: "disconnected", AuthMethod: "reliant"})
+		message = "Reliant token revoked and local credential removed"
+	}
+	if err := s.database.EmitUserRefetch(ctx, userID, db.RefetchConfigHealth, db.RefetchOpts{}); err != nil {
+		logging.Warn("Failed to emit config_health refetch after Reliant token revoke", "error", err)
+	}
+	return connect.NewResponse(&reliantv1.RevokeReliantProviderTokenResponse{Success: true, Message: message}), nil
+}
+
+func (s *SettingsService) GetReliantProviderStatus(ctx context.Context, req *connect.Request[reliantv1.GetReliantProviderStatusRequest]) (*connect.Response[reliantv1.GetReliantProviderStatusResponse], error) {
+	userID := auth.MustGetUserID(ctx)
+	if err := s.ensureReliantManagedAccessEnabled(ctx, userID); err != nil {
+		return nil, err
+	}
+	storedToken, err := s.getReliantStoredToken(ctx, userID)
+	if err != nil {
+		logging.Error("Failed to load stored Reliant token", "error", err)
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load Reliant provider status"))
+	}
+
+	resp := &reliantv1.GetReliantProviderStatusResponse{
+		Configured:  storedToken != "",
+		MaskedToken: maskStoredCredential(storedToken),
+		Tokens:      []*reliantv1.ReliantProviderToken{},
+	}
+
+	if s.hasControlPlaneClient() {
+		if userJWT, ok := auth.GetUserJWTFromContext(ctx); ok && strings.TrimSpace(userJWT) != "" {
+			tokens, listErr := s.controlPlaneClient.ListUserTokens(ctx, strings.TrimSpace(userJWT))
+			if listErr != nil {
+				logging.Warn("Failed to list Reliant provider tokens", "error", listErr)
+			} else {
+				for _, token := range tokens {
+					resp.Tokens = append(resp.Tokens, reliantProviderTokenToProto(token))
+				}
+			}
+		}
+	}
+
+	if storedToken == "" {
+		resp.Access = &reliantv1.ReliantProviderAccessStatus{State: "not_configured", Message: "Reliant is not configured"}
+		return connect.NewResponse(resp), nil
+	}
+	if !s.hasControlPlaneClient() {
+		resp.Access = reliantAccessStatusFromError(controlplane.ErrNotConfigured, "Reliant control-plane client is not configured")
+		return connect.NewResponse(resp), nil
+	}
+
+	access, accessErr := s.controlPlaneClient.GetCurrentLLMAccess(ctx, storedToken)
+	if accessErr != nil {
+		resp.Access = reliantAccessStatusFromError(accessErr, "Failed to load Reliant access status")
+	} else {
+		resp.Access = reliantAccessStatusFromGrant(access)
+	}
+	return connect.NewResponse(resp), nil
 }
 
 func (s *SettingsService) CompleteCodexOAuth(ctx context.Context, req *connect.Request[reliantv1.CompleteCodexOAuthRequest]) (*connect.Response[reliantv1.CompleteCodexOAuthResponse], error) {

--- a/internal/grpc/services/settings.go
+++ b/internal/grpc/services/settings.go
@@ -20,6 +20,7 @@ import (
 	"github.com/reliant-labs/reliant/internal/analytics"
 	"github.com/reliant-labs/reliant/internal/auth"
 	"github.com/reliant-labs/reliant/internal/config"
+	"github.com/reliant-labs/reliant/internal/controlplane"
 	"github.com/reliant-labs/reliant/internal/db"
 	"github.com/reliant-labs/reliant/internal/features"
 	reliantv1 "github.com/reliant-labs/reliant/internal/gen/reliant/v1"
@@ -41,15 +42,21 @@ import (
 // SettingsService implements the SettingsService RPC handlers
 type SettingsService struct {
 	reliantv1connect.UnimplementedSettingsServiceHandler
-	database     db.Repository
-	daemonRouter toolexec.DaemonRouter
+	database           db.Repository
+	daemonRouter       toolexec.DaemonRouter
+	controlPlaneClient *controlplane.Client
 }
 
 // NewSettingsService creates a new SettingsService
-func NewSettingsService(database db.Repository, daemonRouter toolexec.DaemonRouter) *SettingsService {
+func NewSettingsService(database db.Repository, daemonRouter toolexec.DaemonRouter, controlPlaneClient ...*controlplane.Client) *SettingsService {
+	var cpClient *controlplane.Client
+	if len(controlPlaneClient) > 0 {
+		cpClient = controlPlaneClient[0]
+	}
 	return &SettingsService{
-		database:     database,
-		daemonRouter: daemonRouter,
+		database:           database,
+		daemonRouter:       daemonRouter,
+		controlPlaneClient: cpClient,
 	}
 }
 

--- a/internal/grpc/services/settings_codex_test.go
+++ b/internal/grpc/services/settings_codex_test.go
@@ -377,6 +377,62 @@ func TestSettingsService_GetProviderStatuses_CodexUsesPersistedTokenExpiry(t *te
 	assert.Nil(t, expiredCodexStatus.MaskedKey)
 }
 
+func TestSettingsService_ReliantManagedAccessDisabled_HidesAndBlocksSettingsFlows(t *testing.T) {
+	repo, cleanup := db.SetupTestDB(t)
+	defer cleanup()
+
+	t.Setenv(features.ReliantManagedAccessEnabledEnvVar, "false")
+
+	svc := NewSettingsService(repo, nil)
+	ctx := newSettingsServiceTestContext()
+	userID := "test-user"
+
+	require.NoError(t, repo.SetProviderAPIKey(ctx, userID, "reliant", "cpat_disabled_test_token"))
+
+	t.Run("provider statuses omit reliant", func(t *testing.T) {
+		resp, err := svc.GetProviderStatuses(ctx, connect.NewRequest(&reliantv1.GetProviderStatusesRequest{}))
+		require.NoError(t, err)
+		for _, status := range resp.Msg.Providers {
+			assert.NotEqual(t, "reliant", status.Provider)
+		}
+	})
+
+	t.Run("validate returns disabled response", func(t *testing.T) {
+		resp, err := svc.ValidateProviderAPIKey(ctx, connect.NewRequest(&reliantv1.ValidateProviderAPIKeyRequest{
+			Provider: "reliant",
+		}))
+		require.NoError(t, err)
+		assert.False(t, resp.Msg.Valid)
+		assert.Equal(t, "reliant managed access feature is disabled", resp.Msg.Message)
+	})
+
+	t.Run("mutating and reliant rpc methods fail precondition", func(t *testing.T) {
+		_, err := svc.UpdateProviderAPIKey(ctx, connect.NewRequest(&reliantv1.UpdateProviderAPIKeyRequest{
+			Provider: "reliant",
+			ApiKey:   "cpat_new_disabled_token",
+		}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+		assert.Contains(t, err.Error(), "reliant managed access feature is disabled")
+
+		_, err = svc.CreateReliantProviderToken(ctx, connect.NewRequest(&reliantv1.CreateReliantProviderTokenRequest{}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+		_, err = svc.ListReliantProviderTokens(ctx, connect.NewRequest(&reliantv1.ListReliantProviderTokensRequest{}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+		_, err = svc.RevokeReliantProviderToken(ctx, connect.NewRequest(&reliantv1.RevokeReliantProviderTokenRequest{TokenId: "tok_disabled"}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+		_, err = svc.GetReliantProviderStatus(ctx, connect.NewRequest(&reliantv1.GetReliantProviderStatusRequest{}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	})
+}
+
 func setSkillsFeatureFlagForSettingsTests(t *testing.T, repo *db.Repo, enabled bool) {
 	t.Helper()
 	value := "false"

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/reliant-labs/reliant/internal/configadapter"
 	"github.com/reliant-labs/reliant/internal/db"
 	"github.com/reliant-labs/reliant/internal/envutil"
+	"github.com/reliant-labs/reliant/internal/features"
 	"github.com/reliant-labs/reliant/internal/grpc/services"
 	"github.com/reliant-labs/reliant/internal/llm/drivers"
 	"github.com/reliant-labs/reliant/internal/llm/tools"
@@ -157,10 +158,16 @@ func NewServer(cfg *Config) (*Server, error) {
 	wg.Wait()
 
 	// Initialize API key provider with database (after repo is created)
+	controlPlaneClient := controlplane.NewClientFromEnv()
+	reliantRuntimeBaseURL := envutil.GetEnv("RELIANT_RUNTIME_BASE_URL", "")
+	if !features.IsReliantManagedAccessEnabledForContext(ctx, nil, "") {
+		controlPlaneClient = nil
+		reliantRuntimeBaseURL = ""
+	}
 	drivers.InitializeAPIKeyProvider(
 		repo,
-		drivers.WithControlPlaneClient(controlplane.NewClientFromEnv()),
-		drivers.WithReliantRuntimeBaseURL(envutil.GetEnv("RELIANT_RUNTIME_BASE_URL", "")),
+		drivers.WithControlPlaneClient(controlPlaneClient),
+		drivers.WithReliantRuntimeBaseURL(reliantRuntimeBaseURL),
 	)
 
 	// Check for errors

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -8,12 +8,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/reliant-labs/reliant/internal/controlplane"
 	"github.com/reliant-labs/reliant/internal/daemon"
 	"github.com/reliant-labs/reliant/internal/mcpconfig"
 
 	"github.com/reliant-labs/reliant/internal/config"
 	"github.com/reliant-labs/reliant/internal/configadapter"
 	"github.com/reliant-labs/reliant/internal/db"
+	"github.com/reliant-labs/reliant/internal/envutil"
 	"github.com/reliant-labs/reliant/internal/grpc/services"
 	"github.com/reliant-labs/reliant/internal/llm/drivers"
 	"github.com/reliant-labs/reliant/internal/llm/tools"
@@ -155,7 +157,11 @@ func NewServer(cfg *Config) (*Server, error) {
 	wg.Wait()
 
 	// Initialize API key provider with database (after repo is created)
-	drivers.InitializeAPIKeyProvider(repo)
+	drivers.InitializeAPIKeyProvider(
+		repo,
+		drivers.WithControlPlaneClient(controlplane.NewClientFromEnv()),
+		drivers.WithReliantRuntimeBaseURL(envutil.GetEnv("RELIANT_RUNTIME_BASE_URL", "")),
+	)
 
 	// Check for errors
 	if dbErr != nil {

--- a/internal/integration/server.go
+++ b/internal/integration/server.go
@@ -160,7 +160,7 @@ func NewServer(cfg *Config) (*Server, error) {
 	// Initialize API key provider with database (after repo is created)
 	controlPlaneClient := controlplane.NewClientFromEnv()
 	reliantRuntimeBaseURL := envutil.GetEnv("RELIANT_RUNTIME_BASE_URL", "")
-	if !features.IsReliantManagedAccessEnabledForContext(ctx, nil, "") {
+	if !features.IsReliantManagedAccessEnabledForContext(context.Background(), nil, "") {
 		controlPlaneClient = nil
 		reliantRuntimeBaseURL = ""
 	}

--- a/internal/llm/drivers/api_key_provider.go
+++ b/internal/llm/drivers/api_key_provider.go
@@ -4,8 +4,10 @@ package drivers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
+	"github.com/reliant-labs/reliant/internal/controlplane"
 	"github.com/reliant-labs/reliant/internal/db"
 	"github.com/reliant-labs/reliant/internal/llm/models"
 	"github.com/reliant-labs/reliant/internal/logging"
@@ -17,19 +19,52 @@ var (
 	providerMu           sync.Mutex
 )
 
-// APIKeyProvider manages API keys for drivers
+// APIKeyProvider manages API keys and shared runtime dependencies for drivers.
 type APIKeyProvider struct {
-	repo db.Repository
+	repo                  db.Repository
+	controlPlaneClient    *controlplane.Client
+	reliantRuntimeBaseURL string
+}
+
+// APIKeyProviderOption configures shared driver-resolution dependencies.
+type APIKeyProviderOption func(*APIKeyProvider)
+
+// WithControlPlaneClient injects the shared Reliant control-plane client used for runtime grant exchange.
+func WithControlPlaneClient(client *controlplane.Client) APIKeyProviderOption {
+	return func(p *APIKeyProvider) {
+		p.controlPlaneClient = client
+	}
+}
+
+// WithReliantRuntimeBaseURL sets the explicit OpenAI-compatible runtime base URL for Reliant-managed access.
+func WithReliantRuntimeBaseURL(baseURL string) APIKeyProviderOption {
+	return func(p *APIKeyProvider) {
+		p.reliantRuntimeBaseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	}
 }
 
 // InitializeAPIKeyProvider initializes or updates the global API key provider.
-// This can be called multiple times (e.g., in tests) to update the repo reference.
-func InitializeAPIKeyProvider(repo db.Repository) {
+// This can be called multiple times (e.g., in tests) to update shared references.
+func InitializeAPIKeyProvider(repo db.Repository, opts ...APIKeyProviderOption) {
 	providerMu.Lock()
 	defer providerMu.Unlock()
-	globalAPIKeyProvider = &APIKeyProvider{
-		repo: repo,
+
+	provider := &APIKeyProvider{repo: repo}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(provider)
+		}
 	}
+	globalAPIKeyProvider = provider
+}
+
+func getReliantRuntimeDependencies() (*controlplane.Client, string) {
+	providerMu.Lock()
+	defer providerMu.Unlock()
+	if globalAPIKeyProvider == nil {
+		return nil, ""
+	}
+	return globalAPIKeyProvider.controlPlaneClient, globalAPIKeyProvider.reliantRuntimeBaseURL
 }
 
 // ErrNoAPIKeysConfigured is returned when no API keys are available

--- a/internal/llm/drivers/helpers.go
+++ b/internal/llm/drivers/helpers.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/reliant-labs/reliant/internal/controlplane"
 	"github.com/reliant-labs/reliant/internal/db"
+	"github.com/reliant-labs/reliant/internal/features"
 	"github.com/reliant-labs/reliant/internal/llm/drivers/claude"
 	"github.com/reliant-labs/reliant/internal/llm/drivers/codex"
 	"github.com/reliant-labs/reliant/internal/llm/drivers/local"
@@ -81,6 +83,14 @@ func BuildAvailableDrivers(ctx context.Context, repo db.Repository, userID strin
 			continue
 		}
 
+		if driverID == "reliant" {
+			config, ok := buildReliantDriverConfig(ctx, repo, userID)
+			if ok {
+				drivers[config.DriverID] = config
+			}
+			continue
+		}
+
 		// Get the actual unmasked API key for this provider
 		apiKey, err := repo.GetProviderAPIKey(ctx, userID, driverID)
 		if err != nil {
@@ -124,6 +134,78 @@ func BuildAvailableDrivers(ctx context.Context, repo db.Repository, userID strin
 		return models.AvailableDrivers{Drivers: make(map[models.DriverID]models.DriverConfig)}, nil
 	}
 	return models.AvailableDrivers{Drivers: drivers}, nil
+}
+
+func buildReliantDriverConfig(ctx context.Context, repo db.Repository, userID string) (models.DriverConfig, bool) {
+	if !features.IsReliantManagedAccessEnabledForContext(ctx, repo, userID) {
+		return models.DriverConfig{}, false
+	}
+	controlPlaneClient, runtimeBaseURL := getReliantRuntimeDependencies()
+	if controlPlaneClient == nil || !controlPlaneClient.Enabled() {
+		return models.DriverConfig{}, false
+	}
+	runtimeBaseURL = strings.TrimRight(strings.TrimSpace(runtimeBaseURL), "/")
+	if runtimeBaseURL == "" {
+		return models.DriverConfig{}, false
+	}
+
+	storedToken, err := repo.GetProviderAPIKey(ctx, userID, "reliant")
+	if err != nil {
+		logging.Warn("Failed to load stored Reliant token for runtime exchange", "user_id", userID, "error", err)
+		return models.DriverConfig{}, false
+	}
+	storedToken = strings.TrimSpace(storedToken)
+	if storedToken == "" || storedToken == "dummy" {
+		return models.DriverConfig{}, false
+	}
+
+	access, err := controlPlaneClient.GetCurrentLLMAccess(ctx, storedToken)
+	if err != nil {
+		logReliantExchangeFailure(userID, err)
+		return models.DriverConfig{}, false
+	}
+	apiKey := strings.TrimSpace(access.Key)
+	if apiKey == "" {
+		logging.Warn("Reliant runtime exchange returned empty key", "user_id", userID)
+		return models.DriverConfig{}, false
+	}
+
+	allowedModels := make(map[models.ModelID]struct{}, len(access.AllowedModels))
+	for _, modelID := range access.AllowedModels {
+		modelID = strings.TrimSpace(modelID)
+		if modelID == "" {
+			continue
+		}
+		allowedModels[models.ModelID(modelID)] = struct{}{}
+	}
+
+	return models.DriverConfig{
+		DriverID:      models.DriverID("reliant"),
+		APIKey:        apiKey,
+		BaseURL:       runtimeBaseURL,
+		Enabled:       true,
+		AllowedModels: allowedModels,
+	}, true
+}
+
+func logReliantExchangeFailure(userID string, err error) {
+	level := "warn"
+	if errorsIsNotConfigured(err) {
+		level = "debug"
+	}
+	fields := []any{"user_id", userID, "error", err}
+	if rpcErr, ok := err.(*controlplane.RPCError); ok {
+		fields = append(fields, "status_code", rpcErr.StatusCode, "code", rpcErr.Code)
+	}
+	if level == "debug" {
+		logging.Debug("Reliant runtime exchange unavailable", fields...)
+		return
+	}
+	logging.Warn("Reliant runtime exchange failed", fields...)
+}
+
+func errorsIsNotConfigured(err error) bool {
+	return err == controlplane.ErrNotConfigured
 }
 
 // BuildClaudeTokenRefresher returns a closure that refreshes Claude OAuth tokens

--- a/internal/llm/drivers/helpers_test.go
+++ b/internal/llm/drivers/helpers_test.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/reliant-labs/reliant/internal/controlplane"
 	"github.com/reliant-labs/reliant/internal/db"
+	"github.com/reliant-labs/reliant/internal/features"
+	"github.com/reliant-labs/reliant/internal/llm/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -100,4 +105,38 @@ func TestBuildAvailableDrivers_CodexMarkerWithoutTokensIsSkipped(t *testing.T) {
 	anthropic, hasAnthropic := availableDrivers.Drivers["anthropic"]
 	require.True(t, hasAnthropic)
 	assert.Equal(t, "sk-ant-test", anthropic.APIKey)
+}
+
+func TestBuildAvailableDrivers_ReliantUsesExchangedRuntimeAccess(t *testing.T) {
+	repo, cleanup := db.SetupTestDB(t)
+	defer cleanup()
+
+	t.Setenv(features.ReliantManagedAccessEnabledEnvVar, "true")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/controlplane.v1.LLMAccessService/GetCurrentLLMAccess", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"key":"sk-reliant-runtime","allowedModels":["claude-4.5-sonnet"]}`))
+	}))
+	defer server.Close()
+
+	InitializeAPIKeyProvider(
+		repo,
+		WithControlPlaneClient(controlplane.NewClient(controlplane.Config{BaseURL: server.URL})),
+		WithReliantRuntimeBaseURL("https://runtime.reliant.test/v1"),
+	)
+
+	ctx := context.Background()
+	userID := "test-user"
+	require.NoError(t, repo.SetProviderAPIKey(ctx, userID, "reliant", "cpat_test_token"))
+
+	availableDrivers, err := BuildAvailableDrivers(ctx, repo, userID)
+	require.NoError(t, err)
+
+	selected, ok := availableDrivers.Drivers[models.DriverID("reliant")]
+	require.True(t, ok, "reliant should be synthesized when runtime exchange succeeds")
+	assert.Equal(t, models.DriverID("reliant"), selected.DriverID)
+	assert.Equal(t, "sk-reliant-runtime", selected.APIKey)
+	assert.Equal(t, "https://runtime.reliant.test/v1", selected.BaseURL)
+	assert.Contains(t, selected.AllowedModels, models.ModelID("claude-4.5-sonnet"))
 }

--- a/internal/llm/drivers/model_selection.go
+++ b/internal/llm/drivers/model_selection.go
@@ -89,6 +89,130 @@ func ValidateModelIsAvailable(ctx context.Context, userID string, modelID string
 	return nil
 }
 
+// ResolveModelSelector resolves a selector against configured drivers, including synthetic runtime providers.
+func ResolveModelSelector(selector models.ModelSelector, availableDrivers models.AvailableDrivers) (*models.ResolvedModel, error) {
+	if selector.ID == "" && len(selector.Tags) == 0 {
+		return nil, fmt.Errorf("ModelSelector must have either ID or Tags set")
+	}
+
+	reg := models.MustGetRegistry()
+	allModels := reg.ListAll()
+
+	if selector.ID != "" {
+		baseModelID, explicitDriverID := ParseModelIDWithDriver(selector.ID)
+		def, ok := reg.GetDefinition(baseModelID)
+		if !ok {
+			return nil, fmt.Errorf("model not found: %s", selector.ID)
+		}
+		modelID := models.ModelID(baseModelID)
+
+		if explicitDriverID != "" {
+			config, ok := availableDrivers.Drivers[models.DriverID(explicitDriverID)]
+			if !ok || !driverConfigCanServeModel(config, modelID) {
+				return nil, fmt.Errorf("none of required providers [%s] available for model %s", explicitDriverID, baseModelID)
+			}
+			return &models.ResolvedModel{Definition: *def, Provider: providerMappingForDriver(*def, explicitDriverID)}, nil
+		}
+
+		if len(selector.Providers) > 0 {
+			for _, provider := range selector.Providers {
+				config, ok := availableDrivers.Drivers[models.DriverID(provider)]
+				if ok && driverConfigCanServeModel(config, modelID) {
+					return &models.ResolvedModel{Definition: *def, Provider: providerMappingForDriver(*def, provider)}, nil
+				}
+			}
+		}
+
+		bestDriver, found := models.SelectBestDriver(modelID, availableDrivers)
+		if !found {
+			return nil, fmt.Errorf("no available provider for model %s", baseModelID)
+		}
+		return &models.ResolvedModel{Definition: *def, Provider: providerMappingForDriver(*def, string(bestDriver.DriverID))}, nil
+	}
+
+	weights := make([]int, len(selector.Tags))
+	for i := range selector.Tags {
+		weights[i] = 1 << (len(selector.Tags) - 1 - i)
+	}
+
+	type candidate struct {
+		def   models.ModelDefinition
+		score int
+		index int
+	}
+	candidates := make([]candidate, 0, len(allModels))
+	for i, def := range allModels {
+		score := scoreModelTags(def, selector.Tags, weights)
+		if score > 0 {
+			candidates = append(candidates, candidate{def: def, score: score, index: i})
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("no models found matching tags: %v", selector.Tags)
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].score != candidates[j].score {
+			return candidates[i].score > candidates[j].score
+		}
+		return candidates[i].index < candidates[j].index
+	})
+
+	for _, cand := range candidates {
+		modelID := models.ModelID(cand.def.ID)
+		if len(selector.Providers) > 0 {
+			for _, provider := range selector.Providers {
+				config, ok := availableDrivers.Drivers[models.DriverID(provider)]
+				if ok && driverConfigCanServeModel(config, modelID) {
+					return &models.ResolvedModel{Definition: cand.def, Provider: providerMappingForDriver(cand.def, provider)}, nil
+				}
+			}
+		}
+
+		bestDriver, found := models.SelectBestDriver(modelID, availableDrivers)
+		if found {
+			return &models.ResolvedModel{Definition: cand.def, Provider: providerMappingForDriver(cand.def, string(bestDriver.DriverID))}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no available provider for models with tags: %v (tried %d candidates)", selector.Tags, len(candidates))
+}
+
+func scoreModelTags(def models.ModelDefinition, tags []string, weights []int) int {
+	tagSet := make(map[string]struct{}, len(def.Tags))
+	for _, tag := range def.Tags {
+		tagSet[tag] = struct{}{}
+	}
+	var score int
+	for i, tag := range tags {
+		if _, ok := tagSet[tag]; ok {
+			score += weights[i]
+		}
+	}
+	return score
+}
+
+func driverConfigCanServeModel(config models.DriverConfig, modelID models.ModelID) bool {
+	if !config.IsConfigured() || !config.AllowsModel(modelID) {
+		return false
+	}
+	if len(config.AllowedModels) > 0 {
+		return true
+	}
+	return models.CanDriverUseModel(models.Family(config.DriverID), modelID)
+}
+
+func providerMappingForDriver(def models.ModelDefinition, driver string) models.ProviderMapping {
+	if driver == "reliant" {
+		return models.ProviderMapping{Driver: driver, APIModel: def.ID}
+	}
+	for _, provider := range def.Providers {
+		if provider.Driver == driver {
+			return provider
+		}
+	}
+	return models.ProviderMapping{Driver: driver, APIModel: def.ID}
+}
+
 // ValidateModelSelector validates that a model selector can be resolved with the user's configured API keys.
 // This is used for early validation during chat creation to fail fast if the model isn't available.
 //
@@ -126,23 +250,7 @@ func ValidateModelSelector(ctx context.Context, userID string, selector interfac
 		return fmt.Errorf("no API keys configured - please add an API key in Settings")
 	}
 
-	// Build availableProviders slice from configured drivers
-	availableProviders := make([]string, 0, len(availableDrivers.Drivers))
-	for driverID, driverConfig := range availableDrivers.Drivers {
-		// Use IsConfigured() which handles both API key drivers and local drivers (BaseURL)
-		if driverConfig.IsConfigured() {
-			availableProviders = append(availableProviders, string(driverID))
-		}
-	}
-
-	if len(availableProviders) == 0 {
-		return fmt.Errorf("no API keys configured - please add an API key in Settings")
-	}
-
-	// Try to resolve the model
-	registry := models.MustGetRegistry()
-	_, err = registry.Resolve(ms, availableProviders)
-	if err != nil {
+	if _, err := ResolveModelSelector(ms, availableDrivers); err != nil {
 		// Provide actionable error message
 		if ms.ID != "" {
 			return fmt.Errorf("model '%s' is not available: %w. Check your API key configuration in Settings", ms.ID, err)

--- a/internal/llm/drivers/openai/driver.go
+++ b/internal/llm/drivers/openai/driver.go
@@ -163,11 +163,29 @@ func (o *OpenaiClient) ConvertTools(tools []tools.Tool) []openai.ChatCompletionT
 			required = []string{}
 		}
 
-		// Convert properties from OrderedMap to regular map for OpenAI
+		// Convert properties from OrderedMap to regular map for OpenAI.
+		// Sanitize nested boolean JSON Schema nodes because some OpenAI-compatible
+		// gateway stacks (notably LiteLLM -> Vertex Gemini) choke on boolean schema
+		// values inside tool parameter properties even when OpenAI itself accepts them.
 		properties := make(map[string]interface{})
 		if schema.Properties != nil {
 			for pair := schema.Properties.Oldest(); pair != nil; pair = pair.Next() {
-				properties[pair.Key] = pair.Value
+				propertyJSON, err := json.Marshal(pair.Value)
+				if err != nil {
+					properties[pair.Key] = pair.Value
+					continue
+				}
+				var propertyValue any
+				if err := json.Unmarshal(propertyJSON, &propertyValue); err != nil {
+					properties[pair.Key] = pair.Value
+					continue
+				}
+				if propertyMap, ok := propertyValue.(map[string]any); ok {
+					SanitizeChatToolSchema(propertyMap)
+					properties[pair.Key] = propertyMap
+					continue
+				}
+				properties[pair.Key] = propertyValue
 			}
 		}
 

--- a/internal/llm/drivers/openai/schema_normalize.go
+++ b/internal/llm/drivers/openai/schema_normalize.go
@@ -173,6 +173,56 @@ func ValidateResponsesToolSchemaStrict(schema map[string]any) error {
 	return validateResponsesToolSchemaStrictAtPath(schema, "$")
 }
 
+// SanitizeChatToolSchema mutates a chat-completions tool schema into a safer
+// OpenAI-compatible subset for gateway stacks that choke on boolean JSON Schema
+// nodes (for example additionalProperties=false or items=false nested inside
+// property definitions).
+//
+// Unlike NormalizeResponsesToolSchema, this is intentionally conservative:
+// - root schema handling happens in ConvertTools
+// - nested object/array/combinator structure is preserved where possible
+// - boolean schema nodes are deleted or replaced with empty object schemas
+func SanitizeChatToolSchema(schema map[string]any) {
+	if schema == nil {
+		return
+	}
+	for key, raw := range schema {
+		switch key {
+		case "additionalProperties":
+			if _, ok := raw.(bool); ok {
+				delete(schema, key)
+				continue
+			}
+		case "items", "contains", "not", "if", "then", "else", "unevaluatedProperties", "propertyNames":
+			if _, ok := raw.(bool); ok {
+				schema[key] = map[string]any{}
+				continue
+			}
+		}
+
+		schema[key] = sanitizeChatToolSchemaValue(raw)
+	}
+}
+
+func sanitizeChatToolSchemaValue(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		SanitizeChatToolSchema(v)
+		return v
+	case []any:
+		for i, item := range v {
+			if _, ok := item.(bool); ok {
+				v[i] = map[string]any{}
+				continue
+			}
+			v[i] = sanitizeChatToolSchemaValue(item)
+		}
+		return v
+	default:
+		return value
+	}
+}
+
 func validateResponsesToolSchemaStrictAtPath(schema map[string]any, path string) error {
 	if schema == nil {
 		return fmt.Errorf("%s: schema is nil", path)

--- a/internal/llm/drivers/openai/schema_normalize_test.go
+++ b/internal/llm/drivers/openai/schema_normalize_test.go
@@ -3,7 +3,12 @@ package openai
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
+
+	"github.com/reliant-labs/reliant/internal/llm"
+	"github.com/reliant-labs/reliant/internal/llm/models"
+	llmtools "github.com/reliant-labs/reliant/internal/llm/tools"
 )
 
 func TestNormalizeResponsesToolSchema_EmptyObjectStaysObject(t *testing.T) {
@@ -287,6 +292,79 @@ func TestValidateResponsesToolSchemaStrict_RejectsNonObjectItems(t *testing.T) {
 			t.Fatal("expected non-object items nested under anyOf to be rejected")
 		}
 	})
+}
+
+func TestSanitizeChatToolSchema_RemovesBooleanSchemaNodesFromChatPayload(t *testing.T) {
+	registry := models.MustGetRegistry()
+	def, ok := registry.GetDefinition(string(models.GPT54Mini))
+	if !ok {
+		t.Fatalf("missing model %s", models.GPT54Mini)
+	}
+
+	client := NewClient(llm.DriverOptions{Model: def.ToModel()})
+	tool := llmtools.NewSchemaOnlyTool(
+		"mcp__example__broken",
+		"Broken MCP-like schema",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"config": map[string]any{
+					"type":                 "object",
+					"additionalProperties": false,
+					"properties": map[string]any{
+						"enabled": map[string]any{"type": "boolean"},
+					},
+				},
+				"values": map[string]any{
+					"type":  "array",
+					"items": false,
+				},
+				"mode": map[string]any{
+					"anyOf": []any{
+						false,
+						map[string]any{"type": "string"},
+					},
+				},
+			},
+			"required": []string{"config", "values", "mode"},
+		},
+	)
+
+	converted := client.ConvertTools([]llmtools.Tool{tool})
+	if len(converted) != 1 || converted[0].OfFunction == nil {
+		t.Fatalf("expected single function tool")
+	}
+
+	payload, err := json.Marshal(converted[0].OfFunction.Function.Parameters)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	payloadStr := string(payload)
+	if strings.Contains(payloadStr, `"additionalProperties":false`) {
+		t.Fatalf("expected chat payload to strip boolean additionalProperties, got %s", payloadStr)
+	}
+	if strings.Contains(payloadStr, `"items":false`) || strings.Contains(payloadStr, `"items":true`) {
+		t.Fatalf("expected chat payload to rewrite boolean items, got %s", payloadStr)
+	}
+	if strings.Contains(payloadStr, `[false,`) || strings.Contains(payloadStr, `,false]`) || strings.Contains(payloadStr, `,false,`) {
+		t.Fatalf("expected chat payload combinators to avoid boolean schema entries, got %s", payloadStr)
+	}
+
+	var root map[string]any
+	if err := json.Unmarshal(payload, &root); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	props, ok := root["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected properties map in payload")
+	}
+	values, ok := props["values"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected values property map")
+	}
+	if _, ok := values["items"].(map[string]any); !ok {
+		t.Fatalf("expected values.items to be object schema, got %#v", values["items"])
+	}
 }
 
 func TestRewriteMapSchemaToKVArray(t *testing.T) {

--- a/internal/llm/drivers/reliant/driver.go
+++ b/internal/llm/drivers/reliant/driver.go
@@ -1,0 +1,25 @@
+package reliant
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/reliant-labs/reliant/internal/llm"
+	openaiDriver "github.com/reliant-labs/reliant/internal/llm/drivers/openai"
+	"github.com/reliant-labs/reliant/internal/llm/drivers/registry"
+	"github.com/reliant-labs/reliant/internal/llm/models"
+)
+
+const Family models.Family = "reliant"
+
+func createClient(opts *llm.DriverOptions) (registry.Client, error) {
+	if strings.TrimSpace(opts.ApiKey) == "" {
+		return nil, fmt.Errorf("reliant runtime access key is required")
+	}
+	if strings.TrimSpace(opts.BaseURL) == "" {
+		return nil, fmt.Errorf("reliant runtime base URL is required")
+	}
+	// Reliant runtime is an OpenAI-compatible gateway that expects canonical Reliant model IDs.
+	opts.Model.APIModel = string(opts.Model.ID)
+	return openaiDriver.NewClient(*opts), nil
+}

--- a/internal/llm/drivers/reliant/models.go
+++ b/internal/llm/drivers/reliant/models.go
@@ -1,0 +1,17 @@
+package reliant
+
+import (
+	"github.com/reliant-labs/reliant/internal/llm/drivers/registry"
+	"github.com/reliant-labs/reliant/internal/llm/models"
+)
+
+func init() {
+	reg := models.MustGetRegistry()
+	allModels := reg.ListAll()
+	ids := make([]models.ModelID, 0, len(allModels))
+	for _, def := range allModels {
+		ids = append(ids, models.ModelID(def.ID))
+	}
+	models.RegisterDriverModels(Family, ids)
+	registry.RegisterDriver(Family, createClient)
+}

--- a/internal/llm/drivers/resolver.go
+++ b/internal/llm/drivers/resolver.go
@@ -1,4 +1,3 @@
-// Copyright (c) 2025 Reliant Labs
 package drivers
 
 import (
@@ -22,6 +21,7 @@ import (
 	_ "github.com/reliant-labs/reliant/internal/llm/drivers/local"
 	_ "github.com/reliant-labs/reliant/internal/llm/drivers/openai"
 	_ "github.com/reliant-labs/reliant/internal/llm/drivers/openrouter"
+	_ "github.com/reliant-labs/reliant/internal/llm/drivers/reliant"
 	_ "github.com/reliant-labs/reliant/internal/llm/drivers/vertexai"
 )
 
@@ -105,6 +105,9 @@ func GetDriverForModel(model models.Model, driverID models.Family, opts ...llm.D
 // GetDriver allows injecting a custom driver function for testing
 var GetDriver func(ctx context.Context, userID string, preferences models.Preferences, opts ...llm.DriverOption) (llm.Driver, error) = defaultGetDriver
 
+// AvailableDrivers snapshot without re-fetching credentials/configuration.
+var GetDriverWithConfig func(ctx context.Context, userID string, pref models.Preference, model models.Model, availableDrivers models.AvailableDrivers, opts ...llm.DriverOption) (llm.Driver, error) = defaultGetDriverWithConfig
+
 // ReplayMode holds the current replay configuration
 var ReplayMode struct {
 	Enabled  bool
@@ -151,14 +154,11 @@ func defaultGetDriver(ctx context.Context, userID string, preferences models.Pre
 	}
 	logging.Debug("calling defaultGetDriver", "preferences", preferences)
 	for _, pref := range preferences {
-		// Parse model ID to extract base model and optional explicit driver
-		// Format: "model-id" or "model-id@driver" (e.g., "claude-4.5-sonnet@openrouter")
-		baseModelID, explicitDriverID := ParseModelIDWithDriver(string(pref.ModelID))
+		baseModelID, _ := ParseModelIDWithDriver(string(pref.ModelID))
 		modelID := models.ModelID(baseModelID)
 
-		logging.Debug("parsing model preference", "original", pref.ModelID, "baseModel", baseModelID, "explicitDriver", explicitDriverID)
+		logging.Debug("parsing model preference", "original", pref.ModelID, "baseModel", baseModelID)
 
-		// Get model details from registry
 		registry := models.MustGetRegistry()
 		def, ok := registry.GetDefinition(string(modelID))
 		if !ok {
@@ -167,100 +167,86 @@ func defaultGetDriver(ctx context.Context, userID string, preferences models.Pre
 		}
 		model := def.ToModel()
 
-		// Use preference's token budget if specified, otherwise model's default
-		maxTokens := int64(def.Capabilities.MaxOutputTokens)
-		if pref.TokenBudget != nil {
-			maxTokens = *pref.TokenBudget
-		}
-
-		// Get available drivers
 		availableDrivers := GetAvailableDrivers(ctx, userID)
 
-		var driverConfig models.DriverConfig
-		var found bool
-
-		if explicitDriverID != "" {
-			// User explicitly selected a driver (e.g., "openrouter" or "local")
-			// Use that driver directly instead of auto-selecting
-			config, exists := availableDrivers.Drivers[models.DriverID(explicitDriverID)]
-			if exists && config.IsConfigured() {
-				// Verify this driver supports the model
-				if models.CanDriverUseModel(models.Family(explicitDriverID), modelID) {
-					driverConfig = config
-					found = true
-					logging.Debug("using explicit driver", "driver", explicitDriverID, "model", modelID)
-				} else {
-					logging.Warn("explicit driver does not support model", "driver", explicitDriverID, "model", modelID)
-				}
-			} else {
-				logging.Warn("explicit driver not available", "driver", explicitDriverID, "exists", exists, "isConfigured", config.IsConfigured())
-			}
-		}
-
-		// Fall back to auto-selection if no explicit driver or explicit driver wasn't available
-		if !found {
-			driverConfig, found = models.SelectBestDriver(model.ID, availableDrivers)
-			logging.Debug("auto-selected driver", "driverConfig", driverConfig, "found", found)
-		}
-
-		if !found {
-			continue // Try next model in preferences
-		}
-
-		// Build driver options with the API key from the selected driver
-		driverOpts := []llm.DriverOption{
-			llm.WithAPIKey(driverConfig.APIKey),
-			llm.WithModel(model),
-			llm.WithMaxTokens(maxTokens),
-		}
-
-		// Add base URL if specified for this driver
-		if driverConfig.BaseURL != "" {
-			driverOpts = append(driverOpts, llm.WithBaseURL(driverConfig.BaseURL))
-		}
-
-		// Pass Claude OAuth account metadata and token refresh if available
-		if driverConfig.AccountUUID != "" {
-			driverOpts = append(driverOpts, llm.WithAccountMetadata(driverConfig.AccountUUID, driverConfig.AccountEmail, driverConfig.OrganizationUUID))
-		}
-		if driverConfig.RefreshToken != "" {
-			refresher := BuildClaudeTokenRefresher(ctx, userID)
-			driverOpts = append(driverOpts, llm.WithTokenRefresher(refresher, driverConfig.RefreshToken, driverConfig.TokenExpiresAt))
-		}
-
-		// Add temperature if specified in preference AND supported by the model.
-		// Some models only support their default temperature and will hard-error if we send a value.
-		if pref.Temperature != nil {
-			switch model.TemperatureMode {
-			case "", models.TemperatureModeAny:
-				driverOpts = append(driverOpts, llm.WithTemperature(*pref.Temperature))
-			case models.TemperatureModeOmit:
-				// Intentionally omit temperature
-			default:
-				// Unknown mode: fail safe by omitting temperature
-			}
-		}
-
-		// Add disable cache if specified
-		if pref.DisableCache {
-			driverOpts = append(driverOpts, llm.WithDisableCache())
-		}
-
-		// Handle thinking mode configuration
-		driverOpts = append(driverOpts, llm.WithReasoningEffort(pref.ThinkingMode))
-
-		// Merge with any additional options passed in
-		driverOpts = append(driverOpts, opts...)
-
-		agentProvider, err := GetDriverForModel(model, models.Family(driverConfig.DriverID), driverOpts...)
+		agentProvider, err := GetDriverWithConfig(ctx, userID, pref, model, availableDrivers, opts...)
 		logging.Debug("provider, err", "provider", agentProvider, "err", err)
 		if err != nil {
 			continue
 		}
 
-		// Success!
 		return agentProvider, nil
 	}
 
 	return nil, fmt.Errorf("failed to get driver for preferences: no suitable models available: %v", preferences[0])
+}
+
+func defaultGetDriverWithConfig(ctx context.Context, userID string, pref models.Preference, model models.Model, availableDrivers models.AvailableDrivers, opts ...llm.DriverOption) (llm.Driver, error) {
+	baseModelID, explicitDriverID := ParseModelIDWithDriver(string(pref.ModelID))
+	modelID := models.ModelID(baseModelID)
+
+	var driverConfig models.DriverConfig
+	var found bool
+
+	if explicitDriverID != "" {
+		config, exists := availableDrivers.Drivers[models.DriverID(explicitDriverID)]
+		if exists && config.IsConfigured() && config.AllowsModel(modelID) {
+			if len(config.AllowedModels) > 0 || models.CanDriverUseModel(models.Family(explicitDriverID), modelID) {
+				driverConfig = config
+				found = true
+				logging.Debug("using explicit driver", "driver", explicitDriverID, "model", modelID)
+			} else {
+				logging.Warn("explicit driver does not support model", "driver", explicitDriverID, "model", modelID)
+			}
+		} else {
+			logging.Warn("explicit driver not available", "driver", explicitDriverID, "exists", exists, "isConfigured", config.IsConfigured())
+		}
+	}
+
+	if !found {
+		driverConfig, found = models.SelectBestDriver(model.ID, availableDrivers)
+		logging.Debug("auto-selected driver", "driverConfig", driverConfig, "found", found)
+	}
+
+	if !found {
+		return nil, fmt.Errorf("no suitable driver config available for model %s", model.ID)
+	}
+
+	maxTokens := model.DefaultMaxTokens
+	if pref.TokenBudget != nil {
+		maxTokens = *pref.TokenBudget
+	}
+
+	driverOpts := []llm.DriverOption{
+		llm.WithAPIKey(driverConfig.APIKey),
+		llm.WithModel(model),
+		llm.WithMaxTokens(maxTokens),
+	}
+	if driverConfig.BaseURL != "" {
+		driverOpts = append(driverOpts, llm.WithBaseURL(driverConfig.BaseURL))
+	}
+	if driverConfig.AccountUUID != "" {
+		driverOpts = append(driverOpts, llm.WithAccountMetadata(driverConfig.AccountUUID, driverConfig.AccountEmail, driverConfig.OrganizationUUID))
+	}
+	if driverConfig.RefreshToken != "" {
+		refresher := BuildClaudeTokenRefresher(ctx, userID)
+		driverOpts = append(driverOpts, llm.WithTokenRefresher(refresher, driverConfig.RefreshToken, driverConfig.TokenExpiresAt))
+	}
+	if pref.Temperature != nil {
+		switch model.TemperatureMode {
+		case "", models.TemperatureModeAny:
+			driverOpts = append(driverOpts, llm.WithTemperature(*pref.Temperature))
+		case models.TemperatureModeOmit:
+			// Intentionally omit temperature
+		default:
+			// Unknown mode: fail safe by omitting temperature
+		}
+	}
+	if pref.DisableCache {
+		driverOpts = append(driverOpts, llm.WithDisableCache())
+	}
+	driverOpts = append(driverOpts, llm.WithReasoningEffort(pref.ThinkingMode))
+	driverOpts = append(driverOpts, opts...)
+
+	return GetDriverForModel(model, models.Family(driverConfig.DriverID), driverOpts...)
 }

--- a/internal/llm/models/driver_config.go
+++ b/internal/llm/models/driver_config.go
@@ -22,6 +22,17 @@ type DriverConfig struct {
 	OrganizationUUID string    // Optional: Claude OAuth organization UUID
 	RefreshToken     string    // Optional: Claude OAuth refresh token for auto-refresh
 	TokenExpiresAt   time.Time // Optional: when the access token expires
+	AllowedModels    map[ModelID]struct{}
+}
+
+// AllowsModel returns true when the driver config permits the given model.
+// Empty allowlists mean the driver is not model-restricted.
+func (c DriverConfig) AllowsModel(modelID ModelID) bool {
+	if len(c.AllowedModels) == 0 {
+		return true
+	}
+	_, ok := c.AllowedModels[modelID]
+	return ok
 }
 
 // IsConfigured returns true if the driver has the required configuration.
@@ -52,7 +63,7 @@ func GetAvailableDriversForModel(modelID ModelID, availableDrivers AvailableDriv
 
 	var configs []DriverConfig
 	for _, driverID := range supportingDrivers {
-		if config, exists := availableDrivers.Drivers[DriverID(driverID)]; exists && config.IsConfigured() {
+		if config, exists := availableDrivers.Drivers[DriverID(driverID)]; exists && config.IsConfigured() && config.AllowsModel(modelID) {
 			configs = append(configs, config)
 		}
 	}

--- a/internal/serverapi/run.go
+++ b/internal/serverapi/run.go
@@ -18,8 +18,10 @@ import (
 	"github.com/reliant-labs/reliant/internal/api"
 	"github.com/reliant-labs/reliant/internal/auth"
 	"github.com/reliant-labs/reliant/internal/certs"
+	"github.com/reliant-labs/reliant/internal/controlplane"
 	"github.com/reliant-labs/reliant/internal/daemon"
 	"github.com/reliant-labs/reliant/internal/db"
+	"github.com/reliant-labs/reliant/internal/envutil"
 	grpcserver "github.com/reliant-labs/reliant/internal/grpc"
 	"github.com/reliant-labs/reliant/internal/grpc/services"
 	"github.com/reliant-labs/reliant/internal/llm/drivers"
@@ -176,7 +178,13 @@ func Run(ctx context.Context, opts Options) error {
 	logging.Info("Database initialized", "driver", opts.DatabaseDriver)
 
 	// API key provider (allows LLM drivers to resolve per-user keys from DB)
-	drivers.InitializeAPIKeyProvider(repo)
+	controlPlaneClient := controlplane.NewClientFromEnv()
+	reliantRuntimeBaseURL := envutil.GetEnv("RELIANT_RUNTIME_BASE_URL", "")
+	drivers.InitializeAPIKeyProvider(
+		repo,
+		drivers.WithControlPlaneClient(controlPlaneClient),
+		drivers.WithReliantRuntimeBaseURL(reliantRuntimeBaseURL),
+	)
 
 	// External Temporal client
 	temporalClient, err := temporal.NewExternalClient(ctx, temporal.ExternalClientConfig{

--- a/internal/serverapi/run.go
+++ b/internal/serverapi/run.go
@@ -22,6 +22,7 @@ import (
 	"github.com/reliant-labs/reliant/internal/daemon"
 	"github.com/reliant-labs/reliant/internal/db"
 	"github.com/reliant-labs/reliant/internal/envutil"
+	"github.com/reliant-labs/reliant/internal/features"
 	grpcserver "github.com/reliant-labs/reliant/internal/grpc"
 	"github.com/reliant-labs/reliant/internal/grpc/services"
 	"github.com/reliant-labs/reliant/internal/llm/drivers"
@@ -180,6 +181,10 @@ func Run(ctx context.Context, opts Options) error {
 	// API key provider (allows LLM drivers to resolve per-user keys from DB)
 	controlPlaneClient := controlplane.NewClientFromEnv()
 	reliantRuntimeBaseURL := envutil.GetEnv("RELIANT_RUNTIME_BASE_URL", "")
+	if !features.IsReliantManagedAccessEnabledForContext(ctx, nil, "") {
+		controlPlaneClient = nil
+		reliantRuntimeBaseURL = ""
+	}
 	drivers.InitializeAPIKeyProvider(
 		repo,
 		drivers.WithControlPlaneClient(controlPlaneClient),

--- a/internal/serverworker/run.go
+++ b/internal/serverworker/run.go
@@ -17,8 +17,10 @@ import (
 	"github.com/reliant-labs/reliant/internal/analytics"
 	"github.com/reliant-labs/reliant/internal/config"
 	"github.com/reliant-labs/reliant/internal/configadapter"
+	"github.com/reliant-labs/reliant/internal/controlplane"
 	"github.com/reliant-labs/reliant/internal/daemon"
 	"github.com/reliant-labs/reliant/internal/db"
+	"github.com/reliant-labs/reliant/internal/envutil"
 	"github.com/reliant-labs/reliant/internal/llm/drivers"
 	"github.com/reliant-labs/reliant/internal/llm/drivers/local"
 	"github.com/reliant-labs/reliant/internal/llm/models"
@@ -132,7 +134,13 @@ func Run(ctx context.Context, opts Options) error {
 	defer func() { _ = repo.Close() }()
 
 	// API key provider (allows LLM drivers to resolve per-user keys from DB)
-	drivers.InitializeAPIKeyProvider(repo)
+	controlPlaneClient := controlplane.NewClientFromEnv()
+	reliantRuntimeBaseURL := envutil.GetEnv("RELIANT_RUNTIME_BASE_URL", "")
+	drivers.InitializeAPIKeyProvider(
+		repo,
+		drivers.WithControlPlaneClient(controlPlaneClient),
+		drivers.WithReliantRuntimeBaseURL(reliantRuntimeBaseURL),
+	)
 
 	// -----------------------------------------------------------------
 	// 5. Temporal client

--- a/internal/serverworker/run.go
+++ b/internal/serverworker/run.go
@@ -21,6 +21,7 @@ import (
 	"github.com/reliant-labs/reliant/internal/daemon"
 	"github.com/reliant-labs/reliant/internal/db"
 	"github.com/reliant-labs/reliant/internal/envutil"
+	"github.com/reliant-labs/reliant/internal/features"
 	"github.com/reliant-labs/reliant/internal/llm/drivers"
 	"github.com/reliant-labs/reliant/internal/llm/drivers/local"
 	"github.com/reliant-labs/reliant/internal/llm/models"
@@ -136,6 +137,10 @@ func Run(ctx context.Context, opts Options) error {
 	// API key provider (allows LLM drivers to resolve per-user keys from DB)
 	controlPlaneClient := controlplane.NewClientFromEnv()
 	reliantRuntimeBaseURL := envutil.GetEnv("RELIANT_RUNTIME_BASE_URL", "")
+	if !features.IsReliantManagedAccessEnabledForContext(ctx, nil, "") {
+		controlPlaneClient = nil
+		reliantRuntimeBaseURL = ""
+	}
 	drivers.InitializeAPIKeyProvider(
 		repo,
 		drivers.WithControlPlaneClient(controlPlaneClient),

--- a/internal/workflow/runtime/activities/handlers/call_llm.go
+++ b/internal/workflow/runtime/activities/handlers/call_llm.go
@@ -281,9 +281,9 @@ func (a *CallLLMActivity) streamLLMResponse(ctx context.Context, chat *db.Chat, 
 			modelSelector.Providers = protoModel.GetProviders()
 		}
 
-		// Resolve model using the new registry
-		registry := models.MustGetRegistry()
-		resolved, err := registry.Resolve(modelSelector, availableProviders)
+		// Resolve model using the driver-aware resolver so synthetic providers
+		// like @reliant work the same way they do in catalog/model validation.
+		resolved, err := drivers.ResolveModelSelector(modelSelector, availableDrivers)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve model: %w. Please check your API key configuration in Settings", err)
 		}

--- a/proto/reliant/v1/settings.proto
+++ b/proto/reliant/v1/settings.proto
@@ -70,6 +70,19 @@ service SettingsService {
   // ValidateProviderAPIKey validates an API key for a provider
   rpc ValidateProviderAPIKey(ValidateProviderAPIKeyRequest) returns (ValidateProviderAPIKeyResponse) {}
 
+  // CreateReliantProviderToken creates a first-party Reliant provider token for the current user
+  // and stores the raw token client-side only.
+  rpc CreateReliantProviderToken(CreateReliantProviderTokenRequest) returns (CreateReliantProviderTokenResponse) {}
+
+  // ListReliantProviderTokens lists Reliant provider tokens for the current signed-in user.
+  rpc ListReliantProviderTokens(ListReliantProviderTokensRequest) returns (ListReliantProviderTokensResponse) {}
+
+  // RevokeReliantProviderToken revokes a Reliant provider token in the control-plane.
+  rpc RevokeReliantProviderToken(RevokeReliantProviderTokenRequest) returns (RevokeReliantProviderTokenResponse) {}
+
+  // GetReliantProviderStatus returns local/storage status plus the latest control-plane access state.
+  rpc GetReliantProviderStatus(GetReliantProviderStatusRequest) returns (GetReliantProviderStatusResponse) {}
+
   // CompleteCodexOAuth exchanges an OAuth authorization code + PKCE verifier
   // and marks Codex as connected for the current user.
   rpc CompleteCodexOAuth(CompleteCodexOAuthRequest) returns (CompleteCodexOAuthResponse) {}
@@ -200,6 +213,36 @@ message ProviderStatus {
   bool has_api_key = 3;
   optional string masked_key = 4;
   string display_name = 5;
+  optional string auth_method = 6;
+  optional string status = 7;
+  optional string status_message = 8;
+}
+
+message ReliantProviderToken {
+  string id = 1;
+  string name = 2;
+  string token_prefix = 3;
+  bool ephemeral = 4;
+  string created_at = 5;
+  optional string last_used_at = 6;
+  optional string expires_at = 7;
+  optional string revoked_at = 8;
+}
+
+message ReliantProviderAccessStatus {
+  string state = 1;
+  string message = 2;
+  optional string plan_id = 3;
+  optional string plan_code = 4;
+  repeated string allowed_models = 5;
+  repeated string request_tags = 6;
+  double spend = 7;
+  double hard_budget_usd = 8;
+  string budget_duration = 9;
+  int64 rpm_limit = 10;
+  int64 tpm_limit = 11;
+  int64 max_parallel_requests = 12;
+  string key_duration = 13;
 }
 
 // ============================================
@@ -400,6 +443,44 @@ message ValidateProviderAPIKeyRequest {
 message ValidateProviderAPIKeyResponse {
   bool valid = 1;
   string message = 2;
+}
+
+message CreateReliantProviderTokenRequest {
+  optional string name = 1;
+  optional bool ephemeral = 2;
+  optional int64 expires_in_seconds = 3;
+}
+
+message CreateReliantProviderTokenResponse {
+  bool success = 1;
+  string message = 2;
+  string token = 3;
+  optional ReliantProviderToken daemon_token = 4;
+}
+
+message ListReliantProviderTokensRequest {}
+
+message ListReliantProviderTokensResponse {
+  repeated ReliantProviderToken tokens = 1;
+}
+
+message RevokeReliantProviderTokenRequest {
+  string token_id = 1;
+  bool delete_local_credential = 2;
+}
+
+message RevokeReliantProviderTokenResponse {
+  bool success = 1;
+  string message = 2;
+}
+
+message GetReliantProviderStatusRequest {}
+
+message GetReliantProviderStatusResponse {
+  bool configured = 1;
+  optional string masked_token = 2;
+  repeated ReliantProviderToken tokens = 3;
+  optional ReliantProviderAccessStatus access = 4;
 }
 
 message CompleteCodexOAuthRequest {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -381,6 +381,9 @@ export const api = {
         hasApiKey: p.has_api_key,
         maskedKey: p.masked_key,
         displayName: p.display_name,
+        authMethod: p.auth_method,
+        status: p.status,
+        statusMessage: p.status_message,
       }));
     },
 
@@ -397,6 +400,9 @@ export const api = {
         hasApiKey: found.has_api_key,
         maskedKey: found.masked_key,
         displayName: found.display_name,
+        authMethod: found.auth_method,
+        status: found.status,
+        statusMessage: found.status_message,
       };
     },
 
@@ -413,6 +419,25 @@ export const api = {
 
     validateProviderAPIKey: async (provider: string, apiKey: string) => {
       return settingsGrpc.validateProviderAPIKey(provider, apiKey);
+    },
+
+    createReliantProviderToken: async (input?: {
+      name?: string;
+      ephemeral?: boolean;
+      expires_in_seconds?: number;
+    }) => {
+      return settingsGrpc.createReliantProviderToken(input);
+    },
+
+    revokeReliantProviderToken: async (
+      tokenId: string,
+      deleteLocalCredential?: boolean
+    ) => {
+      return settingsGrpc.revokeReliantProviderToken(tokenId, deleteLocalCredential);
+    },
+
+    getReliantProviderStatus: async () => {
+      return settingsGrpc.getReliantProviderStatus();
     },
 
     completeCodexOAuth: async (code: string, codeVerifier: string, redirectURI: string) => {

--- a/web/src/api/grpc-client.ts
+++ b/web/src/api/grpc-client.ts
@@ -97,16 +97,10 @@ const daemonLastSeenInterceptor: Interceptor = (next) => async (req) => {
   return await next(req);
 };
 
-// Auth interceptor to add JWT token to requests
+// Auth interceptor to add JWT token to requests.
+// In local dev, prefer a real persisted session JWT when present; otherwise
+// fall back to the backend's dev-user behavior by omitting Authorization.
 const authInterceptor: Interceptor = (next) => async (req) => {
-  // In dev mode, skip auth - backend will use DevUser
-  if (getIsDev()) {
-    logger.info("[gRPC Client] Dev mode - skipping auth:", {
-      method: req.method.name,
-    });
-    return await next(req);
-  }
-
   try {
     const {
       data: { session },
@@ -117,6 +111,11 @@ const authInterceptor: Interceptor = (next) => async (req) => {
       logger.info("[gRPC Client] Auth token set for request:", {
         method: req.method.name,
         tokenLength: session.access_token.length,
+        isDev: getIsDev(),
+      });
+    } else if (getIsDev()) {
+      logger.info("[gRPC Client] Dev mode - no persisted JWT, falling back to backend dev user:", {
+        method: req.method.name,
       });
     } else {
       logger.warn("[gRPC Client] No auth token available for request:", {

--- a/web/src/api/settings-grpc.ts
+++ b/web/src/api/settings-grpc.ts
@@ -16,6 +16,8 @@ import type {
   Setting as ProtoSetting,
   UserPrompt as ProtoUserPrompt,
   ProviderStatus as ProtoProviderStatus,
+  ReliantProviderToken as ProtoReliantProviderToken,
+  ReliantProviderAccessStatus as ProtoReliantProviderAccessStatus,
   InstalledSkill as ProtoInstalledSkill,
   RecommendedSkill as ProtoRecommendedSkill,
   SkillDiscoveryDiagnostic as ProtoSkillDiscoveryDiagnostic,
@@ -41,6 +43,10 @@ import {
   GetProviderStatusesRequestSchema,
   UpdateProviderAPIKeyRequestSchema,
   ValidateProviderAPIKeyRequestSchema,
+  CreateReliantProviderTokenRequestSchema,
+  ListReliantProviderTokensRequestSchema,
+  RevokeReliantProviderTokenRequestSchema,
+  GetReliantProviderStatusRequestSchema,
   CompleteCodexOAuthRequestSchema,
   CompleteClaudeOAuthRequestSchema,
   // Sub-phase 6e: Privacy
@@ -88,6 +94,43 @@ export interface ProviderStatus {
   has_api_key: boolean;
   masked_key?: string;
   display_name: string;
+  auth_method?: string;
+  status?: string;
+  status_message?: string;
+}
+
+export interface ReliantProviderToken {
+  id: string;
+  name: string;
+  token_prefix: string;
+  ephemeral: boolean;
+  created_at: string;
+  last_used_at?: string;
+  expires_at?: string;
+  revoked_at?: string;
+}
+
+export interface ReliantProviderAccessStatus {
+  state: string;
+  message: string;
+  plan_id?: string;
+  plan_code?: string;
+  allowed_models: string[];
+  request_tags: string[];
+  spend: number;
+  hard_budget_usd: number;
+  budget_duration: string;
+  rpm_limit: number;
+  tpm_limit: number;
+  max_parallel_requests: number;
+  key_duration: string;
+}
+
+export interface ReliantProviderStatus {
+  configured: boolean;
+  masked_token?: string;
+  tokens: ReliantProviderToken[];
+  access?: ReliantProviderAccessStatus;
 }
 
 export interface Preferences {
@@ -246,6 +289,44 @@ function protoProviderStatusToFrontend(
     has_api_key: proto.hasApiKey,
     masked_key: proto.maskedKey || undefined,
     display_name: proto.displayName,
+    auth_method: proto.authMethod || undefined,
+    status: proto.status || undefined,
+    status_message: proto.statusMessage || undefined,
+  };
+}
+
+function protoReliantProviderTokenToFrontend(
+  proto: ProtoReliantProviderToken
+): ReliantProviderToken {
+  return {
+    id: proto.id,
+    name: proto.name,
+    token_prefix: proto.tokenPrefix,
+    ephemeral: proto.ephemeral,
+    created_at: proto.createdAt,
+    last_used_at: proto.lastUsedAt || undefined,
+    expires_at: proto.expiresAt || undefined,
+    revoked_at: proto.revokedAt || undefined,
+  };
+}
+
+function protoReliantProviderAccessStatusToFrontend(
+  proto: ProtoReliantProviderAccessStatus
+): ReliantProviderAccessStatus {
+  return {
+    state: proto.state,
+    message: proto.message,
+    plan_id: proto.planId || undefined,
+    plan_code: proto.planCode || undefined,
+    allowed_models: proto.allowedModels,
+    request_tags: proto.requestTags,
+    spend: proto.spend,
+    hard_budget_usd: proto.hardBudgetUsd,
+    budget_duration: proto.budgetDuration,
+    rpm_limit: Number(proto.rpmLimit),
+    tpm_limit: Number(proto.tpmLimit),
+    max_parallel_requests: Number(proto.maxParallelRequests),
+    key_duration: proto.keyDuration,
   };
 }
 
@@ -679,6 +760,76 @@ export const settingsGrpc = {
     return {
       valid: response.valid,
       message: response.message,
+    };
+  },
+
+  async createReliantProviderToken(input?: {
+    name?: string;
+    ephemeral?: boolean;
+    expires_in_seconds?: number;
+  }): Promise<{
+    success: boolean;
+    message: string;
+    token: string;
+    daemon_token?: ReliantProviderToken;
+  }> {
+    const client = grpcClient.settings();
+    const request = create(CreateReliantProviderTokenRequestSchema, {
+      name: input?.name,
+      ephemeral: input?.ephemeral,
+      expiresInSeconds:
+        typeof input?.expires_in_seconds === "number"
+          ? BigInt(Math.trunc(input.expires_in_seconds))
+          : undefined,
+    });
+    const response = await client.createReliantProviderToken(request);
+    return {
+      success: response.success,
+      message: response.message,
+      token: response.token,
+      daemon_token: response.daemonToken
+        ? protoReliantProviderTokenToFrontend(response.daemonToken)
+        : undefined,
+    };
+  },
+
+  async listReliantProviderTokens(): Promise<ReliantProviderToken[]> {
+    const client = grpcClient.settings();
+    const request = create(ListReliantProviderTokensRequestSchema, {});
+    const response = await client.listReliantProviderTokens(request);
+    return response.tokens.map(protoReliantProviderTokenToFrontend);
+  },
+
+  async revokeReliantProviderToken(
+    tokenId: string,
+    deleteLocalCredential = false
+  ): Promise<{
+    success: boolean;
+    message: string;
+  }> {
+    const client = grpcClient.settings();
+    const request = create(RevokeReliantProviderTokenRequestSchema, {
+      tokenId,
+      deleteLocalCredential,
+    });
+    const response = await client.revokeReliantProviderToken(request);
+    return {
+      success: response.success,
+      message: response.message,
+    };
+  },
+
+  async getReliantProviderStatus(): Promise<ReliantProviderStatus> {
+    const client = grpcClient.settings();
+    const request = create(GetReliantProviderStatusRequestSchema, {});
+    const response = await client.getReliantProviderStatus(request);
+    return {
+      configured: response.configured,
+      masked_token: response.maskedToken || undefined,
+      tokens: response.tokens.map(protoReliantProviderTokenToFrontend),
+      access: response.access
+        ? protoReliantProviderAccessStatusToFrontend(response.access)
+        : undefined,
     };
   },
 

--- a/web/src/components/ApiKeySetupModal.tsx
+++ b/web/src/components/ApiKeySetupModal.tsx
@@ -1,5 +1,17 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { ExternalLink, Eye, EyeOff, CheckCircle2, XCircle } from "lucide-react";
+import {
+  CheckCircle2,
+  Copy,
+  ExternalLink,
+  Eye,
+  EyeOff,
+  Loader2,
+  Plus,
+  RefreshCw,
+  TestTube,
+  Trash2,
+  XCircle,
+} from "lucide-react";
 import { Modal } from "./ui/Modal";
 import { api } from "../api/client";
 import { useApiKeySetupStore } from "../store/apiKeySetupStore";
@@ -9,11 +21,23 @@ import { useCodexOAuth, useClaudeOAuth, useOAuthAvailability } from "../hooks";
 
 const PROVIDERS = [
   {
+    id: "reliant" as const,
+    name: "Reliant",
+    docsUrl: "",
+    keyFormat: "cpat_...",
+    usesOAuth: false as const,
+    isManaged: true,
+    description:
+      "Managed Reliant access. Create a token here or store an existing one; runtime model access is exchanged automatically.",
+  },
+  {
     id: "claude" as const,
     name: "Claude Code",
     docsUrl: "https://claude.ai",
     keyFormat: "",
     usesOAuth: "claude" as const,
+    isManaged: false,
+    description: "Connect Claude Code with OAuth.",
   },
   {
     id: "codex" as const,
@@ -21,6 +45,8 @@ const PROVIDERS = [
     docsUrl: "https://github.com/openai/codex",
     keyFormat: "",
     usesOAuth: "codex" as const,
+    isManaged: false,
+    description: "Connect Codex with OAuth.",
   },
   {
     id: "anthropic" as const,
@@ -28,6 +54,8 @@ const PROVIDERS = [
     docsUrl: "https://console.anthropic.com/settings/keys",
     keyFormat: "sk-ant-...",
     usesOAuth: false as const,
+    isManaged: false,
+    description: "Use an Anthropic API key.",
   },
   {
     id: "openai" as const,
@@ -35,6 +63,8 @@ const PROVIDERS = [
     docsUrl: "https://platform.openai.com/api-keys",
     keyFormat: "sk-...",
     usesOAuth: false as const,
+    isManaged: false,
+    description: "Use an OpenAI API key.",
   },
   {
     id: "gemini" as const,
@@ -42,6 +72,8 @@ const PROVIDERS = [
     docsUrl: "https://makersuite.google.com/app/apikey",
     keyFormat: "AIza...",
     usesOAuth: false as const,
+    isManaged: false,
+    description: "Use a Google Gemini API key.",
   },
   {
     id: "openrouter" as const,
@@ -49,13 +81,95 @@ const PROVIDERS = [
     docsUrl: "https://openrouter.ai/keys",
     keyFormat: "sk-or-...",
     usesOAuth: false as const,
+    isManaged: false,
+    description: "Use an OpenRouter API key.",
   },
-];
+] as const;
 
 type ProviderId = (typeof PROVIDERS)[number]["id"];
 
+interface ReliantTokenRecord {
+  id: string;
+  name: string;
+  token_prefix: string;
+  ephemeral: boolean;
+  created_at: string;
+  last_used_at?: string;
+  expires_at?: string;
+  revoked_at?: string;
+}
+
+interface ReliantAccessRecord {
+  state: string;
+  message: string;
+  plan_id?: string;
+  plan_code?: string;
+  allowed_models: string[];
+  request_tags: string[];
+  spend: number;
+  hard_budget_usd: number;
+  budget_duration: string;
+  rpm_limit: number;
+  tpm_limit: number;
+  max_parallel_requests: number;
+  key_duration: string;
+}
+
+interface ReliantProviderRecord {
+  configured: boolean;
+  masked_token?: string;
+  tokens: ReliantTokenRecord[];
+  access?: ReliantAccessRecord;
+}
+
 function parseErrorMessage(errorText: string, provider: string): string {
   const lowerError = (errorText || "").toLowerCase();
+
+  if (provider === "reliant") {
+    if (lowerError.includes("signed-in session required")) {
+      return "You need to be signed in to Reliant before creating or managing tokens.";
+    }
+    if (
+      lowerError.includes("missing authorization token") ||
+      lowerError.includes("invalid authorization header")
+    ) {
+      return "Your Reliant session is missing or invalid. Please sign in again and retry.";
+    }
+    if (
+      lowerError.includes("control-plane client is not configured") ||
+      lowerError.includes("reliant control-plane client is not configured")
+    ) {
+      return "This Reliant dev server is missing RELIANT_CONTROLPLANE_URL, so managed Reliant token actions are unavailable in this worktree.";
+    }
+    if (lowerError.includes("not configured")) {
+      return "Reliant is not configured yet. Create or store a token to continue.";
+    }
+    if (
+      lowerError.includes("unauthenticated") ||
+      lowerError.includes("invalid token") ||
+      lowerError.includes("invalid reliant token")
+    ) {
+      return "Reliant could not verify this token or session. Try signing in again or create a fresh token.";
+    }
+    if (lowerError.includes("subscription")) {
+      return "A Reliant subscription is required for managed access.";
+    }
+    if (lowerError.includes("billing")) {
+      return "Reliant billing is required before this token can be used.";
+    }
+    if (lowerError.includes("quota")) {
+      return "Reliant quota is exhausted for this token or plan.";
+    }
+    if (
+      lowerError.includes("rate limit") ||
+      lowerError.includes("resource_exhausted")
+    ) {
+      return "Reliant rate limit reached. Wait a moment and try again.";
+    }
+    if (lowerError.includes("control-plane client is not configured")) {
+      return "Reliant managed access is not available in this environment.";
+    }
+  }
 
   if (provider === "openrouter") {
     if (lowerError.includes("no endpoints found matching your data policy")) {
@@ -79,16 +193,65 @@ function parseErrorMessage(errorText: string, provider: string): string {
     return "Account issue. Check your billing or quota.";
   }
 
-  return errorText || "Validation failed. Please check your API key.";
+  return errorText || "Validation failed. Please check your credentials.";
 }
+
+const statusBadgeClasses = (status?: string) => {
+  switch ((status || "").toLowerCase()) {
+    case "connected":
+      return "bg-emerald-500/10 text-emerald-600 border border-emerald-500/20";
+    case "not_configured":
+      return "bg-muted text-muted-foreground border border-border";
+    case "subscription_required":
+    case "billing_required":
+    case "failed_precondition":
+      return "bg-amber-500/10 text-amber-700 border border-amber-500/20";
+    case "resource_exhausted":
+    case "rate_limit":
+    case "quota_exceeded":
+    case "quota":
+    case "unauthenticated":
+    case "internal":
+      return "bg-red-500/10 text-red-600 border border-red-500/20";
+    default:
+      return "bg-muted text-muted-foreground border border-border";
+  }
+};
+
+const statusLabel = (status?: string) => {
+  switch ((status || "").toLowerCase()) {
+    case "connected":
+      return "Connected";
+    case "not_configured":
+      return "Not configured";
+    case "subscription_required":
+      return "Subscription required";
+    case "billing_required":
+      return "Billing required";
+    case "resource_exhausted":
+      return "Usage limited";
+    case "failed_precondition":
+      return "Setup required";
+    case "unauthenticated":
+      return "Invalid token";
+    case "internal":
+      return "Error";
+    default:
+      return status ? status.replace(/_/g, " ") : "Unknown";
+  }
+};
+
+const formatDateTime = (value?: string) => {
+  if (!value) return "—";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+};
 
 export function ApiKeySetupModal() {
   const showModal = useApiKeySetupStore((s) => s.showModal);
   const dismissModal = useApiKeySetupStore((s) => s.dismissModal);
 
-  const [selectedProvider, setSelectedProvider] = useState<ProviderId>(
-    "claude"
-  );
+  const [selectedProvider, setSelectedProvider] = useState<ProviderId>("reliant");
   const [apiKey, setApiKey] = useState("");
   const [showKey, setShowKey] = useState(false);
   const [validationResult, setValidationResult] = useState<{
@@ -97,6 +260,13 @@ export function ApiKeySetupModal() {
   } | null>(null);
   const [isValidating, setIsValidating] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [reliantStatus, setReliantStatus] = useState<ReliantProviderRecord | null>(null);
+  const [reliantLoading, setReliantLoading] = useState(false);
+  const [reliantActionLoading, setReliantActionLoading] = useState<string | null>(null);
+  const [reliantTokenName, setReliantTokenName] = useState("");
+  const [createdReliantToken, setCreatedReliantToken] = useState("");
+  const [copiedReliantToken, setCopiedReliantToken] = useState(false);
+
   const codexOAuth = useCodexOAuth();
   const claudeOAuth = useClaudeOAuth();
   const oauthAvailability = useOAuthAvailability();
@@ -106,67 +276,119 @@ export function ApiKeySetupModal() {
     [selectedProvider]
   );
 
-  useEffect(() => {
-    if (!showModal) {
-      codexOAuth.cancel();
-      claudeOAuth.cancel();
-      setApiKey("");
-      setValidationResult(null);
-      setIsValidating(false);
-      setIsSaving(false);
-      setShowKey(false);
-      setSelectedProvider("claude");
-    }
-  }, [showModal, codexOAuth, claudeOAuth]);
+  const refreshAfterConfiguration = useCallback(async () => {
+    useApiKeySetupStore.setState({ hasApiKey: true, showModal: false });
+    const { useGlobalDataStore } = await import("../store/globalDataStore");
+    await useGlobalDataStore.getState().refetchModels();
+    window.dispatchEvent(new CustomEvent("api-key-saved"));
+  }, []);
 
-  const handleConnectOAuth = useCallback(async (oauthType: "codex" | "claude") => {
-    setIsValidating(true);
-    setValidationResult(null);
-
-    const oauthHook = oauthType === "claude" ? claudeOAuth : codexOAuth;
-    const displayName = oauthType === "claude" ? "Claude Code" : "Codex";
-
+  const refreshReliantStatus = useCallback(async () => {
+    setReliantLoading(true);
     try {
-      const result = await oauthHook.start();
-      if (!result.ok) {
-        setValidationResult({ valid: false, message: result.message });
-        return false;
-      }
-
-      setValidationResult({ valid: true, message: result.message || `Connected to ${displayName} successfully!` });
-
-      // Mark store as having a key and close modal
-      useApiKeySetupStore.setState({ hasApiKey: true, showModal: false });
-
-      // Refetch models
-      const { useGlobalDataStore } = await import("../store/globalDataStore");
-      await useGlobalDataStore.getState().refetchModels();
-      window.dispatchEvent(new CustomEvent("api-key-saved"));
-      return true;
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      setValidationResult({ valid: false, message: msg });
-      return false;
+      const status = await api.settings.getReliantProviderStatus();
+      setReliantStatus(status);
+    } catch (error) {
+      console.error("Failed to load Reliant status:", error);
     } finally {
-      setIsValidating(false);
+      setReliantLoading(false);
     }
-  }, [codexOAuth, claudeOAuth]);
+  }, []);
 
-  // Handle provider selection only; OAuth starts from explicit button click.
+  useEffect(() => {
+    if (showModal) {
+      void refreshReliantStatus();
+      return;
+    }
+
+    codexOAuth.cancel();
+    claudeOAuth.cancel();
+    setApiKey("");
+    setValidationResult(null);
+    setIsValidating(false);
+    setIsSaving(false);
+    setShowKey(false);
+    setSelectedProvider("reliant");
+    setReliantTokenName("");
+    setCreatedReliantToken("");
+    setCopiedReliantToken(false);
+  }, [claudeOAuth, codexOAuth, refreshReliantStatus, showModal]);
+
+  const handleConnectOAuth = useCallback(
+    async (oauthType: "codex" | "claude") => {
+      setIsValidating(true);
+      setValidationResult(null);
+
+      const oauthHook = oauthType === "claude" ? claudeOAuth : codexOAuth;
+      const displayName = oauthType === "claude" ? "Claude Code" : "Codex";
+
+      try {
+        const result = await oauthHook.start();
+        if (!result.ok) {
+          setValidationResult({ valid: false, message: result.message });
+          return false;
+        }
+
+        setValidationResult({
+          valid: true,
+          message: result.message || `Connected to ${displayName} successfully!`,
+        });
+
+        await refreshAfterConfiguration();
+        return true;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setValidationResult({ valid: false, message: parseErrorMessage(msg, oauthType) });
+        return false;
+      } finally {
+        setIsValidating(false);
+      }
+    },
+    [claudeOAuth, codexOAuth, refreshAfterConfiguration]
+  );
+
   const handleProviderSelect = useCallback((providerId: ProviderId) => {
     setSelectedProvider(providerId);
     setValidationResult(null);
+    setApiKey("");
+    setShowKey(false);
+    setCreatedReliantToken("");
   }, []);
 
   const handleValidate = useCallback(async () => {
-    // For OAuth providers, use the dedicated handler
     if (provider.usesOAuth) {
       await handleConnectOAuth(provider.usesOAuth as "codex" | "claude");
       return;
     }
 
+    if (provider.isManaged && !apiKey.trim()) {
+      setIsValidating(true);
+      setValidationResult(null);
+      try {
+        const result = await api.settings.validateProviderAPIKey("reliant", "");
+        setValidationResult({
+          valid: result.valid,
+          message: result.valid
+            ? result.message || "Reliant access looks healthy."
+            : parseErrorMessage(result.message || "Reliant validation failed", "reliant"),
+        });
+        await refreshReliantStatus();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setValidationResult({ valid: false, message: parseErrorMessage(msg, "reliant") });
+      } finally {
+        setIsValidating(false);
+      }
+      return;
+    }
+
     if (!apiKey.trim()) {
-      setValidationResult({ valid: false, message: "Please enter an API key." });
+      setValidationResult({
+        valid: false,
+        message: provider.isManaged
+          ? "Paste a cpat_ token or create a new one first."
+          : "Please enter an API key.",
+      });
       return;
     }
 
@@ -180,12 +402,24 @@ export function ApiKeySetupModal() {
       );
 
       if (result.valid) {
-        setValidationResult({ valid: true, message: "API key looks valid." });
+        setValidationResult({
+          valid: true,
+          message:
+            result.message ||
+            (provider.isManaged ? "Reliant access looks healthy." : "API key looks valid."),
+        });
       } else {
         setValidationResult({
           valid: false,
-          message: parseErrorMessage(result.message || "Invalid API key", selectedProvider),
+          message: parseErrorMessage(
+            result.message || "Invalid API key",
+            selectedProvider
+          ),
         });
+      }
+
+      if (provider.isManaged) {
+        await refreshReliantStatus();
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -196,11 +430,23 @@ export function ApiKeySetupModal() {
     } finally {
       setIsValidating(false);
     }
-  }, [apiKey, selectedProvider, provider.usesOAuth, handleConnectOAuth]);
+  }, [
+    apiKey,
+    handleConnectOAuth,
+    provider.isManaged,
+    provider.usesOAuth,
+    refreshReliantStatus,
+    selectedProvider,
+  ]);
 
   const handleSave = useCallback(async () => {
     if (!apiKey.trim()) {
-      setValidationResult({ valid: false, message: "Please enter an API key." });
+      setValidationResult({
+        valid: false,
+        message: provider.isManaged
+          ? "Paste a cpat_ token to store it locally."
+          : "Please enter an API key.",
+      });
       return;
     }
 
@@ -208,7 +454,6 @@ export function ApiKeySetupModal() {
     setValidationResult(null);
 
     try {
-      // Validate first (server-side) to avoid saving obviously bad keys.
       const validation = await api.settings.validateProviderAPIKey(
         selectedProvider,
         apiKey.trim()
@@ -226,18 +471,14 @@ export function ApiKeySetupModal() {
       }
 
       await api.settings.updateProvider(selectedProvider, apiKey.trim());
+      if (provider.isManaged) {
+        await refreshReliantStatus();
+      }
+      await refreshAfterConfiguration();
 
-      // Mark store as having a key so other ensure() calls stop prompting.
-      useApiKeySetupStore.setState({ hasApiKey: true, showModal: false });
-
-      // Immediately refetch models so they appear in dropdowns right away
-      const { useGlobalDataStore } = await import("../store/globalDataStore");
-      await useGlobalDataStore.getState().refetchModels();
-
-      // Dispatch event to notify all model inputs to refresh
-      window.dispatchEvent(new CustomEvent('api-key-saved'));
-
-      logger.info("[ApiKeySetupModal] Saved API key and refetched models", { provider: selectedProvider });
+      logger.info("[ApiKeySetupModal] Saved provider credentials and refetched models", {
+        provider: selectedProvider,
+      });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       setValidationResult({
@@ -247,25 +488,385 @@ export function ApiKeySetupModal() {
     } finally {
       setIsSaving(false);
     }
-  }, [apiKey, selectedProvider]);
+  }, [
+    apiKey,
+    provider.isManaged,
+    refreshAfterConfiguration,
+    refreshReliantStatus,
+    selectedProvider,
+  ]);
+
+  const handleCreateReliantToken = useCallback(async () => {
+    setReliantActionLoading("create");
+    setValidationResult(null);
+
+    try {
+      const result = await api.settings.createReliantProviderToken({
+        name: reliantTokenName.trim() || undefined,
+      });
+      if (!result.success) {
+        throw new Error(result.message || "Failed to create Reliant token");
+      }
+
+      setCreatedReliantToken(result.token);
+      setCopiedReliantToken(false);
+      if (navigator.clipboard?.writeText) {
+        try {
+          await navigator.clipboard.writeText(result.token);
+          setCopiedReliantToken(true);
+          setTimeout(() => setCopiedReliantToken(false), 2000);
+        } catch (error) {
+          console.error("Failed to copy Reliant token:", error);
+        }
+      }
+
+      setValidationResult({
+        valid: true,
+        message:
+          result.message ||
+          "Reliant token created, stored locally, and copied to your clipboard.",
+      });
+      setReliantTokenName("");
+
+      const refreshFailures: string[] = [];
+      try {
+        await refreshReliantStatus();
+      } catch (error) {
+        console.error("Failed to refresh Reliant status after token creation:", error);
+        refreshFailures.push("status");
+      }
+      try {
+        await refreshAfterConfiguration();
+      } catch (error) {
+        console.error("Failed to refresh app state after token creation:", error);
+        refreshFailures.push("app");
+      }
+
+      if (refreshFailures.length > 0) {
+        setValidationResult({
+          valid: true,
+          message:
+            "Reliant token created successfully. Some follow-up refresh steps failed, so you may need to refresh the UI before access status updates.",
+        });
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setValidationResult({ valid: false, message: parseErrorMessage(msg, "reliant") });
+    } finally {
+      setReliantActionLoading(null);
+    }
+  }, [refreshAfterConfiguration, refreshReliantStatus, reliantTokenName]);
+
+  const handleCopyToken = useCallback(async () => {
+    if (!createdReliantToken || !navigator.clipboard?.writeText) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(createdReliantToken);
+      setCopiedReliantToken(true);
+      setTimeout(() => setCopiedReliantToken(false), 2000);
+    } catch (error) {
+      console.error("Failed to copy token:", error);
+    }
+  }, [createdReliantToken]);
+
+  const handleRevokeReliantToken = useCallback(
+    async (tokenId: string) => {
+      if (!window.confirm("Revoke this Reliant token? This cannot be undone.")) {
+        return;
+      }
+
+      setReliantActionLoading(`revoke:${tokenId}`);
+      setValidationResult(null);
+
+      try {
+        const result = await api.settings.revokeReliantProviderToken(tokenId, false);
+        if (!result.success) {
+          throw new Error(result.message || "Failed to revoke Reliant token");
+        }
+        setValidationResult({
+          valid: true,
+          message: result.message || "Reliant token revoked.",
+        });
+        await refreshReliantStatus();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setValidationResult({
+          valid: false,
+          message: parseErrorMessage(msg, "reliant"),
+        });
+      } finally {
+        setReliantActionLoading(null);
+      }
+    },
+    [refreshReliantStatus]
+  );
+
+  const renderReliantStatus = () => {
+    const access = reliantStatus?.access;
+    return (
+      <div className="space-y-4">
+        <div className="rounded-lg border border-border bg-muted/20 p-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-medium">Managed access status</span>
+            <span
+              className={cn(
+                "inline-flex items-center rounded-full px-2 py-1 text-xs font-medium",
+                statusBadgeClasses(access?.state)
+              )}
+            >
+              {statusLabel(access?.state)}
+            </span>
+          </div>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {access?.message || "Reliant status will appear here once you configure a token."}
+          </p>
+          {reliantStatus?.masked_token ? (
+            <p className="mt-2 font-mono text-xs text-muted-foreground">
+              Stored token: {reliantStatus.masked_token}
+            </p>
+          ) : null}
+          {access?.allowed_models?.length ? (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {access.allowed_models.map((model) => (
+                <span
+                  key={model}
+                  className="rounded-full border border-border bg-background px-2 py-1 text-xs"
+                >
+                  {model}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        {createdReliantToken ? (
+          <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium text-emerald-700">New Reliant token</p>
+                <p className="mt-1 break-all font-mono text-xs text-emerald-700/90">
+                  {createdReliantToken}
+                </p>
+                <p className="mt-2 text-xs text-emerald-700/80">
+                  This token is only shown once. Copy it now if you need it elsewhere.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => void handleCopyToken()}
+                className="inline-flex items-center gap-2 rounded-md border border-emerald-500/30 bg-background px-3 py-1.5 text-sm text-emerald-700 hover:bg-background/80"
+              >
+                <Copy className="h-4 w-4" />
+                {copiedReliantToken ? "Copied" : "Copy"}
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="space-y-4 rounded-lg border border-primary/20 bg-primary/5 p-4">
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-foreground">Create a Reliant token</p>
+            <p className="text-sm text-muted-foreground">
+              This is the normal setup path. Reliant stores the token locally for this app and
+              exchanges it for runtime model access automatically.
+            </p>
+          </div>
+          <input
+            value={reliantTokenName}
+            onChange={(e) => setReliantTokenName(e.target.value)}
+            placeholder="Optional token name"
+            className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+          />
+          <p className="text-xs text-muted-foreground">
+            The full cpat_ token is shown once after creation in case you need to copy it
+            elsewhere.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void handleCreateReliantToken()}
+              disabled={reliantActionLoading === "create"}
+              className={cn(
+                "px-4 py-2 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors",
+                reliantActionLoading === "create" && "opacity-50 cursor-not-allowed"
+              )}
+            >
+              {reliantActionLoading === "create" ? (
+                <span className="inline-flex items-center gap-2">
+                  <Loader2 className="w-4 h-4 animate-spin" /> Creating…
+                </span>
+              ) : (
+                <span className="inline-flex items-center gap-2">
+                  <Plus className="w-4 h-4" /> Create token
+                </span>
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={() => void refreshReliantStatus()}
+              disabled={reliantLoading}
+              className={cn(
+                "px-4 py-2 text-sm border border-border rounded-lg hover:bg-muted transition-colors",
+                reliantLoading && "opacity-50 cursor-not-allowed"
+              )}
+            >
+              {reliantLoading ? (
+                <span className="inline-flex items-center gap-2">
+                  <Loader2 className="w-4 h-4 animate-spin" /> Refreshing…
+                </span>
+              ) : (
+                <span className="inline-flex items-center gap-2">
+                  <RefreshCw className="w-4 h-4" /> Refresh status
+                </span>
+              )}
+            </button>
+          </div>
+        </div>
+
+        <details className="rounded-lg border border-border bg-background p-4">
+          <summary className="cursor-pointer list-none text-sm font-medium text-foreground">
+            Use an existing token instead
+          </summary>
+          <div className="mt-4 space-y-2">
+            <p className="text-sm text-muted-foreground">
+              Paste a cpat_ token only if you already created one in another Reliant client or on
+              another device.
+            </p>
+            <div className="relative">
+              <input
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder={provider.keyFormat}
+                type={showKey ? "text" : "password"}
+                className={cn(
+                  "w-full rounded-lg border border-border bg-background px-3 py-2 pr-10 text-sm font-mono",
+                  "focus:outline-none focus:ring-2 focus:ring-primary"
+                )}
+                autoComplete="off"
+              />
+              <button
+                type="button"
+                onClick={() => setShowKey((v) => !v)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground"
+                aria-label={showKey ? "Hide token" : "Show token"}
+              >
+                {showKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={handleValidate}
+                disabled={isValidating}
+                className={cn(
+                  "px-4 py-2 text-sm border border-border rounded-lg hover:bg-muted transition-colors",
+                  isValidating && "opacity-50 cursor-not-allowed"
+                )}
+              >
+                {isValidating ? (
+                  <span className="inline-flex items-center gap-2">
+                    <Loader2 className="w-4 h-4 animate-spin" /> Checking…
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center gap-2">
+                    <TestTube className="w-4 h-4" /> Check access
+                  </span>
+                )}
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={!apiKey.trim() || isSaving || isValidating}
+                className={cn(
+                  "px-4 py-2 text-sm border border-primary/30 bg-primary/10 text-primary rounded-lg hover:bg-primary/15 transition-colors",
+                  (isSaving || isValidating) && "opacity-50 cursor-not-allowed"
+                )}
+              >
+                {isSaving ? "Saving…" : "Store token"}
+              </button>
+            </div>
+          </div>
+        </details>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <div>
+              <h4 className="text-sm font-medium">Control-plane tokens</h4>
+              <p className="text-xs text-muted-foreground">
+                Runtime model keys are exchanged from these stored control-plane tokens.
+              </p>
+            </div>
+          </div>
+          {reliantStatus?.tokens?.length ? (
+            <div className="space-y-2">
+              {reliantStatus.tokens.map((token) => (
+                <div
+                  key={token.id}
+                  className="flex flex-col gap-3 rounded-lg border border-border bg-background p-3 md:flex-row md:items-center md:justify-between"
+                >
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-medium">{token.name || token.token_prefix}</span>
+                      <span className="rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground">
+                        {token.token_prefix}
+                      </span>
+                    </div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      Created {formatDateTime(token.created_at)}
+                      {token.last_used_at ? ` • Last used ${formatDateTime(token.last_used_at)}` : ""}
+                      {token.expires_at ? ` • Expires ${formatDateTime(token.expires_at)}` : ""}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => void handleRevokeReliantToken(token.id)}
+                    disabled={reliantActionLoading === `revoke:${token.id}`}
+                    className={cn(
+                      "inline-flex items-center gap-2 rounded-md border border-destructive/20 px-3 py-1.5 text-sm text-destructive hover:bg-destructive/10",
+                      reliantActionLoading === `revoke:${token.id}` &&
+                        "opacity-50 cursor-not-allowed"
+                    )}
+                  >
+                    {reliantActionLoading === `revoke:${token.id}` ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <Trash2 className="w-4 h-4" />
+                    )}
+                    Revoke
+                  </button>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
+              No Reliant tokens returned from the control plane yet.
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  };
 
   return (
     <Modal
       isOpen={showModal}
       onClose={() => dismissModal(false)}
-      title="Add an API key"
+      title="Set up a provider"
       size="lg"
     >
       <div className="space-y-5">
         <p className="text-sm text-muted-foreground">
-          Reliant needs an LLM provider API key to run workflows. Add one now to
-          continue.
+          Reliant needs at least one configured provider before workflows can run.
+          You can use managed Reliant access, connect an OAuth-backed provider, or
+          add a standard API key.
         </p>
 
         <div className="space-y-2">
           <div className="flex items-center justify-between">
             <label className="text-sm font-medium text-foreground">Provider</label>
-            {!provider.usesOAuth && (
+            {!provider.usesOAuth && !provider.isManaged && (
               <a
                 href={provider.docsUrl}
                 target="_blank"
@@ -296,8 +897,27 @@ export function ApiKeySetupModal() {
           </div>
         </div>
 
-        {/* OAuth Section */}
-        {provider.usesOAuth ? (
+        {validationResult && (
+          <div
+            className={cn(
+              "flex items-center gap-2 text-sm p-3 rounded-lg border",
+              validationResult.valid
+                ? "bg-emerald-500/10 text-emerald-600 border-emerald-500/20"
+                : "bg-red-500/10 text-red-600 border-red-500/20"
+            )}
+          >
+            {validationResult.valid ? (
+              <CheckCircle2 className="w-4 h-4" />
+            ) : (
+              <XCircle className="w-4 h-4" />
+            )}
+            {validationResult.message}
+          </div>
+        )}
+
+        {provider.isManaged ? (
+          renderReliantStatus()
+        ) : provider.usesOAuth ? (
           <div className="space-y-4">
             <div className="p-4 rounded-lg border border-border bg-muted/30">
               <div className="space-y-2">
@@ -317,31 +937,13 @@ export function ApiKeySetupModal() {
               </div>
             </div>
 
-            {validationResult && (
-              <div
-                className={cn(
-                  "flex items-center gap-2 text-sm p-3 rounded-lg",
-                  validationResult.valid
-                    ? "bg-emerald-500/10 text-emerald-600 border border-emerald-500/20"
-                    : "bg-red-500/10 text-red-600 border border-red-500/20"
-                )}
-              >
-                {validationResult.valid ? (
-                  <CheckCircle2 className="w-4 h-4" />
-                ) : (
-                  <XCircle className="w-4 h-4" />
-                )}
-                {validationResult.message}
-              </div>
-            )}
-
             <div className="flex items-center justify-between gap-3 pt-1">
               <button
                 type="button"
                 onClick={() => dismissModal(true)}
                 className="text-sm text-muted-foreground hover:text-foreground"
               >
-                Don't ask again
+                Don&apos;t ask again
               </button>
 
               {oauthAvailability.available ? (
@@ -369,7 +971,6 @@ export function ApiKeySetupModal() {
             </div>
           </div>
         ) : (
-          /* Standard API Key Input Section */
           <>
             <div className="space-y-2">
               <label className="text-sm font-medium text-foreground">API key</label>
@@ -394,17 +995,6 @@ export function ApiKeySetupModal() {
                   {showKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
                 </button>
               </div>
-
-              {validationResult && (
-                <div
-                  className={cn(
-                    "text-xs",
-                    validationResult.valid ? "text-emerald-500" : "text-red-500"
-                  )}
-                >
-                  {validationResult.message}
-                </div>
-              )}
             </div>
 
             <div className="flex items-center justify-between gap-3 pt-1">
@@ -413,7 +1003,7 @@ export function ApiKeySetupModal() {
                 onClick={() => dismissModal(true)}
                 className="text-sm text-muted-foreground hover:text-foreground"
               >
-                Don't ask again
+                Don&apos;t ask again
               </button>
 
               <div className="flex items-center gap-2">

--- a/web/src/components/Settings/CombinedGeneralSettings.tsx
+++ b/web/src/components/Settings/CombinedGeneralSettings.tsx
@@ -1,41 +1,81 @@
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  Loader2,
   AlertCircle,
   Check,
+  CheckCircle2,
+  ChevronDown,
+  Copy,
   Eye,
   EyeOff,
+  Loader2,
   Plus,
+  RefreshCw,
   Settings2,
   TestTube,
-  ChevronDown,
   Trash2,
-  CheckCircle2,
-  XCircle,
 } from "lucide-react";
 import { Toggle } from "../ui/Toggle";
 import { cn } from "../../lib/utils";
 import { api } from "../../api/client";
 import { useGlobalDataStore } from "../../store/globalDataStore";
 import {
-  useApiKeySetupStore,
   resetApiKeySetupDismissed,
+  useApiKeySetupStore,
 } from "../../store/apiKeySetupStore";
 import { useCodexOAuth, useClaudeOAuth, useOAuthAvailability } from "../../hooks";
 
-interface CombinedGeneralSettingsProps {
-  providers: Array<{
-    provider: string;
-    displayName: string;
-    hasApiKey: boolean;
-    maskedKey?: string;
-    configured: boolean;
-  }>;
-  onProvidersUpdate?: () => void;
+interface ProviderSummary {
+  provider: string;
+  displayName: string;
+  hasApiKey: boolean;
+  maskedKey?: string;
+  configured: boolean;
+  authMethod?: string;
+  status?: string;
+  statusMessage?: string;
 }
 
-// Providers visible in the UI (other providers are hidden but implementations remain)
+interface CombinedGeneralSettingsProps {
+  providers: ProviderSummary[];
+  onProvidersUpdate?: () => void | Promise<void>;
+}
+
+interface ReliantTokenRecord {
+  id: string;
+  name: string;
+  token_prefix: string;
+  ephemeral: boolean;
+  created_at: string;
+  last_used_at?: string;
+  expires_at?: string;
+  revoked_at?: string;
+}
+
+interface ReliantAccessRecord {
+  state: string;
+  message: string;
+  plan_id?: string;
+  plan_code?: string;
+  allowed_models: string[];
+  request_tags: string[];
+  spend: number;
+  hard_budget_usd: number;
+  budget_duration: string;
+  rpm_limit: number;
+  tpm_limit: number;
+  max_parallel_requests: number;
+  key_duration: string;
+}
+
+interface ReliantProviderRecord {
+  configured: boolean;
+  masked_token?: string;
+  tokens: ReliantTokenRecord[];
+  access?: ReliantAccessRecord;
+}
+
 const VISIBLE_PROVIDERS = [
+  "reliant",
   "claude",
   "codex",
   "anthropic",
@@ -45,6 +85,15 @@ const VISIBLE_PROVIDERS = [
 ] as const;
 
 const providerConfigs = {
+  reliant: {
+    name: "Reliant",
+    docsUrl: "",
+    keyFormat: "cpat_...",
+    description:
+      "Managed Reliant access. Create a Reliant token here or store an existing one; runtime access is exchanged and limited by your plan.",
+    usesOAuth: false,
+    isManaged: true,
+  },
   claude: {
     name: "Claude Code",
     docsUrl: "https://claude.ai",
@@ -52,102 +101,169 @@ const providerConfigs = {
     description:
       "Claude 4.5 and 4.6 models via Claude OAuth (uses Claude authentication)",
     usesOAuth: "claude" as const,
+    isManaged: false,
   },
   codex: {
     name: "Codex (ChatGPT)",
     docsUrl: "https://github.com/openai/codex",
     keyFormat: "",
     description:
-      "GPT-5.3 Codex (flagship) via ChatGPT backend (uses Codex authentication)",
+      "GPT-5.3 Codex via ChatGPT backend (uses Codex authentication)",
     usesOAuth: "codex" as const,
-  },
-  openrouter: {
-    name: "OpenRouter",
-    docsUrl: "https://openrouter.ai/keys",
-    keyFormat: "sk-or-...",
-    description:
-      "Access 400+ AI models through one API (Claude, GPT, Gemini, Grok)",
-    usesOAuth: false,
+    isManaged: false,
   },
   anthropic: {
     name: "Anthropic",
     docsUrl: "https://console.anthropic.com/settings/keys",
     keyFormat: "sk-ant-...",
-    description: "Claude 3.5, Claude 3, and other Anthropic models",
+    description: "Claude models through Anthropic API keys",
     usesOAuth: false,
+    isManaged: false,
   },
   openai: {
     name: "OpenAI",
     docsUrl: "https://platform.openai.com/api-keys",
     keyFormat: "sk-...",
-    description: "GPT-4, GPT-3.5, and other OpenAI models",
+    description: "GPT models through OpenAI API keys",
     usesOAuth: false,
+    isManaged: false,
   },
   gemini: {
     name: "Google Gemini",
     docsUrl: "https://makersuite.google.com/app/apikey",
     keyFormat: "AIza...",
-    description: "Gemini Pro, Gemini Ultra, and other Google models",
+    description: "Gemini models through Google API keys",
     usesOAuth: false,
+    isManaged: false,
   },
-  azure: {
-    name: "Azure OpenAI",
-    docsUrl: "https://portal.azure.com/",
-    keyFormat: "deployment-specific",
-    description: "OpenAI models hosted on Azure",
+  openrouter: {
+    name: "OpenRouter",
+    docsUrl: "https://openrouter.ai/keys",
+    keyFormat: "sk-or-...",
+    description: "Access multiple model families through OpenRouter",
     usesOAuth: false,
+    isManaged: false,
   },
-  bedrock: {
-    name: "AWS Bedrock",
-    docsUrl: "https://console.aws.amazon.com/bedrock/",
-    keyFormat: "AWS credentials",
-    description: "Claude, Llama, and other models on AWS",
-    usesOAuth: false,
-  },
-  copilot: {
-    name: "GitHub Copilot",
-    docsUrl: "https://github.com/settings/copilot",
-    keyFormat: "GitHub token",
-    description: "GitHub Copilot API access",
-    usesOAuth: false,
-  },
-  groq: {
-    name: "Groq",
-    docsUrl: "https://console.groq.com/keys",
-    keyFormat: "gsk_...",
-    description: "Fast inference with Groq LPU",
-    usesOAuth: false,
-  },
-  vertexai: {
-    name: "Vertex AI",
-    docsUrl: "https://console.cloud.google.com/vertex-ai",
-    keyFormat: "GCP credentials",
-    description: "Google Cloud AI models",
-    usesOAuth: false,
-  },
-  xai: {
-    name: "xAI",
-    docsUrl: "https://x.ai/",
-    keyFormat: "xai-...",
-    description: "Grok and other xAI models",
-    usesOAuth: false,
-  },
-  local: {
-    name: "Local Models",
-    docsUrl: "",
-    keyFormat: "N/A",
-    description: "Ollama, llama.cpp, and other local models",
-    usesOAuth: false,
-  },
-};
+} as const;
 
 type ProviderId = keyof typeof providerConfigs;
 
-// Comprehensive error message parser for all API providers
-const parseErrorMessage = (errorText: string, provider: string): string => {
-  const lowerError = errorText.toLowerCase();
+const isProviderConnected = (provider: {
+  configured: boolean;
+  hasApiKey: boolean;
+}) => provider.configured || provider.hasApiKey;
 
-  // Claude specific errors
+const statusBadgeClasses = (status?: string) => {
+  switch ((status || "").toLowerCase()) {
+    case "connected":
+      return "bg-emerald-500/10 text-emerald-600 border border-emerald-500/20";
+    case "not_configured":
+      return "bg-muted text-muted-foreground border border-border";
+    case "subscription_required":
+    case "billing_required":
+    case "failed_precondition":
+      return "bg-amber-500/10 text-amber-700 border border-amber-500/20";
+    case "resource_exhausted":
+    case "rate_limit":
+    case "quota_exceeded":
+    case "quota":
+    case "unauthenticated":
+    case "internal":
+      return "bg-red-500/10 text-red-600 border border-red-500/20";
+    default:
+      return "bg-muted text-muted-foreground border border-border";
+  }
+};
+
+const statusLabel = (status?: string) => {
+  switch ((status || "").toLowerCase()) {
+    case "connected":
+      return "Connected";
+    case "not_configured":
+      return "Not configured";
+    case "subscription_required":
+      return "Subscription required";
+    case "billing_required":
+      return "Billing required";
+    case "resource_exhausted":
+      return "Usage limited";
+    case "failed_precondition":
+      return "Setup required";
+    case "unauthenticated":
+      return "Invalid token";
+    case "internal":
+      return "Error";
+    case "unavailable":
+      return "Unavailable";
+    default:
+      return status ? status.replace(/_/g, " ") : "Unknown";
+  }
+};
+
+const formatDateTime = (value?: string) => {
+  if (!value) return "—";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+};
+
+const formatCurrency = (value?: number) => {
+  if (typeof value !== "number") return "—";
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(value);
+};
+
+const parseErrorMessage = (errorText: string, provider: string): string => {
+  const lowerError = (errorText || "").toLowerCase();
+
+  if (provider === "reliant") {
+    if (lowerError.includes("signed-in session required")) {
+      return "You need to be signed in to Reliant before creating or managing tokens.";
+    }
+    if (
+      lowerError.includes("missing authorization token") ||
+      lowerError.includes("invalid authorization header")
+    ) {
+      return "Your Reliant session is missing or invalid. Please sign in again and retry.";
+    }
+    if (
+      lowerError.includes("control-plane client is not configured") ||
+      lowerError.includes("reliant control-plane client is not configured")
+    ) {
+      return "This Reliant dev server is missing RELIANT_CONTROLPLANE_URL, so managed Reliant token actions are unavailable in this worktree.";
+    }
+    if (lowerError.includes("not configured")) {
+      return "Reliant is not configured yet. Create or store a Reliant token to continue.";
+    }
+    if (
+      lowerError.includes("unauthenticated") ||
+      lowerError.includes("invalid token") ||
+      lowerError.includes("invalid reliant token")
+    ) {
+      return "Reliant could not verify this token or session. Try signing in again or create a fresh token.";
+    }
+    if (lowerError.includes("subscription")) {
+      return "A Reliant subscription is required for managed access.";
+    }
+    if (lowerError.includes("billing")) {
+      return "Reliant billing is required before this token can be used.";
+    }
+    if (lowerError.includes("quota")) {
+      return "Reliant quota is exhausted for this token or plan.";
+    }
+    if (
+      lowerError.includes("rate limit") ||
+      lowerError.includes("resource_exhausted")
+    ) {
+      return "Reliant rate limit reached. Wait a moment and try again.";
+    }
+    if (lowerError.includes("control-plane client is not configured")) {
+      return "Reliant managed access is not available in this environment.";
+    }
+  }
+
   if (provider === "claude") {
     if (lowerError.includes("not authenticated")) {
       return "Claude is not connected. Please use Login with Claude.";
@@ -158,15 +274,8 @@ const parseErrorMessage = (errorText: string, provider: string): string => {
     if (lowerError.includes("unauthorized") || lowerError.includes("401")) {
       return "Claude authentication failed. Please reconnect with Login with Claude.";
     }
-    if (lowerError.includes("rate limit") || lowerError.includes("429")) {
-      return "Claude rate limit exceeded. Please wait a moment before trying again.";
-    }
-    if (lowerError.includes("session") || lowerError.includes("invalid")) {
-      return "Claude session error. Please reconnect with Login with Claude.";
-    }
   }
 
-  // Codex (ChatGPT) specific errors
   if (provider === "codex") {
     if (lowerError.includes("not authenticated")) {
       return "Codex is not connected. Please use Login with Codex.";
@@ -177,121 +286,17 @@ const parseErrorMessage = (errorText: string, provider: string): string => {
     if (lowerError.includes("unauthorized") || lowerError.includes("401")) {
       return "Codex authentication failed. Please reconnect with Login with Codex.";
     }
-    if (lowerError.includes("rate limit") || lowerError.includes("429")) {
-      return "Codex rate limit exceeded. Please wait a moment before trying again.";
-    }
-    if (lowerError.includes("session") || lowerError.includes("invalid")) {
-      return "Codex session error. Please reconnect with Login with Codex.";
-    }
   }
 
-  // OpenRouter specific errors
   if (provider === "openrouter") {
     if (lowerError.includes("no endpoints found matching your data policy")) {
-      return "OpenRouter requires privacy settings configuration. Please visit https://openrouter.ai/settings/privacy to configure your data policy, then try again.";
+      return "OpenRouter requires privacy settings configuration. Visit OpenRouter privacy settings, then try again.";
     }
     if (lowerError.includes("unauthorized") || lowerError.includes("401")) {
-      return "Invalid OpenRouter API key. Please check your key at https://openrouter.ai/keys";
-    }
-    if (lowerError.includes("quota") || lowerError.includes("limit")) {
-      return "OpenRouter quota exceeded. Please check your usage limits at https://openrouter.ai/activity";
+      return "Invalid OpenRouter API key. Please check your key.";
     }
   }
 
-  // Anthropic specific errors
-  if (provider === "anthropic") {
-    if (lowerError.includes("model:") && lowerError.includes("not found")) {
-      // Extract the specific model name from the error if possible
-      const modelMatch = errorText.match(/model:\s*([^\s,]+)/i);
-      const modelName = modelMatch ? modelMatch[1] : "the specified model";
-      return `The model "${modelName}" was not found. This model may not exist, may require beta access, or may not be available in your region. Your API key is valid, but please check https://console.anthropic.com/ for available models.`;
-    }
-    if (lowerError.includes("unauthorized") || lowerError.includes("401")) {
-      return "Invalid Anthropic API key. Please check your key at https://console.anthropic.com/settings/keys";
-    }
-    if (lowerError.includes("rate limit") || lowerError.includes("429")) {
-      return "Anthropic rate limit exceeded. Please wait a moment before trying again.";
-    }
-    if (lowerError.includes("quota") || lowerError.includes("usage")) {
-      return "Anthropic usage limit reached. Please check your account usage at https://console.anthropic.com/account/usage";
-    }
-  }
-
-  // OpenAI specific errors
-  if (provider === "openai") {
-    if (lowerError.includes("unauthorized") || lowerError.includes("401")) {
-      return "Invalid OpenAI API key. Please check your key at https://platform.openai.com/api-keys";
-    }
-    if (lowerError.includes("quota") || lowerError.includes("billing")) {
-      return "OpenAI billing issue. Please check your account and billing at https://platform.openai.com/account/billing";
-    }
-    if (lowerError.includes("rate limit") || lowerError.includes("429")) {
-      return "OpenAI rate limit exceeded. Please upgrade your plan or wait before trying again.";
-    }
-  }
-
-  // Google Gemini specific errors
-  if (provider === "gemini") {
-    if (lowerError.includes("unauthorized") || lowerError.includes("401")) {
-      return "Invalid Google API key. Please check your key at https://makersuite.google.com/app/apikey";
-    }
-    if (lowerError.includes("quota") || lowerError.includes("limit")) {
-      return "Google API quota exceeded. Please check your quota limits in the Google Cloud Console.";
-    }
-  }
-
-  // Groq specific errors
-  if (provider === "groq") {
-    if (lowerError.includes("unauthorized") || lowerError.includes("401")) {
-      return "Invalid Groq API key. Please check your key at https://console.groq.com/keys";
-    }
-    if (lowerError.includes("rate limit") || lowerError.includes("429")) {
-      return "Groq rate limit exceeded. Please wait before trying again.";
-    }
-  }
-
-  // xAI specific errors
-  if (provider === "xai") {
-    if (lowerError.includes("unauthorized") || lowerError.includes("401")) {
-      return "Invalid xAI API key. Please check your account at https://x.ai/";
-    }
-  }
-
-  // Azure specific errors
-  if (provider === "azure") {
-    if (lowerError.includes("unauthorized") || lowerError.includes("401")) {
-      return "Invalid Azure credentials. Please check your Azure OpenAI deployment configuration.";
-    }
-    if (lowerError.includes("deployment")) {
-      return "Azure deployment issue. Please verify your deployment name and region in the Azure portal.";
-    }
-  }
-
-  // AWS Bedrock specific errors
-  if (provider === "bedrock") {
-    if (lowerError.includes("unauthorized") || lowerError.includes("403")) {
-      return "Invalid AWS credentials or insufficient permissions. Please check your IAM permissions for Bedrock.";
-    }
-    if (lowerError.includes("region")) {
-      return "AWS region issue. Please ensure Bedrock is available in your configured region.";
-    }
-  }
-
-  // GitHub Copilot specific errors
-  if (provider === "copilot") {
-    if (lowerError.includes("unauthorized") || lowerError.includes("401")) {
-      return "Invalid GitHub token. Please check your Copilot subscription and token permissions.";
-    }
-  }
-
-  // Vertex AI specific errors
-  if (provider === "vertexai") {
-    if (lowerError.includes("unauthorized") || lowerError.includes("403")) {
-      return "Invalid GCP credentials. Please check your service account permissions for Vertex AI.";
-    }
-  }
-
-  // Generic authentication errors
   if (
     lowerError.includes("unauthorized") ||
     lowerError.includes("authentication") ||
@@ -302,12 +307,10 @@ const parseErrorMessage = (errorText: string, provider: string): string => {
     return "Invalid API key. Please check your credentials and try again.";
   }
 
-  // Generic rate limiting
   if (lowerError.includes("rate limit") || lowerError.includes("429")) {
     return "Rate limit exceeded. Please wait a moment before trying again.";
   }
 
-  // Generic quota/billing issues
   if (
     lowerError.includes("quota") ||
     lowerError.includes("limit") ||
@@ -317,29 +320,8 @@ const parseErrorMessage = (errorText: string, provider: string): string => {
     return "Usage limit or billing issue. Please check your account status.";
   }
 
-  // Network/connection errors
-  if (
-    lowerError.includes("network") ||
-    lowerError.includes("connection") ||
-    lowerError.includes("timeout") ||
-    lowerError.includes("refused")
-  ) {
-    return "Connection failed. Please check your internet connection and try again.";
-  }
-
-  // Server errors
-  if (
-    lowerError.includes("500") ||
-    lowerError.includes("502") ||
-    lowerError.includes("503") ||
-    lowerError.includes("server error")
-  ) {
-    return "Provider server error. Please try again in a few moments.";
-  }
-
-  // If no specific pattern matches, return a cleaned version of the original error
   return errorText.length > 200
-    ? "API validation failed. Please check your key and try again."
+    ? "Validation failed. Please check your credentials and try again."
     : errorText;
 };
 
@@ -347,7 +329,6 @@ export function CombinedGeneralSettings({
   providers,
   onProvidersUpdate,
 }: CombinedGeneralSettingsProps) {
-  // Add Provider State
   const [selectedProvider, setSelectedProvider] = useState<string>("");
   const [apiKey, setApiKey] = useState<string>("");
   const [showKey, setShowKey] = useState<boolean>(false);
@@ -358,79 +339,187 @@ export function CombinedGeneralSettings({
     message: string;
   } | null>(null);
 
-  // Edit Provider State
   const [editingProvider, setEditingProvider] = useState<string | null>(null);
-  const [editApiKeys, setEditApiKeys] = useState<{ [key: string]: string }>({});
-  const [showEditKeys, setShowEditKeys] = useState<{ [key: string]: boolean }>(
-    {}
-  );
+  const [editApiKeys, setEditApiKeys] = useState<Record<string, string>>({});
+  const [showEditKeys, setShowEditKeys] = useState<Record<string, boolean>>({});
   const [deletingProvider, setDeletingProvider] = useState<string | null>(null);
 
-  // Streaming preference state
   const [streamingEnabled, setStreamingEnabled] = useState<boolean>(false);
   const [loadingPreferences, setLoadingPreferences] = useState<boolean>(true);
+
+  const [reliantProvider, setReliantProvider] = useState<ReliantProviderRecord | null>(null);
+  const [reliantLoading, setReliantLoading] = useState<boolean>(false);
+  const [reliantActionLoading, setReliantActionLoading] = useState<string | null>(null);
+  const [reliantTokenName, setReliantTokenName] = useState<string>("");
+  const [createdReliantToken, setCreatedReliantToken] = useState<string>("");
+  const [copiedReliantToken, setCopiedReliantToken] = useState<boolean>(false);
 
   const codexOAuth = useCodexOAuth();
   const claudeOAuth = useClaudeOAuth();
   const oauthAvailability = useOAuthAvailability();
 
-  // Filter to only show visible providers (hide others but keep implementations)
-  const configuredProviders = providers.filter(
-    (p) =>
-      p.hasApiKey &&
-      VISIBLE_PROVIDERS.includes(
-        p.provider as (typeof VISIBLE_PROVIDERS)[number]
-      )
+  const currentReliantSummary = useMemo(
+    () => providers.find((p) => p.provider === "reliant"),
+    [providers]
   );
-  const availableProviders = Object.entries(providerConfigs).filter(
-    ([id]) =>
-      VISIBLE_PROVIDERS.includes(id as (typeof VISIBLE_PROVIDERS)[number]) &&
-      !providers.find((p) => p.provider === id && p.hasApiKey)
-  ) as [ProviderId, (typeof providerConfigs)[ProviderId]][];
+
+  const configuredProviders = useMemo(
+    () =>
+      providers.filter(
+        (p) =>
+          isProviderConnected(p) &&
+          VISIBLE_PROVIDERS.includes(p.provider as (typeof VISIBLE_PROVIDERS)[number])
+      ),
+    [providers]
+  );
+
+  const availableProviders = useMemo(
+    () =>
+      Object.entries(providerConfigs).filter(
+        ([id]) =>
+          VISIBLE_PROVIDERS.includes(id as (typeof VISIBLE_PROVIDERS)[number]) &&
+          !providers.find((p) => p.provider === id && isProviderConnected(p))
+      ) as [ProviderId, (typeof providerConfigs)[ProviderId]][],
+    [providers]
+  );
+
+  const selectedConfig = selectedProvider
+    ? providerConfigs[selectedProvider as ProviderId]
+    : undefined;
+
+  const refreshReliantStatus = useCallback(async () => {
+    setReliantLoading(true);
+    try {
+      const status = await api.settings.getReliantProviderStatus();
+      setReliantProvider(status);
+    } catch (error) {
+      console.error("Failed to load Reliant provider status:", error);
+    } finally {
+      setReliantLoading(false);
+    }
+  }, []);
+
+  const refreshProviderSurfaces = useCallback(
+    async (hasConfiguredProvider?: boolean) => {
+      await Promise.resolve(onProvidersUpdate?.());
+      await refreshReliantStatus();
+      await useGlobalDataStore.getState().refetchModels();
+      window.dispatchEvent(new CustomEvent("api-key-saved"));
+      if (typeof hasConfiguredProvider === "boolean") {
+        useApiKeySetupStore.setState({
+          hasApiKey: hasConfiguredProvider,
+          showModal: false,
+        });
+      }
+    },
+    [onProvidersUpdate, refreshReliantStatus]
+  );
+
+  useEffect(() => {
+    void refreshReliantStatus();
+  }, [refreshReliantStatus]);
+
+  useEffect(() => {
+    const loadPreferences = async () => {
+      try {
+        const data = await api.settings.getPreferences();
+        setStreamingEnabled((data.streaming_enabled as boolean) ?? false);
+      } catch (error) {
+        console.error("Failed to load preferences:", error);
+      } finally {
+        setLoadingPreferences(false);
+      }
+    };
+
+    void loadPreferences();
+  }, []);
+
+  const handleStreamingToggle = async (enabled: boolean) => {
+    try {
+      await api.settings.updatePreferences({ streaming_enabled: enabled });
+      setStreamingEnabled(enabled);
+    } catch (error) {
+      console.error("Failed to update streaming preference:", error);
+    }
+  };
+
+  const handleCopyCreatedReliantToken = async () => {
+    if (!createdReliantToken || !navigator.clipboard?.writeText) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(createdReliantToken);
+      setCopiedReliantToken(true);
+      setTimeout(() => setCopiedReliantToken(false), 2000);
+    } catch (error) {
+      console.error("Failed to copy Reliant token:", error);
+    }
+  };
 
   const handleDeleteProvider = async (provider: string) => {
-    const config = providerConfigs[provider as keyof typeof providerConfigs];
+    const config = providerConfigs[provider as ProviderId];
     if (
-      !confirm(
-        `Are you sure you want to remove the API key for ${
-          config?.name || provider
-        }?`
+      !window.confirm(
+        `Are you sure you want to remove ${config?.name || provider} from Reliant?`
       )
     ) {
       return;
     }
 
     setDeletingProvider(provider);
+    setValidationMessage(null);
+
     try {
-      await api.settings.updateProvider(provider, ""); // Empty key triggers deletion
-      onProvidersUpdate?.();
-
-      // Refresh models immediately - the API call already waits for the database write to complete
-      await useGlobalDataStore.getState().refetchModels();
-
-      // Dispatch event to notify all model inputs to refresh
-      window.dispatchEvent(new CustomEvent('api-key-saved'));
-
-      // Check if this was the last API key - if so, reset the API key setup state
-      // so the modal will show again when user navigates to project/chat screens
-      const remainingWithKeys = providers.filter(
-        (p) => p.hasApiKey && p.provider !== provider
+      await api.settings.updateProvider(provider, "");
+      const remainingConfigured = providers.filter(
+        (p) => p.provider !== provider && isProviderConnected(p)
       );
-      if (remainingWithKeys.length === 0) {
-        // Reset the dismissed state and hasApiKey so modal can show again
+      const hasConfiguredProvider = remainingConfigured.length > 0;
+      await refreshProviderSurfaces(hasConfiguredProvider);
+
+      if (!hasConfiguredProvider) {
         resetApiKeySetupDismissed();
         useApiKeySetupStore.setState({ hasApiKey: false });
       }
+
+      setEditingProvider((current) => (current === provider ? null : current));
+      setValidationMessage({
+        valid: true,
+        message:
+          provider === "reliant"
+            ? "Reliant disconnected successfully."
+            : `${config?.name || provider} removed successfully.`,
+      });
+      setTimeout(() => setValidationMessage(null), 3000);
     } catch (error) {
-      console.error("Failed to delete provider:", error);
+      const message = error instanceof Error ? error.message : "Failed to remove provider";
+      setValidationMessage({
+        valid: false,
+        message: parseErrorMessage(message, provider),
+      });
     } finally {
       setDeletingProvider(null);
     }
   };
 
   const handleSaveApiKey = async (provider?: string) => {
-    const targetProvider = provider || selectedProvider;
+    const targetProvider = (provider || selectedProvider) as ProviderId;
     const targetKey = provider ? editApiKeys[provider] : apiKey;
+
+    if (!targetProvider) {
+      return;
+    }
+
+    if (!targetKey?.trim()) {
+      setValidationMessage({
+        valid: false,
+        message:
+          targetProvider === "reliant"
+            ? "Paste a cpat_ token to store it locally."
+            : "Please enter an API key.",
+      });
+      return;
+    }
 
     if (!provider) {
       setSaving(true);
@@ -438,40 +527,32 @@ export function CombinedGeneralSettings({
     setValidationMessage(null);
 
     try {
-      await api.settings.updateProvider(targetProvider, targetKey || "");
-      onProvidersUpdate?.();
-
-      // Refresh models immediately - the API call already waits for the database write to complete
-      await useGlobalDataStore.getState().refetchModels();
-
-      // Dispatch event to notify all model inputs to refresh
-      window.dispatchEvent(new CustomEvent('api-key-saved'));
+      await api.settings.updateProvider(targetProvider, targetKey.trim());
+      await refreshProviderSurfaces(true);
 
       if (provider) {
-        // Editing existing provider
         setEditingProvider(null);
-        setEditApiKeys({ ...editApiKeys, [provider]: "" });
+        setEditApiKeys((current) => ({ ...current, [provider]: "" }));
+        setShowEditKeys((current) => ({ ...current, [provider]: false }));
       } else {
-        // Adding new provider
         setSelectedProvider("");
         setApiKey("");
-        setValidationMessage({
-          valid: true,
-          message: "API key saved successfully",
-        });
-        setTimeout(() => setValidationMessage(null), 3000);
+        setShowKey(false);
       }
-    } catch (error) {
-      console.error("Failed to save API key:", error);
-      const errorText =
-        error instanceof Error ? error.message : "Invalid API key";
-
-      // Use comprehensive error parser
-      const errorMessage = parseErrorMessage(errorText, targetProvider);
 
       setValidationMessage({
+        valid: true,
+        message:
+          targetProvider === "reliant"
+            ? "Reliant token saved successfully."
+            : "API key saved successfully.",
+      });
+      setTimeout(() => setValidationMessage(null), 3000);
+    } catch (error) {
+      const errorText = error instanceof Error ? error.message : "Invalid API key";
+      setValidationMessage({
         valid: false,
-        message: errorMessage,
+        message: parseErrorMessage(errorText, targetProvider),
       });
     } finally {
       if (!provider) {
@@ -480,70 +561,53 @@ export function CombinedGeneralSettings({
     }
   };
 
-  // Load streaming and notification preferences on mount
-  useEffect(() => {
-    const loadPreferences = async () => {
-      try {
-        const data = await api.settings.getPreferences();
-        setStreamingEnabled((data.streaming_enabled as boolean) ?? false);
-        // Convert backend settings to interaction mode
-      } catch (error) {
-        console.error("Failed to load preferences:", error);
-      } finally {
-        setLoadingPreferences(false);
-      }
-    };
-    loadPreferences();
-  }, []);
+  const handleValidateApiKey = async (providerOverride?: ProviderId, keyOverride?: string) => {
+    const targetProvider = providerOverride || (selectedProvider as ProviderId);
+    const targetKey = typeof keyOverride === "string" ? keyOverride : apiKey;
 
-  // Handle streaming toggle
-  const handleStreamingToggle = async (enabled: boolean) => {
-    try {
-      await api.settings.updatePreferences({
-        streaming_enabled: enabled,
-      });
-      setStreamingEnabled(enabled);
-    } catch (error) {
-      console.error("Failed to update streaming preference:", error);
+    if (!targetProvider) {
+      return;
     }
-  };
 
-  // Validate API key via gRPC
-  const handleValidateApiKey = async () => {
+    if (targetProvider !== "reliant" && !targetKey.trim()) {
+      setValidationMessage({ valid: false, message: "Please enter an API key." });
+      return;
+    }
+
     setValidating(true);
     setValidationMessage(null);
 
     try {
       const result = await api.settings.validateProviderAPIKey(
-        selectedProvider,
-        apiKey
+        targetProvider,
+        targetProvider === "reliant" ? targetKey.trim() : targetKey.trim()
       );
-      let message =
-        result.message || "Connection failed. Please check your API key.";
+      const message = result.valid
+        ? result.message ||
+          (targetProvider === "reliant"
+            ? "Reliant access looks healthy."
+            : "Connection successful! API key is valid.")
+        : parseErrorMessage(
+            result.message || "Connection failed. Please check your credentials.",
+            targetProvider
+          );
 
-      // Use comprehensive error parser for validation errors
-      if (!result.valid) {
-        message = parseErrorMessage(message, selectedProvider);
+      setValidationMessage({ valid: result.valid, message });
+      if (targetProvider === "reliant") {
+        await refreshReliantStatus();
       }
-
-      setValidationMessage({
-        valid: result.valid,
-        message: result.valid
-          ? "Connection successful! API key is valid."
-          : message,
-      });
     } catch (error) {
-      console.error("Failed to validate API key:", error);
+      const errorText = error instanceof Error ? error.message : "Failed to validate provider";
       setValidationMessage({
         valid: false,
-        message: "Failed to test connection. Please try again.",
+        message: parseErrorMessage(errorText, targetProvider),
       });
     } finally {
       setValidating(false);
     }
   };
 
-  const handleConnectOAuth = async (oauthType: string) => {
+  const handleConnectOAuth = async (oauthType: "claude" | "codex") => {
     setValidating(true);
     setValidationMessage(null);
 
@@ -552,22 +616,12 @@ export function CombinedGeneralSettings({
 
     try {
       const result = await oauthHook.start();
-
       if (!result.ok) {
-        setValidationMessage({
-          valid: false,
-          message: result.message,
-        });
+        setValidationMessage({ valid: false, message: result.message });
         return;
       }
 
-      onProvidersUpdate?.();
-
-      // Refresh models
-      await useGlobalDataStore.getState().refetchModels();
-      window.dispatchEvent(new CustomEvent("api-key-saved"));
-
-      // Reset form
+      await refreshProviderSurfaces(true);
       setSelectedProvider("");
       setValidationMessage({
         valid: true,
@@ -575,7 +629,6 @@ export function CombinedGeneralSettings({
       });
       setTimeout(() => setValidationMessage(null), 3000);
     } catch (error) {
-      console.error(`Failed to connect ${displayName}:`, error);
       const errorMessage = error instanceof Error ? error.message : "Connection failed";
       setValidationMessage({
         valid: false,
@@ -586,21 +639,458 @@ export function CombinedGeneralSettings({
     }
   };
 
+  const handleCreateReliantToken = async () => {
+    setReliantActionLoading("create");
+    setValidationMessage(null);
+
+    try {
+      const result = await api.settings.createReliantProviderToken({
+        name: reliantTokenName.trim() || undefined,
+      });
+
+      if (!result.success) {
+        throw new Error(result.message || "Failed to create Reliant token");
+      }
+
+      setCreatedReliantToken(result.token);
+      setCopiedReliantToken(false);
+      setSelectedProvider("");
+      setEditingProvider("reliant");
+      setApiKey("");
+      setReliantTokenName("");
+
+      if (result.token && navigator.clipboard?.writeText) {
+        try {
+          await navigator.clipboard.writeText(result.token);
+          setCopiedReliantToken(true);
+          setTimeout(() => setCopiedReliantToken(false), 2000);
+        } catch (error) {
+          console.error("Failed to copy created Reliant token:", error);
+        }
+      }
+
+      setValidationMessage({
+        valid: true,
+        message:
+          result.message ||
+          "Reliant token created, saved locally, and copied to your clipboard.",
+      });
+
+      let refreshFailed = false;
+      try {
+        await refreshProviderSurfaces(true);
+      } catch (error) {
+        refreshFailed = true;
+        console.error("Failed to refresh provider surfaces after Reliant token creation:", error);
+      }
+
+      if (refreshFailed) {
+        setValidationMessage({
+          valid: true,
+          message:
+            "Reliant token created successfully. Some follow-up refresh steps failed, so you may need to refresh the UI before status updates appear.",
+        });
+      }
+      setTimeout(() => setValidationMessage(null), 4000);
+    } catch (error) {
+      const errorText = error instanceof Error ? error.message : "Failed to create Reliant token";
+      setValidationMessage({
+        valid: false,
+        message: parseErrorMessage(errorText, "reliant"),
+      });
+    } finally {
+      setReliantActionLoading(null);
+    }
+  };
+
+  const handleRevokeReliantToken = async (tokenId: string) => {
+    if (!window.confirm("Revoke this Reliant token? This cannot be undone.")) {
+      return;
+    }
+
+    setReliantActionLoading(`revoke:${tokenId}`);
+    setValidationMessage(null);
+
+    try {
+      const result = await api.settings.revokeReliantProviderToken(tokenId, false);
+      if (!result.success) {
+        throw new Error(result.message || "Failed to revoke Reliant token");
+      }
+      await refreshReliantStatus();
+      setValidationMessage({
+        valid: true,
+        message: result.message || "Reliant token revoked.",
+      });
+      setTimeout(() => setValidationMessage(null), 3000);
+    } catch (error) {
+      const errorText = error instanceof Error ? error.message : "Failed to revoke Reliant token";
+      setValidationMessage({
+        valid: false,
+        message: parseErrorMessage(errorText, "reliant"),
+      });
+    } finally {
+      setReliantActionLoading(null);
+    }
+  };
+
+  const renderValidationBanner = validationMessage ? (
+    <div
+      className={cn(
+        "flex items-start gap-2 rounded-md border p-3 text-sm",
+        validationMessage.valid
+          ? "border-emerald-500/20 bg-emerald-500/10 text-emerald-700"
+          : "border-red-500/20 bg-red-500/10 text-red-600"
+      )}
+    >
+      {validationMessage.valid ? (
+        <CheckCircle2 className="mt-0.5 h-4 w-4" />
+      ) : (
+        <AlertCircle className="mt-0.5 h-4 w-4" />
+      )}
+      <span>{validationMessage.message}</span>
+    </div>
+  ) : null;
+
+  const renderReliantAccessSummary = () => {
+    const access = reliantProvider?.access;
+    const providerStatus = currentReliantSummary?.status;
+    const providerMessage = currentReliantSummary?.statusMessage;
+
+    return (
+      <div className="space-y-4 rounded-lg border border-border bg-muted/20 p-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm font-medium">Managed access status</span>
+          <span
+            className={cn(
+              "inline-flex items-center rounded-full px-2 py-1 text-xs font-medium",
+              statusBadgeClasses(providerStatus || access?.state)
+            )}
+          >
+            {statusLabel(providerStatus || access?.state)}
+          </span>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {providerMessage || access?.message || "Reliant status will appear here once configured."}
+        </p>
+
+        {access && (
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            <div className="rounded-md border border-border bg-background p-3">
+              <div className="text-xs uppercase text-muted-foreground">Plan</div>
+              <div className="mt-1 text-sm font-medium">
+                {access.plan_code || access.plan_id || "—"}
+              </div>
+            </div>
+            <div className="rounded-md border border-border bg-background p-3">
+              <div className="text-xs uppercase text-muted-foreground">Spend</div>
+              <div className="mt-1 text-sm font-medium">
+                {formatCurrency(access.spend)}
+              </div>
+            </div>
+            <div className="rounded-md border border-border bg-background p-3">
+              <div className="text-xs uppercase text-muted-foreground">Hard budget</div>
+              <div className="mt-1 text-sm font-medium">
+                {formatCurrency(access.hard_budget_usd)}
+              </div>
+            </div>
+            <div className="rounded-md border border-border bg-background p-3">
+              <div className="text-xs uppercase text-muted-foreground">RPM / TPM</div>
+              <div className="mt-1 text-sm font-medium">
+                {access.rpm_limit || 0} / {access.tpm_limit || 0}
+              </div>
+            </div>
+            <div className="rounded-md border border-border bg-background p-3">
+              <div className="text-xs uppercase text-muted-foreground">Parallel requests</div>
+              <div className="mt-1 text-sm font-medium">
+                {access.max_parallel_requests || 0}
+              </div>
+            </div>
+            <div className="rounded-md border border-border bg-background p-3">
+              <div className="text-xs uppercase text-muted-foreground">Key duration</div>
+              <div className="mt-1 text-sm font-medium">{access.key_duration || "—"}</div>
+            </div>
+          </div>
+        )}
+
+        {access?.allowed_models?.length ? (
+          <div className="space-y-2">
+            <div className="text-xs uppercase text-muted-foreground">Allowed models</div>
+            <div className="flex flex-wrap gap-2">
+              {access.allowed_models.map((model) => (
+                <span
+                  key={model}
+                  className="rounded-full border border-border bg-background px-2 py-1 text-xs"
+                >
+                  {model}
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    );
+  };
+
+  const renderReliantTokenList = () => (
+    <div className="space-y-3 rounded-lg border border-border bg-card p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h4 className="text-sm font-semibold">Control-plane tokens</h4>
+          <p className="text-xs text-muted-foreground">
+            Reliant tokens are stored locally as control-plane credentials. Runtime model keys are exchanged on demand.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void refreshReliantStatus()}
+          disabled={reliantLoading}
+          className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent disabled:opacity-50"
+        >
+          {reliantLoading ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <RefreshCw className="h-4 w-4" />
+          )}
+          Refresh
+        </button>
+      </div>
+
+      {reliantProvider?.masked_token ? (
+        <div className="rounded-md border border-border bg-muted/30 p-3 text-sm">
+          <div className="text-xs uppercase text-muted-foreground">Stored token</div>
+          <div className="mt-1 font-mono text-foreground">{reliantProvider.masked_token}</div>
+        </div>
+      ) : null}
+
+      {createdReliantToken ? (
+        <div className="rounded-md border border-emerald-500/20 bg-emerald-500/10 p-3">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="text-sm font-medium text-emerald-700">New Reliant token</div>
+              <p className="mt-1 break-all font-mono text-xs text-emerald-700/90">
+                {createdReliantToken}
+              </p>
+              <p className="mt-2 text-xs text-emerald-700/80">
+                This token is shown once. Copy it now if you need it outside Reliant.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => void handleCopyCreatedReliantToken()}
+              className="inline-flex items-center gap-2 rounded-md border border-emerald-500/30 bg-background px-3 py-1.5 text-sm text-emerald-700 hover:bg-background/80"
+            >
+              <Copy className="h-4 w-4" />
+              {copiedReliantToken ? "Copied" : "Copy"}
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="space-y-2">
+        {reliantProvider?.tokens?.length ? (
+          reliantProvider.tokens.map((token) => (
+            <div
+              key={token.id}
+              className="flex flex-col gap-3 rounded-md border border-border bg-background p-3 md:flex-row md:items-center md:justify-between"
+            >
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-medium">{token.name || token.token_prefix}</span>
+                  <span className="rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground">
+                    {token.token_prefix}
+                  </span>
+                  {token.ephemeral ? (
+                    <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                      Ephemeral
+                    </span>
+                  ) : null}
+                </div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  Created {formatDateTime(token.created_at)}
+                  {token.last_used_at ? ` • Last used ${formatDateTime(token.last_used_at)}` : ""}
+                  {token.expires_at ? ` • Expires ${formatDateTime(token.expires_at)}` : ""}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => void handleRevokeReliantToken(token.id)}
+                disabled={reliantActionLoading === `revoke:${token.id}`}
+                className="inline-flex items-center gap-2 rounded-md border border-destructive/20 px-3 py-1.5 text-sm text-destructive hover:bg-destructive/10 disabled:opacity-50"
+              >
+                {reliantActionLoading === `revoke:${token.id}` ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Trash2 className="h-4 w-4" />
+                )}
+                Revoke
+              </button>
+            </div>
+          ))
+        ) : (
+          <div className="rounded-md border border-dashed border-border p-4 text-sm text-muted-foreground">
+            No Reliant tokens returned from the control plane yet.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  const renderReliantManager = (mode: "add" | "edit") => {
+    const editValue = editApiKeys.reliant || "";
+    const showingEditValue = mode === "edit";
+    const inputValue = showingEditValue ? editValue : apiKey;
+    const inputShown = showingEditValue ? !!showEditKeys.reliant : showKey;
+    const setInputValue = (value: string) => {
+      if (showingEditValue) {
+        setEditApiKeys((current) => ({ ...current, reliant: value }));
+      } else {
+        setApiKey(value);
+      }
+      setValidationMessage(null);
+    };
+
+    return (
+      <div className="space-y-4">
+        <div className="rounded-lg border border-border bg-muted/30 p-4">
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-foreground">Managed Reliant access</p>
+            <p className="text-sm text-muted-foreground">
+              Create a Reliant token here and Reliant will store it locally, then exchange it
+              for runtime model access automatically.
+            </p>
+          </div>
+        </div>
+
+        {renderValidationBanner}
+        {renderReliantAccessSummary()}
+
+        <div className="space-y-4 rounded-lg border border-primary/20 bg-primary/5 p-4">
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-foreground">Create a Reliant token</p>
+            <p className="text-sm text-muted-foreground">
+              This is the normal setup path. The token is stored locally right away and the full
+              cpat_ value is shown once in case you need to copy it elsewhere.
+            </p>
+          </div>
+          <input
+            type="text"
+            value={reliantTokenName}
+            onChange={(e) => setReliantTokenName(e.target.value)}
+            placeholder="Optional token name"
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+          />
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void handleCreateReliantToken()}
+              disabled={reliantActionLoading === "create"}
+              className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              {reliantActionLoading === "create" ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Plus className="h-4 w-4" />
+              )}
+              Create token
+            </button>
+            <button
+              type="button"
+              onClick={() => void refreshReliantStatus()}
+              disabled={reliantLoading}
+              className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 text-sm hover:bg-accent disabled:opacity-50"
+            >
+              {reliantLoading ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="h-4 w-4" />
+              )}
+              Refresh status
+            </button>
+          </div>
+        </div>
+
+        <details className="rounded-lg border border-border bg-card p-4">
+          <summary className="cursor-pointer list-none text-sm font-medium text-foreground">
+            Use an existing token instead
+          </summary>
+          <div className="mt-4 space-y-2">
+            <p className="text-sm text-muted-foreground">
+              Paste a cpat_ token only if you already created one in another Reliant client or on
+              another device.
+            </p>
+            <div className="relative">
+              <input
+                type={inputShown ? "text" : "password"}
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                placeholder="cpat_..."
+                className="w-full rounded-md border border-input bg-background px-3 py-2 pr-10 font-mono text-sm"
+              />
+              <button
+                type="button"
+                onClick={() => {
+                  if (showingEditValue) {
+                    setShowEditKeys((current) => ({
+                      ...current,
+                      reliant: !current.reliant,
+                    }));
+                  } else {
+                    setShowKey((current) => !current);
+                  }
+                }}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              >
+                {inputShown ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => void handleValidateApiKey("reliant", inputValue)}
+                disabled={validating}
+                className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 text-sm hover:bg-accent disabled:opacity-50"
+              >
+                {validating ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <TestTube className="h-4 w-4" />
+                )}
+                Check access
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleSaveApiKey(showingEditValue ? "reliant" : undefined)}
+                disabled={!inputValue.trim() || saving}
+                className="inline-flex items-center gap-2 rounded-md border border-primary/30 bg-primary/10 px-4 py-2 text-sm text-primary hover:bg-primary/15 disabled:opacity-50"
+              >
+                {saving ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Check className="h-4 w-4" />
+                )}
+                {showingEditValue ? "Save token" : "Store token"}
+              </button>
+            </div>
+          </div>
+        </details>
+
+        {renderReliantTokenList()}
+      </div>
+    );
+  };
+
   return (
     <div className="space-y-6">
       <div data-onboarding="ai-providers-settings">
-        <h2 className="text-2xl font-bold tracking-tight">
-          AI Provider Configuration
-        </h2>
+        <h2 className="text-2xl font-bold tracking-tight">AI Provider Configuration</h2>
         <p className="text-muted-foreground">
           Connect your AI providers to enable model access and conversations.
         </p>
       </div>
 
-      {/* Add Provider Section */}
       {availableProviders.length > 0 && (
-        <div className="border border-border rounded-lg p-6 bg-card">
-          <h3 className="text-lg font-semibold mb-4">Add New Provider</h3>
+        <div className="rounded-lg border border-border bg-card p-6">
+          <h3 className="mb-4 text-lg font-semibold">Add New Provider</h3>
 
           <div className="space-y-4">
             <div className="space-y-2">
@@ -609,11 +1099,13 @@ export function CombinedGeneralSettings({
                 <select
                   value={selectedProvider}
                   onChange={(e) => {
-                    const providerId = e.target.value;
-                    setSelectedProvider(providerId);
+                    setSelectedProvider(e.target.value);
+                    setApiKey("");
+                    setShowKey(false);
+                    setCreatedReliantToken("");
                     setValidationMessage(null);
                   }}
-                  className="w-full px-3 py-2 pr-10 border border-input bg-background rounded-md appearance-none cursor-pointer"
+                  className="w-full appearance-none rounded-md border border-input bg-background px-3 py-2 pr-10"
                 >
                   <option value="">Choose a provider...</option>
                   {availableProviders.map(([id, config]) => (
@@ -622,18 +1114,19 @@ export function CombinedGeneralSettings({
                     </option>
                   ))}
                 </select>
-                <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 pointer-events-none text-muted-foreground" />
+                <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               </div>
             </div>
 
-            {selectedProvider && (
-              providerConfigs[selectedProvider as ProviderId]?.usesOAuth ? (
-                /* OAuth Section */
-                <div className="space-y-4">
-                  <div className="p-4 rounded-lg border border-border bg-muted/30">
-                    <div className="space-y-2">
+            {selectedProvider && selectedConfig && (
+              <>
+                {selectedConfig.isManaged ? (
+                  renderReliantManager("add")
+                ) : selectedConfig.usesOAuth ? (
+                  <div className="space-y-4">
+                    <div className="rounded-lg border border-border bg-muted/30 p-4">
                       <p className="text-sm font-medium text-foreground">
-                        Authenticate via {providerConfigs[selectedProvider as ProviderId]?.name}
+                        Authenticate via {selectedConfig.name}
                       </p>
                       <p className="text-sm text-muted-foreground">
                         {oauthAvailability.available
@@ -646,295 +1139,287 @@ export function CombinedGeneralSettings({
                         </code>
                       )}
                     </div>
-                  </div>
 
-                  {validationMessage && (
-                    <div
-                      className={cn(
-                        "flex items-center gap-2 text-sm p-3 rounded-lg",
-                        validationMessage.valid
-                          ? "bg-emerald-500/10 text-emerald-600 border border-emerald-500/20"
-                          : "bg-red-500/10 text-red-600 border border-red-500/20"
-                      )}
-                    >
-                      {validationMessage.valid ? (
-                        <CheckCircle2 className="w-4 h-4" />
+                    {renderValidationBanner}
+
+                    <div className="flex justify-end">
+                      {oauthAvailability.available ? (
+                        <button
+                          type="button"
+                          onClick={() => void handleConnectOAuth(selectedConfig.usesOAuth)}
+                          disabled={validating}
+                          className="inline-flex items-center gap-2 rounded-md border border-primary/30 bg-primary/10 px-4 py-2 text-sm text-primary hover:bg-primary/15 disabled:opacity-50"
+                        >
+                          {validating ? (
+                            <>
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                              Connecting...
+                            </>
+                          ) : (
+                            <>Login with {selectedConfig.name}</>
+                          )}
+                        </button>
                       ) : (
-                        <XCircle className="w-4 h-4" />
+                        <button
+                          className="px-4 py-2 text-sm font-medium border rounded-md transition-colors disabled:opacity-50"
+                          onClick={oauthAvailability.recheck}
+                          disabled={oauthAvailability.loading}
+                        >
+                          {oauthAvailability.loading ? "Checking…" : "Retry"}
+                        </button>
                       )}
-                      {validationMessage.message}
                     </div>
-                  )}
-
-                  <div className="flex justify-end">
-                    {oauthAvailability.available ? (
-                      <button
-                        className="px-4 py-2 text-sm font-medium border-2 rounded-md transition-colors disabled:opacity-50 flex items-center gap-2"
-                        style={{
-                          backgroundColor: "hsl(var(--primary) / 0.1)",
-                          color: "hsl(var(--primary))",
-                          borderColor: "hsl(var(--primary))",
-                        }}
-                        onClick={() => handleConnectOAuth(providerConfigs[selectedProvider as ProviderId]?.usesOAuth as string)}
-                        disabled={validating}
-                      >
-                        {validating ? (
-                          <>
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                            Checking...
-                          </>
-                        ) : (
-                          <>Login with {providerConfigs[selectedProvider as ProviderId]?.name}</>
-                        )}
-                      </button>
-                    ) : (
-                      <button
-                        className="px-4 py-2 text-sm font-medium border rounded-md transition-colors disabled:opacity-50"
-                        onClick={oauthAvailability.recheck}
-                        disabled={oauthAvailability.loading}
-                      >
-                        {oauthAvailability.loading ? "Checking…" : "Retry"}
-                      </button>
-                    )}
                   </div>
-                </div>
-              ) : (
-                /* Standard API Key Input Section */
-                <>
-                  <div className="space-y-2">
-                    <label className="text-sm font-medium">API Key</label>
-                    <div className="relative">
-                      <input
-                        type={showKey ? "text" : "password"}
-                        value={apiKey}
-                        onChange={(e) => {
-                          setApiKey(e.target.value);
-                          setValidationMessage(null);
-                        }}
-                        placeholder={`Enter your ${
-                          providerConfigs[
-                            selectedProvider as ProviderId
-                          ]?.name
-                        } API key`}
-                        className="w-full px-3 py-2 border border-input bg-background rounded-md pr-10 font-mono text-sm"
-                      />
+                ) : (
+                  <div className="space-y-4">
+                    <div className="rounded-lg border border-border bg-muted/30 p-4">
+                      <p className="text-sm font-medium text-foreground">{selectedConfig.name}</p>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        {selectedConfig.description}
+                      </p>
+                    </div>
+
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium">API key</label>
+                      <div className="relative">
+                        <input
+                          type={showKey ? "text" : "password"}
+                          value={apiKey}
+                          onChange={(e) => {
+                            setApiKey(e.target.value);
+                            setValidationMessage(null);
+                          }}
+                          placeholder={selectedConfig.keyFormat}
+                          className="w-full rounded-md border border-input bg-background px-3 py-2 pr-10 font-mono text-sm"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => setShowKey((current) => !current)}
+                          className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                        >
+                          {showKey ? (
+                            <EyeOff className="h-4 w-4" />
+                          ) : (
+                            <Eye className="h-4 w-4" />
+                          )}
+                        </button>
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        Get your API key from{" "}
+                        <a
+                          href={selectedConfig.docsUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary hover:underline"
+                        >
+                          {selectedConfig.name}
+                        </a>
+                        .
+                      </p>
+                    </div>
+
+                    {renderValidationBanner}
+
+                    <div className="flex flex-wrap gap-2">
                       <button
                         type="button"
-                        onClick={() => setShowKey(!showKey)}
-                        className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                        onClick={() => void handleValidateApiKey()}
+                        disabled={!apiKey.trim() || validating}
+                        className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 text-sm hover:bg-accent disabled:opacity-50"
                       >
-                        {showKey ? (
-                          <EyeOff className="h-4 w-4" />
+                        {validating ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
                         ) : (
-                          <Eye className="h-4 w-4" />
+                          <TestTube className="h-4 w-4" />
                         )}
+                        Test Connection
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void handleSaveApiKey()}
+                        disabled={!apiKey.trim() || saving}
+                        className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                      >
+                        {saving ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Plus className="h-4 w-4" />
+                        )}
+                        Add Provider
                       </button>
                     </div>
-                    <p className="text-xs text-muted-foreground">
-                      Get your API key from{" "}
-                      <a
-                        href={
-                          providerConfigs[
-                            selectedProvider as ProviderId
-                          ]?.docsUrl
-                        }
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary hover:underline"
-                      >
-                        {
-                          providerConfigs[
-                            selectedProvider as ProviderId
-                          ]?.name
-                        }{" "}
-                        Console
-                      </a>
-                    </p>
                   </div>
-
-                  {validationMessage && (
-                    <div
-                      className={cn(
-                        "flex items-start gap-2 p-3 rounded-md",
-                        validationMessage.valid
-                          ? "bg-success/10 text-success border border-success/20"
-                          : "bg-destructive/10 text-destructive border border-destructive/20"
-                      )}
-                    >
-                      {validationMessage.valid ? (
-                        <Check className="h-4 w-4 mt-0.5" />
-                      ) : (
-                        <AlertCircle className="h-4 w-4 mt-0.5" />
-                      )}
-                      <span className="text-sm">{validationMessage.message}</span>
-                    </div>
-                  )}
-
-                  <div className="flex gap-2">
-                    <button
-                      className="px-4 py-2 text-sm font-medium border border-input bg-background hover:bg-accent hover:text-accent-foreground rounded-md transition-colors disabled:opacity-50 flex items-center gap-2"
-                      onClick={handleValidateApiKey}
-                      disabled={!apiKey || validating}
-                    >
-                      {validating ? (
-                        <>
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                          Testing...
-                        </>
-                      ) : (
-                        <>
-                          <TestTube className="h-4 w-4" />
-                          Test Connection
-                        </>
-                      )}
-                    </button>
-                    <button
-                      className="px-4 py-2 text-sm font-medium border-2 rounded-md transition-colors disabled:opacity-50 flex items-center gap-2"
-                      style={{
-                        backgroundColor: "hsl(var(--primary) / 0.1)",
-                        color: "hsl(var(--primary))",
-                        borderColor: "hsl(var(--primary))",
-                      }}
-                      onClick={() => handleSaveApiKey()}
-                      disabled={!apiKey || saving}
-                    >
-                      {saving ? (
-                        <>
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                          Saving...
-                        </>
-                      ) : (
-                        <>
-                          <Plus className="h-4 w-4" />
-                          Add Provider
-                        </>
-                      )}
-                    </button>
-                  </div>
-                </>
-              )
+                )}
+              </>
             )}
           </div>
         </div>
       )}
 
-      {/* Configured Providers List */}
       {configuredProviders.length > 0 && (
         <div>
-          <h3 className="text-lg font-semibold mb-4">Configured Providers</h3>
+          <h3 className="mb-4 text-lg font-semibold">Configured Providers</h3>
           <div className="space-y-3">
             {configuredProviders.map((provider) => {
-              const config =
-                providerConfigs[
-                  provider.provider as ProviderId
-                ];
+              const config = providerConfigs[provider.provider as ProviderId];
+              const isReliant = provider.provider === "reliant";
+              const badgeStatus = provider.status || (isProviderConnected(provider) ? "connected" : "not_configured");
+
               return (
                 <div
                   key={provider.provider}
-                  className="border border-border rounded-lg bg-card p-4"
+                  className="rounded-lg border border-border bg-card p-4"
                 >
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-3">
-                      <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center">
+                  <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                    <div className="flex items-start gap-3">
+                      <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10">
                         <span className="text-xs font-semibold text-primary">
                           {config?.name?.charAt(0) || "P"}
                         </span>
                       </div>
-                      <div>
-                        <h4 className="font-semibold">
-                          {provider.displayName}
-                        </h4>
-                        <div className="flex items-center gap-3 mt-1">
-                          <span className="flex items-center gap-1 text-sm text-success">
-                            <Check className="h-3 w-3" />
-                            Connected
+                      <div className="space-y-1">
+                        <h4 className="font-semibold">{provider.displayName}</h4>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span
+                            className={cn(
+                              "inline-flex items-center rounded-full px-2 py-1 text-xs font-medium",
+                              statusBadgeClasses(badgeStatus)
+                            )}
+                          >
+                            {statusLabel(badgeStatus)}
                           </span>
-                          {provider.maskedKey && (
-                            <span className="text-sm text-muted-foreground font-mono" data-sentry-mask>
-                              {provider.maskedKey}
+                          {provider.authMethod ? (
+                            <span className="rounded-full border border-border px-2 py-1 text-xs text-muted-foreground">
+                              {provider.authMethod === "oauth"
+                                ? "OAuth"
+                                : provider.authMethod === "reliant"
+                                  ? "Managed"
+                                  : "API key"}
                             </span>
-                          )}
+                          ) : null}
+                          {(provider.maskedKey || (isReliant && reliantProvider?.masked_token)) ? (
+                            <span className="font-mono text-sm text-muted-foreground" data-sentry-mask>
+                              {provider.maskedKey || reliantProvider?.masked_token}
+                            </span>
+                          ) : null}
                         </div>
+                        {provider.statusMessage ? (
+                          <p className="text-sm text-muted-foreground">
+                            {provider.statusMessage}
+                          </p>
+                        ) : null}
                       </div>
                     </div>
-                    <div className="flex items-center gap-2">
-                      {/* Hide Update button for providers that use OAuth auth (like Codex) */}
-                      {!config?.usesOAuth && (
+
+                    <div className="flex flex-wrap items-center gap-2">
+                      {isReliant ? (
                         <button
-                          className="px-3 py-1.5 text-sm border border-border rounded-md hover:bg-accent transition-colors flex items-center gap-1"
+                          type="button"
+                          onClick={() =>
+                            setEditingProvider((current) =>
+                              current === provider.provider ? null : provider.provider
+                            )
+                          }
+                          className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent"
+                        >
+                          <Settings2 className="h-4 w-4" />
+                          {editingProvider === provider.provider ? "Hide" : "Manage"}
+                        </button>
+                      ) : !config?.usesOAuth ? (
+                        <button
+                          type="button"
                           onClick={() => {
                             if (editingProvider === provider.provider) {
                               setEditingProvider(null);
-                              setEditApiKeys({
-                                ...editApiKeys,
+                              setEditApiKeys((current) => ({
+                                ...current,
                                 [provider.provider]: "",
-                              });
-                              setShowEditKeys({
-                                ...showEditKeys,
+                              }));
+                              setShowEditKeys((current) => ({
+                                ...current,
                                 [provider.provider]: false,
-                              });
+                              }));
                             } else {
                               setEditingProvider(provider.provider);
-                              setEditApiKeys({
-                                ...editApiKeys,
+                              setEditApiKeys((current) => ({
+                                ...current,
                                 [provider.provider]: "",
-                              });
+                              }));
                             }
+                            setValidationMessage(null);
                           }}
+                          className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent"
                         >
-                          <Settings2 className="w-4 h-4" />
-                          {editingProvider === provider.provider
-                            ? "Cancel"
-                            : "Update"}
+                          <Settings2 className="h-4 w-4" />
+                          {editingProvider === provider.provider ? "Cancel" : "Update"}
                         </button>
-                      )}
+                      ) : null}
+
+                      {isReliant ? (
+                        <button
+                          type="button"
+                          onClick={() => void refreshReliantStatus()}
+                          disabled={reliantLoading}
+                          className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent disabled:opacity-50"
+                        >
+                          {reliantLoading ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <RefreshCw className="h-4 w-4" />
+                          )}
+                          Refresh
+                        </button>
+                      ) : null}
+
                       <button
-                        className="px-3 py-1.5 text-sm border border-destructive/20 text-destructive rounded-md hover:bg-destructive/10 transition-colors flex items-center gap-1"
-                        onClick={() => handleDeleteProvider(provider.provider)}
+                        type="button"
+                        onClick={() => void handleDeleteProvider(provider.provider)}
                         disabled={deletingProvider === provider.provider}
+                        className="inline-flex items-center gap-2 rounded-md border border-destructive/20 px-3 py-1.5 text-sm text-destructive hover:bg-destructive/10 disabled:opacity-50"
                       >
                         {deletingProvider === provider.provider ? (
-                          <Loader2 className="w-4 h-4 animate-spin" />
+                          <Loader2 className="h-4 w-4 animate-spin" />
                         ) : (
-                          <Trash2 className="w-4 h-4" />
+                          <Trash2 className="h-4 w-4" />
                         )}
-                        {config?.usesOAuth ? "Disconnect" : "Delete"}
+                        {config?.usesOAuth || isReliant ? "Disconnect" : "Delete"}
                       </button>
                     </div>
                   </div>
 
-                  {/* Only show edit section for providers that use API-key auth */}
-                  {editingProvider === provider.provider && !config?.usesOAuth && (
-                    <div className="border-t border-border mt-4 pt-4 space-y-4">
+                  {renderValidationBanner}
+
+                  {editingProvider === provider.provider && isReliant ? (
+                    <div className="mt-4 border-t border-border pt-4">
+                      {renderReliantManager("edit")}
+                    </div>
+                  ) : null}
+
+                  {editingProvider === provider.provider && !isReliant && !config?.usesOAuth ? (
+                    <div className="mt-4 space-y-4 border-t border-border pt-4">
                       <div className="space-y-2">
-                        <label className="text-sm font-medium">
-                          Update API Key
-                        </label>
+                        <label className="text-sm font-medium">Update API Key</label>
                         <div className="relative">
                           <input
-                            type={
-                              showEditKeys[provider.provider]
-                                ? "text"
-                                : "password"
-                            }
+                            type={showEditKeys[provider.provider] ? "text" : "password"}
                             value={editApiKeys[provider.provider] || ""}
                             onChange={(e) => {
-                              setEditApiKeys({
-                                ...editApiKeys,
+                              setEditApiKeys((current) => ({
+                                ...current,
                                 [provider.provider]: e.target.value,
-                              });
+                              }));
+                              setValidationMessage(null);
                             }}
                             placeholder="Enter new API key to update"
-                            className="w-full px-3 py-2 border border-input bg-background rounded-md pr-10 font-mono text-sm"
+                            className="w-full rounded-md border border-input bg-background px-3 py-2 pr-10 font-mono text-sm"
                           />
                           <button
                             type="button"
                             onClick={() =>
-                              setShowEditKeys({
-                                ...showEditKeys,
-                                [provider.provider]:
-                                  !showEditKeys[provider.provider],
-                              })
+                              setShowEditKeys((current) => ({
+                                ...current,
+                                [provider.provider]: !current[provider.provider],
+                              }))
                             }
                             className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                           >
@@ -946,23 +1431,41 @@ export function CombinedGeneralSettings({
                           </button>
                         </div>
                         <p className="text-xs text-muted-foreground">
-                          Note: For security, existing API keys cannot be
-                          viewed. Enter a new key to update.
+                          Existing API keys cannot be viewed. Enter a new key to replace the current one.
                         </p>
                       </div>
 
-                      <div className="flex gap-2">
+                      <div className="flex flex-wrap gap-2">
                         <button
-                          className="px-4 py-2 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 rounded-md transition-colors disabled:opacity-50 flex items-center gap-2"
-                          onClick={() => handleSaveApiKey(provider.provider)}
+                          type="button"
+                          onClick={() =>
+                            void handleValidateApiKey(
+                              provider.provider as ProviderId,
+                              editApiKeys[provider.provider] || ""
+                            )
+                          }
+                          disabled={!editApiKeys[provider.provider] || validating}
+                          className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 text-sm hover:bg-accent disabled:opacity-50"
+                        >
+                          {validating ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <TestTube className="h-4 w-4" />
+                          )}
+                          Test Connection
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void handleSaveApiKey(provider.provider)}
                           disabled={!editApiKeys[provider.provider]}
+                          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
                         >
                           <Check className="h-4 w-4" />
                           Save Changes
                         </button>
                       </div>
                     </div>
-                  )}
+                  ) : null}
                 </div>
               );
             })}
@@ -970,19 +1473,17 @@ export function CombinedGeneralSettings({
         </div>
       )}
 
-      {/* Chat Preferences Section */}
-      <div className="mt-6 border border-border rounded-lg bg-card p-4">
-        <h3 className="text-base font-semibold mb-4">Chat Preferences</h3>
+      <div className="mt-6 rounded-lg border border-border bg-card p-4">
+        <h3 className="mb-4 text-base font-semibold">Chat Preferences</h3>
 
         <div className="space-y-4">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-6">
             <div>
               <label htmlFor="streaming-toggle" className="text-sm font-medium">
                 Response Streaming
               </label>
-              <p className="text-xs text-muted-foreground mt-1">
-                Enable streaming to see AI responses as they're generated.
-                Disable for faster complete responses.
+              <p className="mt-1 text-xs text-muted-foreground">
+                Enable streaming to see AI responses as they are generated. Disable it for faster complete responses.
               </p>
             </div>
             <Toggle
@@ -990,18 +1491,13 @@ export function CombinedGeneralSettings({
               checked={streamingEnabled}
               onChange={handleStreamingToggle}
               disabled={loadingPreferences}
-              label={`${
-                streamingEnabled ? "Disable" : "Enable"
-              } response streaming`}
+              label={`${streamingEnabled ? "Disable" : "Enable"} response streaming`}
             />
           </div>
 
-          <div className="text-xs text-muted-foreground elevation-1 p-3 rounded-md">
-            <strong>Note:</strong> When streaming is disabled, responses arrive
-            all at once after processing is complete. This can be faster for
-            short responses but provides no visual feedback during generation.
+          <div className="rounded-md p-3 text-xs text-muted-foreground elevation-1">
+            <strong>Note:</strong> When streaming is disabled, responses arrive all at once after processing is complete.
           </div>
-
         </div>
       </div>
     </div>

--- a/web/src/store/authStore.ts
+++ b/web/src/store/authStore.ts
@@ -813,12 +813,35 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     // Always register OAuth callback listener in Electron, including dev mode.
     setupElectronOAuthCallbackListener(set)
 
-    // Dev mode: skip auth and use dev user (backend uses DevUser)
+    // Dev mode: prefer a persisted real auth session when available, but keep
+    // the dev-user fallback for local workflows that do not need a real JWT.
     // Use runtime check so Electron packaged apps always follow RELIANT_CONFIG.isDev
     if (getIsDev()) {
+      try {
+        const { data: { session } } = await supabase.auth.getSession()
+        if (session?.access_token && session.user) {
+          logger.info('[AuthStore] Dev mode - using persisted real session', {
+            userId: session.user.id,
+            email: session.user.email,
+            tokenLength: session.access_token.length,
+          })
+          set({
+            user: session.user,
+            session,
+            loading: false,
+            initialized: true,
+          })
+          return
+        }
+      } catch (error) {
+        logger.warn('[AuthStore] Dev mode - failed to load persisted session, falling back to dev user', {
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+
       // Read user ID from VITE_DEV_USER_ID env var, fallback to a default
       const devUserId = import.meta.env.VITE_DEV_USER_ID || 'dev-user-id';
-      logger.info('[AuthStore] Dev mode - using dev user', { userId: devUserId })
+      logger.info('[AuthStore] Dev mode - using dev user fallback', { userId: devUserId })
       set({
         // Use configured user ID from .env so developers can use their own data
         // Include email_confirmed_at to bypass email verification requirement


### PR DESCRIPTION
## Description

Adds end-to-end support for gated Reliant-managed provider access.

This PR introduces a first-party Reliant managed-access flow that is hidden by default and only becomes active when the feature is enabled. It adds backend control-plane integration for creating, listing, and revoking Reliant provider tokens, plus exchanging stored control-plane credentials for short-lived runtime model access. It also updates model/catalog resolution so synthetic `@reliant` models only appear when access is available and allowlisted.

On the frontend, this updates Settings and API key setup UX to surface Reliant-managed access, token creation/storage, plan/access state, and related messaging. Docs and `.env.example` are also updated so local development can opt into the feature with the required env vars.

## Type of Change

- [x] 🚀 Feature (`changelog:feature`)
- [ ] 🐛 Bug fix (`changelog:fix`)
- [ ] ⚡ Performance (`changelog:perf`)
- [ ] 📚 Documentation (`changelog:docs`)
- [x] 🔧 Improvement/Refactor (`changelog:improvement`)
- [ ] ⚠️ Breaking change (`changelog:breaking`)
- [ ] 🔒 Security (`changelog:security`)
- [ ] 🏗️ Infrastructure/CI (`changelog:infra`)
- [ ] 🚫 Skip changelog (`changelog:skip`)

## Changelog Entry

Added gated Reliant-managed provider access, including token management in Settings and runtime exposure of allowlisted `@reliant` models when enabled.

## Testing

- Added/updated backend tests for:
  - Reliant managed-access feature gating
  - catalog model listing with allowlisted `@reliant` models
  - LLM driver helper/runtime exchange behavior
  - settings service Reliant/Codex flows
  - schema/model normalization coverage impacted by runtime model handling
- Verified the feature is hidden/inactive when `RELIANT_FEATURE_RELIANT_MANAGED_ACCESS_ENABLED` is unset or `false`
- Verified docs and env examples now include the required opt-in configuration:
  - `RELIANT_FEATURE_RELIANT_MANAGED_ACCESS_ENABLED`
  - `RELIANT_CONTROLPLANE_URL`
  - `RELIANT_RUNTIME_BASE_URL`