### PR TITLE
fix oauth callback port reuse

### DIFF
--- a/internal/auth/oauthcallback/oauthcallback.go
+++ b/internal/auth/oauthcallback/oauthcallback.go
@@ -1,18 +1,30 @@
-// Copyright (c) 2025 Reliant Labs
 // Package oauthcallback provides shared OAuth callback handling for both the
 // daemon runtime and the standalone `reliant auth serve` HTTP server.
 package oauthcallback
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
+)
+
+const (
+	probePath  = "/__reliant/oauth/probe"
+	resultPath = "/__reliant/oauth/result"
+
+	listenerKind    = "reliant-oauth-callback"
+	listenerVersion = 1
 )
 
 // CallbackConfig describes how to listen for and construct the OAuth redirect URI.
@@ -31,7 +43,22 @@ type Result struct {
 	CallbackURL string `json:"callback_url"`
 }
 
+type probeResponse struct {
+	Kind         string `json:"kind"`
+	Version      int    `json:"version"`
+	CallbackPath string `json:"callback_path"`
+	RedirectURI  string `json:"redirect_uri"`
+	Active       bool   `json:"active"`
+}
+
+type callbackServer struct {
+	cfg         CallbackConfig
+	redirectURI string
+	resultCh    chan *Result
+}
+
 var openBrowser = OpenBrowser
