### PR TITLE
fix(codex): request api.responses.write and improve scope error UX

### DIFF
--- a/internal/llm/drivers/codex/api_error.go
+++ b/internal/llm/drivers/codex/api_error.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 Reliant Labs
+package codex
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrMissingResponsesWriteScope means the access token is valid but lacks
+// api.responses.write (common after OpenAI scope changes); user must re-run OAuth.
+var ErrMissingResponsesWriteScope = errors.New("codex token missing api.responses.write; reconnect with Login with Codex in Settings")
+
+// AugmentAPIError wraps Codex HTTP/API errors with a clearer message when the
+// backend reports missing_scope for the responses API.
+func AugmentAPIError(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "api.responses.write") &&
+		(strings.Contains(msg, "missing_scope") || strings.Contains(msg, "insufficient permissions")) {
+		return fmt.Errorf("%w: %v", ErrMissingResponsesWriteScope, err)
+	}
+	return err
+}

--- a/internal/llm/drivers/codex/api_error_test.go
+++ b/internal/llm/drivers/codex/api_error_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 Reliant Labs
+package codex
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAugmentAPIError_nil(t *testing.T) {
+	require.NoError(t, AugmentAPIError(nil))
+}
+
+func TestAugmentAPIError_passThrough(t *testing.T) {
+	err := errors.New("some other failure")
+	require.Equal(t, err, AugmentAPIError(err))
+}
+
+func TestAugmentAPIError_missingScope(t *testing.T) {
+	orig := fmt.Errorf(`POST "https://chatgpt.com/backend-api/codex/responses": 401 Unauthorized {
+    "message": "You have insufficient permissions for this operation. Missing scopes: api.responses.write.",
+    "code": "missing_scope"
+  }`)
+	wrapped := AugmentAPIError(orig)
+	require.ErrorIs(t, wrapped, ErrMissingResponsesWriteScope)
+	require.ErrorContains(t, wrapped, orig.Error())
+}

