### PR TITLE
Fix/validation

### DIFF
--- a/internal/db/sqlite/queries/workflows.sql
+++ b/internal/db/sqlite/queries/workflows.sql
@@ -128,16 +128,14 @@ WHERE parent_id = ?
 -- name: ListWorkflowsByStatus :many
 -- List all workflows with a specific status (e.g., 2=running, 6=paused).
 -- Used for startup recovery to restart workers for active workflows.
-SELECT id, parent_id, chat_id, workflow_name, thread, status, spawned_by_node_id, loop_iteration, created_at, completed_at
-FROM workflows
+SELECT id, parent_id, chat_id, workflow_name, thread, spawned_by_node_id, loop_iteration, created_at, completed_at, expired_at, status FROM workflows
 WHERE status = ?
 ORDER BY created_at ASC;
 
 -- name: ListRootWorkflowsByStatus :many
 -- List root workflows (parent_id IS NULL) with a specific status.
 -- Root workflows are the entry points that need dedicated workers.
-SELECT id, parent_id, chat_id, workflow_name, thread, status, spawned_by_node_id, loop_iteration, created_at, completed_at
-FROM workflows
+SELECT id, parent_id, chat_id, workflow_name, thread, spawned_by_node_id, loop_iteration, created_at, completed_at, expired_at, status FROM workflows
 WHERE parent_id IS NULL AND status = ?
 ORDER BY created_at ASC;
 