+var reuseHTTPClient = &http.Client{Timeout: 2 * time.Second}
 
 // InferConfig inspects the authorize URL to determine callback settings.
 func InferConfig(authorizeURLTemplate string) CallbackConfig {
@@ -73,58 +100,200 @@ func Run(ctx context.Context, authorizeURLTemplate string, timeoutSeconds int) (
 	}
 
 	cfg := InferConfig(authorizeURLTemplate)
-	listenAddr := fmt.Sprintf("%s:%d", cfg.ListenHost, cfg.FixedPort)
+	server, authorizeURL, err := newCallbackServer(authorizeURLTemplate, cfg)
+	if err != nil {
+		return nil, err
+	}
 
+	listenAddr := fmt.Sprintf("%s:%d", cfg.ListenHost, cfg.FixedPort)
 	listener, err := net.Listen("tcp", listenAddr)
 	if err != nil {
+		if reusedResult, reuseErr := tryReuseExistingListener(ctx, cfg, server.redirectURI, err); reuseErr == nil {
+			return reusedResult, nil
+		}
 		return nil, fmt.Errorf("failed to start callback listener: %w", err)
 	}
 	defer listener.Close()
 
 	port := listener.Addr().(*net.TCPAddr).Port
-	redirectURI := fmt.Sprintf("http://%s:%d%s", cfg.RedirectHost, port, cfg.CallbackPath)
+	if cfg.FixedPort == 0 {
+		server.redirectURI = fmt.Sprintf("http://%s:%d%s", cfg.RedirectHost, port, cfg.CallbackPath)
+		authorizeURL = strings.ReplaceAll(authorizeURLTemplate, "{redirect_uri}", url.QueryEscape(server.redirectURI))
+	}
 
-	authorizeURL := strings.ReplaceAll(authorizeURLTemplate, "{redirect_uri}", url.QueryEscape(redirectURI))
-
-	callbackCh := make(chan *url.URL, 1)
-
-	mux := http.NewServeMux()
-	mux.HandleFunc(cfg.CallbackPath, func(w http.ResponseWriter, r *http.Request) {
-		callbackCh <- r.URL
-		w.Header().Set("Content-Type", "text/html")
-		fmt.Fprint(w, `<!DOCTYPE html><html><body style="font-family:system-ui;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#1a1a2e;color:#e0e0e0"><div style="text-align:center"><h2>Authentication Successful</h2><p>You can close this tab and return to Reliant.</p></div></body></html>`)
-	})
-
-	server := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
-	go server.Serve(listener) //nolint:errcheck // best-effort serve in background goroutine
-	defer func() { _ = server.Close() }()
+	httpServer := &http.Server{Handler: server.handler(), ReadHeaderTimeout: 10 * time.Second}
+	go httpServer.Serve(listener) //nolint:errcheck // best-effort serve in background goroutine
+	defer func() { _ = httpServer.Close() }()
 
 	go func() {
 		<-ctx.Done()
-		_ = server.Close()
+		_ = httpServer.Close()
 	}()
 
 	if err := openBrowser(authorizeURL); err != nil {
 		return nil, fmt.Errorf("failed to open browser: %w", err)
 	}
 
-	timeoutTimer := time.NewTimer(time.Duration(timeoutSeconds) * time.Second)
-	defer timeoutTimer.Stop()
+	return waitForResult(ctx, timeoutSeconds, server.resultCh)
+}
+
+func newCallbackServer(authorizeURLTemplate string, cfg CallbackConfig) (*callbackServer, string, error) {
+	redirectPort := cfg.FixedPort
+	redirectURI := fmt.Sprintf("http://%s:%d%s", cfg.RedirectHost, redirectPort, cfg.CallbackPath)
+	if cfg.FixedPort == 0 {
+		redirectURI = fmt.Sprintf("http://%s:%s%s", cfg.RedirectHost, "{port}", cfg.CallbackPath)
+	}
+
+	authorizeURL := strings.ReplaceAll(authorizeURLTemplate, "{redirect_uri}", url.QueryEscape(redirectURI))
+	server := &callbackServer{
+		cfg:         cfg,
+		redirectURI: redirectURI,
+		resultCh:    make(chan *Result, 1),
+	}
+	return server, authorizeURL, nil
+}
+
+func (s *callbackServer) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc(s.cfg.CallbackPath, s.handleCallback)
+	mux.HandleFunc(probePath, s.handleProbe)
+	mux.HandleFunc(resultPath, s.handleResult)
+	return mux
+}
+
+func (s *callbackServer) handleCallback(w http.ResponseWriter, r *http.Request) {
+	result := &Result{
+		Code:        r.URL.Query().Get("code"),
+		State:       r.URL.Query().Get("state"),
+		RedirectURI: s.redirectURI,
+		CallbackURL: r.URL.String(),
+	}
+	select {
+	case s.resultCh <- result:
+	default:
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	fmt.Fprint(w, `<!DOCTYPE html><html><body style="font-family:system-ui;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#1a1a2e;color:#e0e0e0"><div style="text-align:center"><h2>Authentication Successful</h2><p>You can close this tab and return to Reliant.</p></div></body></html>`)
+}
+
+func (s *callbackServer) handleProbe(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(probeResponse{
+		Kind:         listenerKind,
+		Version:      listenerVersion,
+		CallbackPath: s.cfg.CallbackPath,
+		RedirectURI:  s.redirectURI,
+		Active:       true,
+	})
+}
+
+func (s *callbackServer) handleResult(w http.ResponseWriter, r *http.Request) {
+	result, err := waitForResult(r.Context(), 0, s.resultCh)
+	if err != nil {
+		status := http.StatusGatewayTimeout
+		if errors.Is(err, context.Canceled) {
+			status = http.StatusRequestTimeout
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+func waitForResult(ctx context.Context, timeoutSeconds int, resultCh <-chan *Result) (*Result, error) {
+	var timeoutTimer *time.Timer
+	if timeoutSeconds > 0 {
+		timeoutTimer = time.NewTimer(time.Duration(timeoutSeconds) * time.Second)
+		defer timeoutTimer.Stop()
+	}
 
 	select {
-	case cbURL := <-callbackCh:
-		query := cbURL.Query()
-		return &Result{
-			Code:        query.Get("code"),
-			State:       query.Get("state"),
-			RedirectURI: redirectURI,
-			CallbackURL: cbURL.String(),
-		}, nil
+	case result := <-resultCh:
+		return result, nil
+	case <-ctx.Done():
+		return nil, fmt.Errorf("OAuth callback cancelled: %w", ctx.Err())
+	default:
+	}
+
+	if timeoutTimer == nil {
+		select {
+		case result := <-resultCh:
+			return result, nil
+		case <-ctx.Done():
+			return nil, fmt.Errorf("OAuth callback cancelled: %w", ctx.Err())
+		}
+	}
+
+	select {
+	case result := <-resultCh:
+		return result, nil
 	case <-timeoutTimer.C:
 		return nil, fmt.Errorf("OAuth callback timed out after %d seconds", timeoutSeconds)
 	case <-ctx.Done():
 		return nil, fmt.Errorf("OAuth callback cancelled: %w", ctx.Err())
 	}
+}
+
+func tryReuseExistingListener(ctx context.Context, cfg CallbackConfig, redirectURI string, listenErr error) (*Result, error) {
+	if cfg.FixedPort == 0 || !isAddressInUse(listenErr) {
+		return nil, listenErr
+	}
+
+	probeURL := fmt.Sprintf("http://%s:%d%s", cfg.ListenHost, cfg.FixedPort, probePath)
+	probeReq, err := http.NewRequestWithContext(ctx, http.MethodGet, probeURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	probeResp, err := reuseHTTPClient.Do(probeReq)
+	if err != nil {
+		return nil, err
+	}
+	defer probeResp.Body.Close()
+	if probeResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("probe returned status %d", probeResp.StatusCode)
+	}
+
+	var probe probeResponse
+	if err := json.NewDecoder(probeResp.Body).Decode(&probe); err != nil {
+		return nil, err
+	}
+	if probe.Kind != listenerKind || probe.Version != listenerVersion || probe.CallbackPath != cfg.CallbackPath || probe.RedirectURI != redirectURI || !probe.Active {
+		return nil, fmt.Errorf("incompatible existing OAuth listener")
+	}
+
+	resultURL := fmt.Sprintf("http://%s:%d%s", cfg.ListenHost, cfg.FixedPort, resultPath)
+	resultReq, err := http.NewRequestWithContext(ctx, http.MethodGet, resultURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resultResp, err := reuseHTTPClient.Do(resultReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resultResp.Body.Close()
+	if resultResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resultResp.Body, 512))
+		return nil, fmt.Errorf("reuse result returned status %d: %s", resultResp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var result Result
+	if err := json.NewDecoder(resultResp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func isAddressInUse(err error) bool {
+	var syscallErr *os.SyscallError
+	if errors.As(err, &syscallErr) && errors.Is(syscallErr.Err, syscall.EADDRINUSE) {
+		return true
+	}
+	return errors.Is(err, syscall.EADDRINUSE)
 }
 
 // OpenBrowser opens the given URL in the user's default browser.

--- a/internal/auth/oauthcallback/oauthcallback_test.go
+++ b/internal/auth/oauthcallback/oauthcallback_test.go
@@ -2,7 +2,11 @@ package oauthcallback
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"net"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -32,4 +36,164 @@ func TestRunCancelsWhenContextDone(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context canceled, got %v", err)
 	}
+}
+
+func TestRunReusesCompatibleExistingListener(t *testing.T) {
+	originalOpenBrowser := openBrowser
+	openBrowser = func(string) error { return nil }
+	defer func() { openBrowser = originalOpenBrowser }()
+
+	cfg := CallbackConfig{
+		ListenHost:   "127.0.0.1",
+		RedirectHost: "localhost",
+		CallbackPath: "/auth/callback",
+		FixedPort:    1455,
+	}
+	server, _, err := newCallbackServer("https://auth.openai.com/oauth/authorize?redirect_uri={redirect_uri}", cfg)
+	if err != nil {
+		t.Fatalf("newCallbackServer error: %v", err)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:1455")
+	if err != nil {
+		t.Fatalf("listen error: %v", err)
+	}
+	defer listener.Close()
+
+	httpServer := &http.Server{Handler: server.handler()}
+	defer httpServer.Close()
+	go func() { _ = httpServer.Serve(listener) }()
+
+	callbackDone := make(chan struct{})
+	go func() {
+		defer close(callbackDone)
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			resp, reqErr := http.Get("http://127.0.0.1:1455" + probePath)
+			if reqErr == nil {
+				resp.Body.Close()
+				break
+			}
+			if time.Now().After(deadline) {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		_, _ = http.Get("http://127.0.0.1:1455/auth/callback?code=test-code&state=test-state")
+	}()
+
+	result, err := Run(context.Background(), "https://auth.openai.com/oauth/authorize?redirect_uri={redirect_uri}", 5)
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	<-callbackDone
+
+	if result.Code != "test-code" {
+		t.Fatalf("Code = %q, want %q", result.Code, "test-code")
+	}
+	if result.State != "test-state" {
+		t.Fatalf("State = %q, want %q", result.State, "test-state")
+	}
+	if result.RedirectURI != "http://localhost:1455/auth/callback" {
+		t.Fatalf("RedirectURI = %q", result.RedirectURI)
+	}
+}
+
+func TestRunFailsForIncompatibleExistingListener(t *testing.T) {
+	originalOpenBrowser := openBrowser
+	openBrowser = func(string) error { return nil }
+	defer func() { openBrowser = originalOpenBrowser }()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(probePath, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"kind":          "someone-else",
+			"version":       1,
+			"callback_path": "/auth/callback",
+			"redirect_uri":  "http://localhost:1455/auth/callback",
+			"active":        true,
+		})
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:1455")
+	if err != nil {
+		t.Fatalf("listen error: %v", err)
+	}
+	defer listener.Close()
+
+	httpServer := &http.Server{Handler: mux}
+	defer httpServer.Close()
+	go func() { _ = httpServer.Serve(listener) }()
+
+	_, err = Run(context.Background(), "https://auth.openai.com/oauth/authorize?redirect_uri={redirect_uri}", 5)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "failed to start callback listener") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTryReuseExistingListenerReadsResult(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(probePath, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(probeResponse{
+			Kind:         listenerKind,
+			Version:      listenerVersion,
+			CallbackPath: "/auth/callback",
+			RedirectURI:  "http://localhost:1455/auth/callback",
+			Active:       true,
+		})
+	})
+	mux.HandleFunc(resultPath, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Result{
+			Code:        "shared-code",
+			State:       "shared-state",
+			RedirectURI: "http://localhost:1455/auth/callback",
+			CallbackURL: "/auth/callback?code=shared-code&state=shared-state",
+		})
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:1455")
+	if err != nil {
+		t.Fatalf("listen error: %v", err)
+	}
+	defer listener.Close()
+
+	httpServer := &http.Server{Handler: mux}
+	defer httpServer.Close()
+	go func() { _ = httpServer.Serve(listener) }()
+
+	result, err := tryReuseExistingListener(
+		context.Background(),
+		CallbackConfig{ListenHost: "127.0.0.1", CallbackPath: "/auth/callback", FixedPort: 1455},
+		"http://localhost:1455/auth/callback",
+		fmt.Errorf("listen tcp 127.0.0.1:1455: %w", syscallEADDRINUSE()),
+	)
+	if err != nil {
+		t.Fatalf("tryReuseExistingListener error: %v", err)
+	}
+	if result.Code != "shared-code" || result.State != "shared-state" {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func syscallEADDRINUSE() error {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return err
+	}
+	addr := ln.Addr().String()
+	_, port, _ := net.SplitHostPort(addr)
+	busyListener, err := net.Listen("tcp", "127.0.0.1:"+port)
+	if err == nil {
+		busyListener.Close()
+		ln.Close()
+		return fmt.Errorf("expected address in use")
+	}
+	ln.Close()
+	return err
 }

--- a/web/src/components/Layout/Sidebar.test.tsx
+++ b/web/src/components/Layout/Sidebar.test.tsx
@@ -1,0 +1,150 @@
+import { render } from "@testing-library/react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Sidebar } from "./Sidebar";
+import { ChatState, ChatActivity } from "../../gen/reliant/v1/chat_pb";
+import { WorktreeStatus } from "../../gen/reliant/v1/worktree_pb";
+import { useChatStore } from "../../store/chatStore";
+import { useActivityStore } from "../../store/activityStore";
+import { useWorktreeStore } from "../../store/worktreeStore";
+import { useProcessStore } from "../../store/processStore";
+import { useProjectStore } from "../../store/projectStore";
+import { useChatListPreferencesStore } from "../../store/chatListPreferencesStore";
+
+vi.mock("../ui/Tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("../ui/Button", () => ({
+  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("../ui/ContextMenu", () => ({
+  ContextMenu: () => null,
+}));
+
+vi.mock("../ui/Dropdown", () => ({
+  Dropdown: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../ui/ActivityDot", () => ({
+  ActivityDot: () => <div data-testid="activity-dot" />,
+}));
+
+vi.mock("../../hooks/useDebounce", () => ({
+  useDebounce: <T,>(value: T) => value,
+}));
+
+describe("Sidebar selected chat scroll", () => {
+  const loadArchivedChats = vi.fn(async () => undefined);
+  const fetchProcesses = vi.fn();
+  const switchWorktreeContext = vi.fn(async () => undefined);
+  const scrollIntoViewMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scrollIntoViewMock.mockReset();
+
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoViewMock,
+    });
+
+    useChatStore.setState({
+      chats: new Map([
+        [
+          "chat-1",
+          {
+            id: "chat-1",
+            title: "Selected chat",
+            createdAt: "2024-01-01T00:00:00.000Z",
+            updatedAt: "2024-01-01T00:00:00.000Z",
+            lastMessageAt: "2024-01-01T00:00:00.000Z",
+            unread: false,
+            state: ChatState.ACTIVE,
+            worktreeId: "worktree-1",
+            projectId: "project-1",
+          },
+        ],
+      ]),
+      activeChatId: "chat-1",
+      archivedChats: [],
+      archivedChatsLoaded: true,
+      loadArchivedChats,
+      selectChat: vi.fn(),
+      deleteChat: vi.fn(async () => undefined),
+      renameChat: vi.fn(async () => undefined),
+      markUnread: vi.fn(async () => undefined),
+    } as Partial<ReturnType<typeof useChatStore.getState>>);
+
+    useActivityStore.setState({
+      activities: new Map([["chat-1", ChatActivity.IDLE]]),
+    } as Partial<ReturnType<typeof useActivityStore.getState>>);
+
+    useWorktreeStore.setState({
+      worktrees: [
+        {
+          id: "worktree-1",
+          name: "Workspace",
+          path: "/tmp/worktree",
+          branch: "feature/test",
+          base_branch: "main",
+          project_id: "project-1",
+          status: WorktreeStatus.ACTIVE,
+          is_main: false,
+          created_at: "2024-01-01T00:00:00.000Z",
+          updated_at: "2024-01-01T00:00:00.000Z",
+          last_active: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      currentWorktree: null,
+      switchWorktreeContext,
+    } as Partial<ReturnType<typeof useWorktreeStore.getState>>);
+
+    useProcessStore.setState({
+      fetchProcesses,
+    } as Partial<ReturnType<typeof useProcessStore.getState>>);
+
+    useProjectStore.setState({
+      currentProject: {
+        id: "project-1",
+        name: "Project",
+        path: "/tmp/project",
+        is_git_repo: true,
+        worktree_count: 1,
+        created_at: "2024-01-01T00:00:00.000Z",
+        updated_at: "2024-01-01T00:00:00.000Z",
+        last_active: "2024-01-01T00:00:00.000Z",
+      },
+    } as Partial<ReturnType<typeof useProjectStore.getState>>);
+
+    useChatListPreferencesStore.setState({
+      sortOrder: "recent_activity",
+      viewMode: "grouped",
+      filters: {},
+      setSortOrder: vi.fn(),
+      setViewMode: vi.fn(),
+      setFilters: vi.fn(),
+      resetFilters: vi.fn(),
+      resetAll: vi.fn(),
+    });
+  });
+
+  it("scrolls the selected chat into view with auto behavior", async () => {
+    vi.useFakeTimers();
+
+    render(<Sidebar />);
+
+    vi.advanceTimersByTime(100);
+
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({
+      block: "nearest",
+      behavior: "auto",
+    });
+
+    vi.useRealTimers();
+  });
+});

--- a/web/src/components/Layout/Sidebar.tsx
+++ b/web/src/components/Layout/Sidebar.tsx
@@ -1305,7 +1305,7 @@ function SidebarComponent({ paddingClass = "" }: SidebarProps) {
       if (chatElement) {
         chatElement.scrollIntoView({
           block: "nearest",
-          behavior: "instant",
+          behavior: "auto",
         });
       }
     }, 100);


### PR DESCRIPTION
## Description

Fix codex oauth complaining about port reuse

## Type of Change

<!-- Add the appropriate label to this PR -->

- [ ] 🚀 Feature (`changelog:feature`)
- [x] 🐛 Bug fix (`changelog:fix`)
- [ ] ⚡ Performance (`changelog:perf`)
- [ ] 📚 Documentation (`changelog:docs`)
- [ ] 🔧 Improvement/Refactor (`changelog:improvement`)
- [ ] ⚠️ Breaking change (`changelog:breaking`)
- [ ] 🔒 Security (`changelog:security`)
- [ ] 🏗️ Infrastructure/CI (`changelog:infra`)
- [ ] 🚫 Skip changelog (`changelog:skip`)

## Changelog Entry

Fix codex oauth complaining about port reuse

## Testing

<!-- How was this tested? -->

## Screenshots

<!-- If applicable, add screenshots -->
