### PR TITLE
improve multi worktree naming

### DIFF
--- a/internal/db/core/project_worktree.go
+++ b/internal/db/core/project_worktree.go
@@ -105,6 +105,7 @@ type ProjectStore interface {
 	CreateProject(ctx context.Context, project *Project) error
 	GetProject(ctx context.Context, id string) (*Project, error)
 	GetProjectByPath(ctx context.Context, path string) (*Project, error)
+	GetProjectByPathAndUser(ctx context.Context, path, userID string) (*Project, error)
 	GetProjectWithUserCheck(ctx context.Context, id string, userID string) (*Project, error)
 	ListProjects(ctx context.Context, filters ProjectFilters) ([]*Project, error)
 	UpdateProject(ctx context.Context, project *Project, userID string) error

--- a/internal/db/postgres/project_worktree_store.go
+++ b/internal/db/postgres/project_worktree_store.go
@@ -53,6 +53,17 @@ func (s *projectStore) GetProjectByPath(ctx context.Context, path string) (*core
 	return projectFromPG(row), nil
 }
 
+func (s *projectStore) GetProjectByPathAndUser(ctx context.Context, path, userID string) (*core.Project, error) {
+	row, err := s.q.GetProjectByPathAndUser(ctx, pgdb.GetProjectByPathAndUserParams{Path: path, UserID: userID})
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("project not found: %s", path)
+		}
+		return nil, fmt.Errorf("failed to get project by path and user: %w", err)
+	}
+	return projectFromPG(row), nil
+}
+
 func (s *projectStore) GetProjectWithUserCheck(ctx context.Context, id string, userID string) (*core.Project, error) {
 	row, err := s.q.GetProjectWithUserCheck(ctx, pgdb.GetProjectWithUserCheckParams{ID: id, UserID: userID})
 	if err != nil {

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -74,6 +74,7 @@ type Repository interface {
 	CreateProject(ctx context.Context, project *Project) error
 	GetProject(ctx context.Context, id string) (*Project, error)
 	GetProjectByPath(ctx context.Context, path string) (*Project, error)
+	GetProjectByPathAndUser(ctx context.Context, path, userID string) (*Project, error)
 	GetProjectWithUserCheck(ctx context.Context, id string, userID string) (*Project, error)
 	ListProjects(ctx context.Context, filters ProjectFilters) ([]*Project, error)
 	UpdateProject(ctx context.Context, project *Project, userID string) error

--- a/internal/db/repository_impl.go
+++ b/internal/db/repository_impl.go
@@ -828,6 +828,17 @@ func (r *Repo) GetProjectByPath(ctx context.Context, path string) (*Project, err
 	return r.projects.GetProjectByPath(ctx, path)
 }
 
+func (r *Repo) GetProjectByPathAndUser(ctx context.Context, path, userID string) (*Project, error) {
+	if path == "" {
+		return nil, fmt.Errorf("project path cannot be empty")
+	}
+	if userID == "" {
+		return nil, fmt.Errorf("user ID cannot be empty")
+	}
+
+	return r.projects.GetProjectByPathAndUser(ctx, path, userID)
+}
+
 func (r *Repo) GetProjectWithUserCheck(ctx context.Context, id string, userID string) (*Project, error) {
 	if id == "" {
 		return nil, fmt.Errorf("project ID cannot be empty")

--- a/internal/db/sqlite/project_worktree_store.go
+++ b/internal/db/sqlite/project_worktree_store.go
@@ -42,6 +42,17 @@ func (s *projectStore) GetProjectByPath(ctx context.Context, path string) (*core
 	return projectFromSQLc(sqlcProject), nil
 }
 
+func (s *projectStore) GetProjectByPathAndUser(ctx context.Context, path, userID string) (*core.Project, error) {
+	sqlcProject, err := s.q.GetProjectByPathAndUser(ctx, sqlitedb.GetProjectByPathAndUserParams{Path: path, UserID: userID})
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("project not found: %s", path)
+		}
+		return nil, fmt.Errorf("failed to get project by path and user: %w", err)
+	}
+	return projectFromSQLc(sqlcProject), nil
+}
+
 func (s *projectStore) GetProjectWithUserCheck(ctx context.Context, id string, userID string) (*core.Project, error) {
 	sqlcProject, err := s.q.GetProjectWithUserCheck(ctx, sqlitedb.GetProjectWithUserCheckParams{ID: id, UserID: userID})
 	if err != nil {

--- a/internal/grpc/services/project.go
+++ b/internal/grpc/services/project.go
@@ -154,9 +154,10 @@ func (s *ProjectService) CreateProject(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("project path must be absolute, got: %q", req.Msg.Path))
 	}
 
-	// Check if project already exists for this user and path
-	existingProject, err := s.database.GetProjectByPath(ctx, req.Msg.Path)
-	if err == nil && existingProject != nil && existingProject.UserID == userID {
+	// Check if project already exists for this user and path. Path-only
+	// lookups are nondeterministic in multi-user setups (the projects table
+	// allows the same path under different user_ids), so scope the check.
+	if existing, err := s.database.GetProjectByPathAndUser(ctx, req.Msg.Path, userID); err == nil && existing != nil {
 		return nil, connect.NewError(connect.CodeAlreadyExists, fmt.Errorf("a project already exists at this path"))
 	}
 
@@ -199,6 +200,14 @@ func (s *ProjectService) CreateProject(
 	}
 
 	if err := s.database.CreateProject(ctx, project); err != nil {
+		// Race-window safety: if a concurrent request inserted the same
+		// (user_id, path) pair after our check above, the DB rejects with a
+		// UNIQUE violation. Surface that as AlreadyExists so the client can
+		// open the existing project instead of seeing an opaque Internal.
+		if strings.Contains(err.Error(), "UNIQUE constraint") || strings.Contains(err.Error(), "duplicate key") {
+			logging.Info("Project already exists at path (unique constraint)", "userID", userID, "path", req.Msg.Path)
+			return nil, connect.NewError(connect.CodeAlreadyExists, fmt.Errorf("a project already exists at this path"))
+		}
 		logging.Error("Failed to create project", "error", err)
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to create project"))
 	}

--- a/internal/grpc/services/worktree.go
+++ b/internal/grpc/services/worktree.go
@@ -20,6 +20,7 @@ import (
 	"github.com/reliant-labs/reliant/internal/gen/reliant/v1/reliantv1connect"
 	"github.com/reliant-labs/reliant/internal/logging"
 	"github.com/reliant-labs/reliant/internal/toolexec"
+	"github.com/reliant-labs/reliant/internal/worktreepath"
 )
 
 const worktreeDaemonCommandTimeoutMs int32 = 120_000
@@ -293,7 +294,10 @@ func (s *WorktreeService) CreateWorktree(
 		}
 	}
 
-	workspaceID := uuid.New().String()
+	// Build a human-readable workspace directory name (e.g.
+	// `myproject/feature-branch-a3f1b2c8`) instead of a bare UUID. Disk path
+	// becomes <HOME>/.reliant/worktrees/<workspaceID>[/<sub_path>].
+	workspaceID := worktreepath.WorkspaceDirName(project.Name, req.Msg.Name)
 
 	type repoCreateResult struct {
 		repo         *core.Repo

--- a/internal/workflow/runtime/activities/handlers/worktree.go
+++ b/internal/workflow/runtime/activities/handlers/worktree.go
@@ -18,6 +18,7 @@ import (
 	"github.com/reliant-labs/reliant/internal/toolexec"
 	"github.com/reliant-labs/reliant/internal/workflow/model"
 	"github.com/reliant-labs/reliant/internal/workflow/runtime/schema"
+	"github.com/reliant-labs/reliant/internal/worktreepath"
 )
 
 const worktreeCreateDaemonTimeoutMs int32 = 120_000
@@ -131,7 +132,10 @@ func (a *CreateWorktreeActivity) Execute(ctx context.Context, input ActivityInpu
 		branch = fmt.Sprintf("worktree/%s-%d", name, time.Now().Unix())
 	}
 
-	workspaceID := uuid.New().String()
+	// Human-readable workspace dir name; matches the convention used by the
+	// CreateWorktree gRPC handler so disk paths look the same regardless of
+	// where the worktree was kicked off.
+	workspaceID := worktreepath.WorkspaceDirName(project.Name, name)
 
 	type repoCreateResult struct {
 		repo         *core.Repo

--- a/internal/worktreepath/dirname.go
+++ b/internal/worktreepath/dirname.go
@@ -1,0 +1,46 @@
+// Package worktreepath builds filesystem-friendly directory names for
+// worktree workspaces. The chosen path becomes part of the absolute path
+// the user sees on disk, so it should be readable, scoped by project,
+// and disambiguated against orphans from previously-deleted worktrees.
+package worktreepath
+
+import (
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const maxSlugLen = 40
+
+var nonSlugRE = regexp.MustCompile(`[^a-z0-9]+`)
+
+// WorkspaceDirName returns the directory segment placed under
+// `<HOME>/.reliant/worktrees/` for a new worktree workspace:
+//
+//	<project-slug>/<worktree-slug>-<short-id>
+//
+// The 8-char short-id keeps the path unique even if the user reuses a
+// worktree name after deleting an old one whose directory wasn't cleaned.
+func WorkspaceDirName(projectName, worktreeName string) string {
+	proj := slug(projectName)
+	if proj == "" {
+		proj = "workspace"
+	}
+	wt := slug(worktreeName)
+	if wt == "" {
+		wt = "worktree"
+	}
+	short := strings.SplitN(uuid.New().String(), "-", 2)[0]
+	return path.Join(proj, wt+"-"+short)
+}
+
+func slug(name string) string {
+	s := nonSlugRE.ReplaceAllString(strings.ToLower(strings.TrimSpace(name)), "-")
+	s = strings.Trim(s, "-")
+	if len(s) > maxSlugLen {
+		s = strings.Trim(s[:maxSlugLen], "-")
+	}
+	return s
+}

--- a/internal/worktreepath/dirname_test.go
+++ b/internal/worktreepath/dirname_test.go
@@ -1,0 +1,70 @@
+package worktreepath
+
+import (
+	"path"
+	"strings"
+	"testing"
+)
+
+func TestSlug(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"  ", ""},
+		{"My Project", "my-project"},
+		{"Hello, World!", "hello-world"},
+		{"___foo___bar___", "foo-bar"},
+		{"already-fine", "already-fine"},
+		{"Über cool", "ber-cool"}, // non-ASCII collapsed to a separator
+		{strings.Repeat("a", 100), strings.Repeat("a", 40)},
+	}
+	for _, tc := range cases {
+		if got := slug(tc.in); got != tc.want {
+			t.Errorf("slug(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestWorkspaceDirName(t *testing.T) {
+	dir := WorkspaceDirName("My Project", "feature/login-flow")
+	parts := strings.Split(dir, "/")
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 path segments, got %q", dir)
+	}
+	if parts[0] != "my-project" {
+		t.Errorf("project segment = %q, want %q", parts[0], "my-project")
+	}
+	// worktree segment is `<slug>-<8-char-hex>`. Don't pin the suffix; just
+	// confirm the name slug is the prefix and there's a trailing disambiguator.
+	if !strings.HasPrefix(parts[1], "feature-login-flow-") {
+		t.Errorf("worktree segment = %q, want prefix %q", parts[1], "feature-login-flow-")
+	}
+	if len(parts[1]) <= len("feature-login-flow-") {
+		t.Errorf("worktree segment %q is missing a unique suffix", parts[1])
+	}
+}
+
+func TestWorkspaceDirName_EmptyInputsFallBack(t *testing.T) {
+	dir := WorkspaceDirName("", "")
+	if !strings.HasPrefix(dir, "workspace"+string('/')+"worktree-") {
+		t.Errorf("dir for empty inputs = %q, want fallback %q", dir, "workspace/worktree-…")
+	}
+}
+
+func TestWorkspaceDirName_Unique(t *testing.T) {
+	a := WorkspaceDirName("p", "wt")
+	b := WorkspaceDirName("p", "wt")
+	if a == b {
+		t.Errorf("expected unique paths, got %q twice", a)
+	}
+}
+
+// path.Join sanity: none of the slug results should escape the base dir.
+func TestWorkspaceDirName_NoTraversal(t *testing.T) {
+	dir := WorkspaceDirName("../etc", "../../passwd")
+	clean := path.Clean(dir)
+	if strings.HasPrefix(clean, "..") || strings.HasPrefix(clean, "/") {
+		t.Errorf("dir %q escapes the worktree base", clean)
+	}
+}

--- a/web/src/store/projectStore.ts
+++ b/web/src/store/projectStore.ts
@@ -1,5 +1,6 @@
 import { logger } from "../lib/logger";
 import { create } from "zustand";
+import { ConnectError, Code } from "@connectrpc/connect";
 
 import { projectGrpc, type Project as GrpcProject } from "../api/project-grpc";
 import { toast } from "../lib/toast-manager";
@@ -276,7 +277,14 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
         error: errorMessage,
         isLoading: false,
       });
-      // Error toast will be shown by error handler
+      // Surface unexpected failures as a toast so the user sees something.
+      // AlreadyExists is a normal "open existing project" path that callers
+      // handle themselves — don't double-notify there.
+      const isAlreadyExists =
+        error instanceof ConnectError && error.code === Code.AlreadyExists;
+      if (!isAlreadyExists) {
+        toast.error(error);
+      }
       throw error;
     }
   },


### PR DESCRIPTION
## Description

improve multi worktree naming
## Type of Change

<!-- Add the appropriate label to this PR -->

- [ ] 🚀 Feature (`changelog:feature`)
- [ ] 🐛 Bug fix (`changelog:fix`)
- [ ] ⚡ Performance (`changelog:perf`)
- [ ] 📚 Documentation (`changelog:docs`)
- [ ] 🔧 Improvement/Refactor (`changelog:improvement`)
- [ ] ⚠️ Breaking change (`changelog:breaking`)
- [ ] 🔒 Security (`changelog:security`)
- [ ] 🏗️ Infrastructure/CI (`changelog:infra`)
- [ ] 🚫 Skip changelog (`changelog:skip`)

## Changelog Entry

<!-- 
If this PR should appear in the changelog, write a user-friendly description.
This will be used in release notes.

Example: "Added support for custom MCP servers with environment variable substitution"

Leave blank if using changelog:skip label.
-->

## Testing

<!-- How was this tested? -->

## Screenshots

<!-- If applicable, add screenshots -->