--- a/internal/workflow/runtime/loop_executor.go
+++ b/internal/workflow/runtime/loop_executor.go
@@ -299,11 +299,12 @@ func (e *InlineLoopExecutor) loadPresetParams(presetName string) (map[string]int
 
 // Execute runs the loop inline and returns the loop output.
 // This is the main entry point - it handles the full loop lifecycle:
-// 1. Execute entry save_message if configured
-// 2. Load sub-workflow definition
-// 3. Execute iterations inline with execContext
-// 4. Evaluate while condition after each iteration
-// 5. Return aggregated output
+// 1. Load sub-workflow definition
+// 2. Execute iterations inline with execContext
+// 3. Evaluate while condition after each iteration
+// 4. Return aggregated output
+// Note: save_message (if configured) is executed by the parent workflow after loop completion,
+// consistent with how all other node types handle save_message.
 func (e *InlineLoopExecutor) Execute() (*reliantv1.LoopOutput, error) {
 	la := model.GetLoopArgs(e.loopStep.Node)
 
@@ -320,14 +321,6 @@ func (e *InlineLoopExecutor) Execute() (*reliantv1.LoopOutput, error) {
 		"hasSaveMessage", e.loopStep.Node.GetSaveMessage() != nil,
 		"hasExecContext", e.execContext != nil,
 	)
-
-	// Handle entry message save:
-	// IMPORTANT: For loops, we do NOT auto-save the trigger message here.
-	// The trigger message was already saved by the root workflow before the loop started.
-	// The execContext is passed to loops for thread tracking, not for message saving.
-	if err := e.executeEntrySaveMessage(); err != nil {
-		return nil, fmt.Errorf("failed to execute loop entry save_message: %w", err)
-	}
 
 	// Load sub-workflow definition
 	if err := e.loadSubWorkflow(); err != nil {
@@ -1478,61 +1471,6 @@ func (e *InlineLoopExecutor) executeYield() (*YieldOutput, error) {
 		YieldID:     createOutput.YieldID,
 		ActionTaken: actionTaken,
 	}, nil
-}
-
-// executeEntrySaveMessage executes the save_message block before the first loop iteration.
-// This allows loops to save an initial message (e.g., user message) without requiring
-// a separate step before the loop.
-//
-// Unlike post-action save_message blocks, this runs BEFORE any activity, so there's no
-// `output.*` namespace - only `workflow.*` and `nodes.*` are available for CEL evaluation.
-func (e *InlineLoopExecutor) executeEntrySaveMessage() error {
-	if e.loopStep.Node.GetSaveMessage() == nil {
-		return nil
-	}
-
-	e.logger.Info("[InlineLoop] Executing entry save_message",
-		"loopID", e.loopID,
-	)
-
-	// Build workflow context for CEL evaluation
-	// Note: No `output.*` namespace since this runs before any activity
-	workflowContext := buildWorkflowContext(
-		e.workflowID,
-		e.workflowName,
-		e.chatID,
-		e.workflowInputs,
-	)
-
-	// Use empty map for activityOutput since this is an entry action (no preceding output)
-	emptyOutput := make(map[string]interface{})
-
-	// Execute the save_message using the shared inline function
-	// Note: Not passing loop context since this is the entry point, not part of an iteration
-	_, err := executeSaveMessageInline(
-		e.ctx,
-		e.loopStep.Node,
-		emptyOutput, // No activity output for entry save
-		workflowContext,
-		e.nodeOutputs, // Parent workflow's step outputs
-		e.chatID,
-		e.workflowID,
-		"",            // No loop node ID (this is the entry point)
-		0,             // No loop iteration
-		e.execContext, // Pass execContext for thread.* namespace access
-	)
-	if err != nil {
-		e.logger.Error("[InlineLoop] Entry save_message failed",
-			"loopID", e.loopID,
-			"error", err,
-		)
-		return err
-	}
-
-	e.logger.Info("[InlineLoop] Entry save_message completed",
-		"loopID", e.loopID,
-	)
-	return nil
 }
 
 // injectHandoffReminder saves a system message to the thread when a yield resolves

--- a/internal/workflow/runtime/loop_executor_parallel.go
+++ b/internal/workflow/runtime/loop_executor_parallel.go
@@ -41,11 +41,6 @@ func (e *InlineLoopExecutor) ExecuteParallel() (*reliantv1.LoopOutput, error) {
 		"workflowIdentity", e.workflowIdentity(),
 	)
 
-	// Execute entry save_message if configured
-	if err := e.executeEntrySaveMessage(); err != nil {
-		return nil, fmt.Errorf("failed to execute loop entry save_message: %w", err)
-	}
-
 	// Load sub-workflow definition (loaded once, shared across iterations)
 	if err := e.loadSubWorkflow(); err != nil {
 		return nil, fmt.Errorf("failed to load loop sub-workflow: %w", err)

--- a/internal/workflow/runtime/simulator.go
+++ b/internal/workflow/runtime/simulator.go
@@ -795,7 +795,7 @@ func (s *WorkflowSimulator) executeInlineLoop(nodePath string, protoNode *relian
 	const maxSimulationIterations = 1000
 
 	for iterations < maxSimulationIterations {
-		iterOutputs, err := s.executeLoopIteration(nodePath, subWorkflow, protoNode, mocker, iterations)
+		iterOutputs, err := s.executeLoopIteration(nodePath, subWorkflow, protoNode, mocker, iterations, lastIterOutputs)
 		if err != nil {
 			return nil, err
 		}
@@ -830,6 +830,7 @@ func (s *WorkflowSimulator) executeLoopIteration(
 	loopNode *reliantv1.Node,
 	mocker StepMocker,
 	iteration int,
+	prevIterOutputs map[string]interface{},
 ) (map[string]interface{}, error) {
 	// Create state machine for sub-workflow
 	subSM := NewSimplifiedStateMachine("sim-workflow", subWorkflow)
@@ -979,9 +980,9 @@ func (s *WorkflowSimulator) executeLoopIteration(
 				"sim-workflow",
 				workflowIdentity,
 				subInputs,
-				nil, // loop context handled via subInputs
-				nil, // loopOutputs
-				nil, // no execContext in simulation
+				nil,             // loop context handled via subInputs
+				prevIterOutputs, // previous iteration outputs for outputs.* namespace
+				nil,             // no execContext in simulation
 			)
 
 			if err != nil {
@@ -1049,7 +1050,7 @@ func (s *WorkflowSimulator) executeNestedLoop(qualifiedPrefix string, protoNode 
 	const maxSimulationIterations = 1000
 
 	for iterations < maxSimulationIterations {
-		iterOutputs, err := s.executeNestedLoopIteration(qualifiedPrefix, inlineWf, protoNode, mocker, iterations)
+		iterOutputs, err := s.executeNestedLoopIteration(qualifiedPrefix, inlineWf, protoNode, mocker, iterations, lastIterOutputs)
 		if err != nil {
 			return nil, err
 		}
@@ -1125,6 +1126,7 @@ func (s *WorkflowSimulator) executeNestedLoopIteration(
 	loopNode *reliantv1.Node,
 	mocker StepMocker,
 	iteration int,
+	prevIterOutputs map[string]interface{},
 ) (map[string]interface{}, error) {
 	subSM := NewSimplifiedStateMachine("sim-workflow", subWorkflow)
 	innerOutputs := make(map[string]interface{})
@@ -1253,7 +1255,7 @@ func (s *WorkflowSimulator) executeNestedLoopIteration(
 			evalResult, err := EvaluateNodeConfig(
 				triggered.Node, innerOutputs,
 				"sim-workflow", workflowIdentity, subInputs,
-				nil, nil, nil,
+				nil, prevIterOutputs, nil,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to evaluate config for node %s: %w", qualifiedID, err)

--- a/internal/workflow/runtime/workflow.go
+++ b/internal/workflow/runtime/workflow.go
@@ -875,8 +875,30 @@ func DynamicWorkflow(ctx workflow.Context, input WorkflowInput) (result *Workflo
 				loopOutputMap := model.ProtoLoopOutputToMap(loopOutput)
 				nodeOutputStore.Set(step.Node.GetId(), loopOutputMap)
 
-				// Note: save_message on loop nodes is executed on ENTRY by InlineLoopExecutor.executeEntrySaveMessage()
-				// We don't execute it again here after loop completion to avoid duplicate messages.
+				// Execute save_message if configured on the loop node
+				// Consistent with all other node types: save_message fires on completion.
+				if step.Node.GetSaveMessage() != nil {
+					_, err := ExecuteSaveMessageForNode(
+						ctx,
+						step.Node,
+						loopOutputMap,
+						nodeOutputs,
+						workflowID,
+						input.WorkflowName,
+						input.ChatID,
+						input.Inputs,
+						execCtx,
+						"", // Not inside a nested loop
+						0,  // Not inside a nested loop
+					)
+					if err != nil {
+						logger.Error("[Workflow Runtime] save_message failed for loop",
+							"stepID", step.Node.GetId(),
+							"error", err,
+						)
+						// Don't fail - save_message errors are logged but non-fatal
+					}
+				}
 
 				// Update thread liveness - mark loop step as completed
 				if threadTracker != nil {


### PR DESCRIPTION
## Description

Save message should run after execution on loops

## Type of Change

<!-- Add the appropriate label to this PR -->

- [ ] 🚀 Feature (`changelog:feature`)
- [x] 🐛 Bug fix (`changelog:fix`)
- [ ] ⚡ Performance (`changelog:perf`)
- [ ] 📚 Documentation (`changelog:docs`)
- [ ] 🔧 Improvement/Refactor (`changelog:improvement`)
- [ ] ⚠️ Breaking change (`changelog:breaking`)
- [ ] 🔒 Security (`changelog:security`)
- [ ] 🏗️ Infrastructure/CI (`changelog:infra`)
- [ ] 🚫 Skip changelog (`changelog:skip`)

## Changelog Entry

Save message now properly runs after execution on loop nodes

## Testing

<!-- How was this tested? -->

## Screenshots

<!-- If applicable, add screenshots -->