--- a/internal/llm/drivers/codex/driver.go
+++ b/internal/llm/drivers/codex/driver.go
@@ -471,7 +471,7 @@ func (c *CodexClient) SendMessages(ctx context.Context, prompts []string, messag
 	var rawResp *http.Response
 	resp, err := c.client.Responses.New(ctx, params, option.WithResponseInto(&rawResp))
 	if err != nil {
-		return nil, fmt.Errorf("codex API request failed: %w", err)
+		return nil, fmt.Errorf("codex API request failed: %w", AugmentAPIError(err))
 	}
 	if resp.Error.Message != "" {
 		return nil, fmt.Errorf("codex API error: %s", resp.Error.Message)
@@ -629,6 +629,7 @@ func (c *CodexClient) StreamResponse(ctx context.Context, prompts []string, mess
 		}
 
 		if err := stream.Err(); err != nil {
+			err = AugmentAPIError(err)
 			logging.Error("[Codex] Stream error", "error", err)
 			eventChan <- llm.DriverEvent{Type: llm.EventError, Error: err}
 			return

--- a/web/src/components/Chat/WorkflowErrorMessage.tsx
+++ b/web/src/components/Chat/WorkflowErrorMessage.tsx
@@ -207,6 +207,13 @@ function extractProviderReconnectSummary(lower: string): string | null {
     return 'Claude session expired. Please reconnect Claude. Workflow paused — send a message to retry.';
   }
   if (
+    lower.includes('missing_scope') ||
+    lower.includes('api.responses.write') ||
+    lower.includes('codex token missing api.responses.write')
+  ) {
+    return 'Codex login is missing required API access. Disconnect Codex in Settings, then use Login with Codex again. Workflow paused — send a message to retry.';
+  }
+  if (
     lower.includes('codex session expired') ||
     lower.includes('please reconnect codex') ||
     lower.includes('codex authentication required')

--- a/web/src/components/Settings/CombinedGeneralSettings.tsx
+++ b/web/src/components/Settings/CombinedGeneralSettings.tsx
@@ -171,6 +171,12 @@ const parseErrorMessage = (errorText: string, provider: string): string => {
     if (lowerError.includes("not authenticated")) {
       return "Codex is not connected. Please use Login with Codex.";
     }
+    if (
+      lowerError.includes("missing_scope") ||
+      lowerError.includes("api.responses.write")
+    ) {
+      return "Codex needs updated API permissions. Disconnect and use Login with Codex again.";
+    }
     if (lowerError.includes("expired")) {
       return "Codex session expired. Please reconnect with Login with Codex.";
     }

--- a/web/src/lib/__tests__/codex-oauth.test.ts
+++ b/web/src/lib/__tests__/codex-oauth.test.ts
@@ -110,7 +110,7 @@ describe("runCodexOAuthFlow", () => {
     );
     expect(parsedUrl.searchParams.get("originator")).toBe("codex_cli_rs");
     expect(parsedUrl.searchParams.get("scope")).toBe(
-      "openid profile email offline_access api.connectors.read api.connectors.invoke",
+      "openid profile email offline_access api.connectors.read api.connectors.invoke api.responses.write",
     );
     expect(
       parsedUrl.searchParams.get("state")?.startsWith(CODEX_OAUTH_STATE_PREFIX),

--- a/web/src/lib/codex-oauth.ts
+++ b/web/src/lib/codex-oauth.ts
@@ -5,10 +5,11 @@ import { startOAuthViaLocalServer } from '@/lib/oauth-local'
 
 const CODEX_OAUTH_AUTHORIZE_URL = 'https://auth.openai.com/oauth/authorize'
 const CODEX_OAUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann'
-// Must match OpenAI Codex CLI authorize URL (codex-rs/login `build_authorize_url`).
-// Other scope strings are rejected by auth.openai.com for this client_id (no ?code= redirect).
+// Align with Codex CLI authorize URL (codex-rs/login `build_authorize_url`) plus
+// api.responses.write, required for POST .../codex/responses (streaming).
+// If auth.openai.com rejects the scope list, OAuth will fail at authorize (no ?code= redirect).
 const CODEX_OAUTH_DEFAULT_SCOPE =
-  'openid profile email offline_access api.connectors.read api.connectors.invoke'
+  'openid profile email offline_access api.connectors.read api.connectors.invoke api.responses.write'
 const CODEX_OAUTH_ADDITIONAL_AUTHORIZE_PARAMS: Record<string, string> = {
   id_token_add_organizations: 'true',
   codex_cli_simplified_flow: 'true',


### PR DESCRIPTION
## Description

Codex OAuth previously omitted `api.responses.write`, which the ChatGPT Codex responses API now requires. Users could appear "connected" but hit 401 `missing_scope` on streaming. This change adds the scope to the authorize request, wraps Codex API errors with a clear reconnect hint, and maps scope errors to friendlier UI copy.

## Type of Change

- [ ] 🚀 Feature (`changelog:feature`)
- [x] 🐛 Bug fix (`changelog:fix`)
- [ ] ⚡ Performance (`changelog:perf`)
- [ ] 📚 Documentation (`changelog:docs`)
- [ ] 🔧 Improvement/Refactor (`changelog:improvement`)
- [ ] ⚠️ Breaking change (`changelog:breaking`)
- [ ] 🔒 Security (`changelog:security`)
- [ ] 🏗️ Infrastructure/CI (`changelog:infra`)
- [ ] 🚫 Skip changelog (`changelog:skip`)

## Changelog Entry

Fixed Codex login requesting `api.responses.write` so Codex models work against the responses API after OpenAI scope enforcement; clearer errors when reconnect is required.

## Testing

- `go test ./internal/llm/drivers/codex/...`
- `npx vitest run src/lib/__tests__/codex-oauth.test.ts`

## Screenshots

N/A
