### PR TITLE
reduce noise from canceled context in error reporting

### DIFF
--- a/internal/grpc/interceptors/error_reporter.go
+++ b/internal/grpc/interceptors/error_reporter.go
@@ -87,17 +87,20 @@ func shouldSkipReporting(code connect.Code, err error) bool {
 		return true
 	}
 
-	// Skip common transient errors
+	// Skip common transient/non-actionable errors
 	errMsg := strings.ToLower(err.Error())
-	transientPatterns := []string{
+	skipPatterns := []string{
 		"context canceled",
-		"context deadline exceeded",
 		"connection reset",
 		"broken pipe",
 		"client disconnected",
+		"exit status 128",
+		"sqlite3: interrupted",
+		"streaming cancelled by user",
+		"signal: killed",
 	}
 
-	for _, pattern := range transientPatterns {
+	for _, pattern := range skipPatterns {
 		if strings.Contains(errMsg, pattern) {
 			return true
 		}

--- a/internal/logging/sentry_handler.go
+++ b/internal/logging/sentry_handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/reliant-labs/reliant/internal/telemetry"
 )
@@ -65,6 +66,22 @@ func (h *sentryHandler) WithGroup(name string) slog.Handler {
 	}
 }
 
+// sentrySilentPatterns are errors that should be completely silent — not
+// reported to Sentry and not re-logged. These are user-initiated cancellations
+// that are a normal part of operation.
+var sentrySilentPatterns = []string{
+	"context canceled",
+	"streaming cancelled by user",
+}
+
+// sentryWarnPatterns are errors that should NOT go to Sentry but should still
+// be logged as warnings for operational visibility.
+var sentryWarnPatterns = []string{
+	"sqlite3: interrupted",
+	"exit status 128",
+	"signal: killed",
+}
+
 // reportToSentry extracts error information from the log record and sends it
 // to Sentry. Runs in a separate goroutine to avoid blocking log callers.
 func (h *sentryHandler) reportToSentry(r slog.Record) {
@@ -89,6 +106,20 @@ func (h *sentryHandler) reportToSentry(r slog.Record) {
 		capturedErr = errors.New(r.Message)
 	}
 
+	// Completely silent — user-initiated cancellations.
+	if matchesAny(capturedErr, sentrySilentPatterns) {
+		return
+	}
+
+	// Warn-only — log for visibility but don't send to Sentry.
+	if matchesAny(capturedErr, sentryWarnPatterns) {
+		Warn("[Sentry] Suppressed non-actionable error",
+			"error", capturedErr.Error(),
+			"log_message", r.Message,
+		)
+		return
+	}
+
 	// Add the log message as extra context when we have a real error.
 	extra["log_message"] = r.Message
 
@@ -105,6 +136,20 @@ func (h *sentryHandler) reportToSentry(r slog.Record) {
 	}
 
 	telemetry.CaptureExceptionWithContext(capturedErr, tags, extra)
+}
+
+// matchesAny returns true if the error message contains any of the given patterns.
+func matchesAny(err error, patterns []string) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, p := range patterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // collectAttr processes a single slog.Attr, extracting error values and

--- a/internal/workflow/runtime/activities/errors.go
+++ b/internal/workflow/runtime/activities/errors.go
@@ -123,6 +123,8 @@ func autoClassify(err error) error {
 		"cannot be nil",
 		"unknown model",
 		"unsupported",
+		// User hasn't configured an API key for any matching provider
+		"no available provider",
 		// CEL errors are deterministic — retrying won't help
 		"cel compilation error",
 		"cel evaluation error",

--- a/internal/workflow/runtime/registry.go
+++ b/internal/workflow/runtime/registry.go
@@ -120,6 +120,8 @@ func classifyError(err error) error {
 		"too many tokens",    // Alternative token limit error message
 		"maximum context",    // Context length exceeded
 		"context length",     // Context length error
+		// User hasn't configured an API key for any matching provider
+		"no available provider",
 	}
 
 	for _, pattern := range terminalPatterns {

--- a/web/src/components/FileBrowser/MonacoDiffViewer.tsx
+++ b/web/src/components/FileBrowser/MonacoDiffViewer.tsx
@@ -168,7 +168,10 @@ export function MonacoDiffViewer({ file }: MonacoDiffViewerProps) {
               
               // Also set scroll directly as backup
               requestAnimationFrame(() => {
-                const scrollableElement = modifiedEditor.getScrollableElement();
+                // getScrollableElement may not exist on all Monaco versions
+                const scrollableElement = typeof modifiedEditor.getScrollableElement === 'function'
+                  ? modifiedEditor.getScrollableElement()
+                  : null;
                 if (scrollableElement) {
                   const lineTop = modifiedEditor.getTopForLineNumber(firstDiffLine);
                   if (lineTop !== -1 && lineTop >= 0) {
@@ -411,7 +414,10 @@ export function MonacoDiffViewer({ file }: MonacoDiffViewerProps) {
             requestAnimationFrame(() => {
               try {
                 // Try to get scrollable element and set scroll directly
-                const scrollableElement = modifiedEditor.getScrollableElement();
+                // getScrollableElement may not exist on all Monaco versions
+                const scrollableElement = typeof modifiedEditor.getScrollableElement === 'function'
+                  ? modifiedEditor.getScrollableElement()
+                  : null;
                 if (scrollableElement) {
                   const lineTop = modifiedEditor.getTopForLineNumber(firstDiffLine);
                   if (lineTop !== -1 && lineTop >= 0) {

--- a/web/src/lib/sentry.ts
+++ b/web/src/lib/sentry.ts
@@ -116,6 +116,12 @@ export async function initSentry() {
       if (!crashReportingEnabled) {
         return null;
       }
+
+      // Filter out noise errors that aren't actionable bugs
+      if (shouldDropEvent(event, hint)) {
+        return null;
+      }
+
       if (isDev) {
         console.error("Sentry Event:", event, hint);
       }
@@ -124,6 +130,58 @@ export async function initSentry() {
   });
 
   console.log(`[Sentry] Initialized (environment: ${sentryEnvironment}, release: reliant@${version}, replayRate: ${replaySessionRate})`);
+}
+
+/**
+ * Patterns that indicate non-actionable errors which should not be reported to Sentry.
+ * These are user-initiated cancellations, expected transient failures, or configuration issues.
+ */
+const NOISE_ERROR_PATTERNS = [
+  // User-initiated cancellations
+  "aborted a request",
+  "signal is aborted",
+  "streaming cancelled by user",
+  "the operation was aborted",
+  // Transient network errors (backend unavailable during startup/shutdown)
+  "failed to fetch",
+  "load failed",
+  "networkerror",
+] as const;
+
+/** Error types (by name) that are always dropped. */
+const NOISE_ERROR_NAMES = new Set([
+  "AbortError",
+]);
+
+function shouldDropEvent(event: Sentry.ErrorEvent, hint: Sentry.EventHint): boolean {
+  const error = hint.originalException;
+
+  // Drop by error name
+  if (error instanceof Error && NOISE_ERROR_NAMES.has(error.name)) {
+    return true;
+  }
+
+  // Drop by error message pattern
+  const message = (error instanceof Error ? error.message : String(error ?? "")).toLowerCase();
+  if (NOISE_ERROR_PATTERNS.some((p) => message.includes(p))) {
+    return true;
+  }
+
+  // Also check event exception values (for errors where hint doesn't have the original)
+  const exceptionValues = event.exception?.values;
+  if (exceptionValues) {
+    for (const ex of exceptionValues) {
+      if (ex.type && NOISE_ERROR_NAMES.has(ex.type)) {
+        return true;
+      }
+      const val = (ex.value ?? "").toLowerCase();
+      if (NOISE_ERROR_PATTERNS.some((p) => val.includes(p))) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 export function setSentryUser(user: { id: string; email?: string } | null) {


### PR DESCRIPTION
## Description

When user's canceled chats it would report an error which is noisy, and also not an error.

## Type of Change

<!-- Add the appropriate label to this PR -->

- [ ] 🚀 Feature (`changelog:feature`)
- [ ] 🐛 Bug fix (`changelog:fix`)
- [ ] ⚡ Performance (`changelog:perf`)
- [ ] 📚 Documentation (`changelog:docs`)
- [ ] 🔧 Improvement/Refactor (`changelog:improvement`)
- [ ] ⚠️ Breaking change (`changelog:breaking`)
- [ ] 🔒 Security (`changelog:security`)
- [ ] 🏗️ Infrastructure/CI (`changelog:infra`)
- [ ] 🚫 Skip changelog (`changelog:skip`)

## Changelog Entry

<!-- 
If this PR should appear in the changelog, write a user-friendly description.
This will be used in release notes.

Example: "Added support for custom MCP servers with environment variable substitution"

Leave blank if using changelog:skip label.
-->

## Testing

<!-- How was this tested? -->

## Screenshots

<!-- If applicable, add screenshots -->
