### PR TITLE
chore: bump forge to v0.0.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,8 +28,8 @@ require (
 	github.com/pdfcpu/pdfcpu v0.13.0
 	github.com/pressly/goose/v3 v3.25.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/reliant-labs/forge v0.0.7
-	github.com/reliant-labs/forge/pkg v0.0.7
+	github.com/reliant-labs/forge v0.0.8
+	github.com/reliant-labs/forge/pkg v0.0.8
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/sqlc-dev/pqtype v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -535,10 +535,14 @@ github.com/reliant-labs/forge v0.0.6 h1:mVRmuSm6D7bikE/Iqs2IcwAaXuSIMyEVJ6GNZv2F
 github.com/reliant-labs/forge v0.0.6/go.mod h1:75fduMaWa7N0tm9T4inY+0pYLqnvv9BMyaBxcn6J81w=
 github.com/reliant-labs/forge v0.0.7 h1:A1Cp1nXYfw5QvofBEoYTEEzkx/mI5diKUBVb4/6u1C0=
 github.com/reliant-labs/forge v0.0.7/go.mod h1:75fduMaWa7N0tm9T4inY+0pYLqnvv9BMyaBxcn6J81w=
+github.com/reliant-labs/forge v0.0.8 h1:GJbGdzLNW/A/Hc1GkLHhhyjm0usLUJp2DB/2lCNkAXE=
+github.com/reliant-labs/forge v0.0.8/go.mod h1:kXi7EgF8l05ZyyMEgShIZqlw12niCRVemT023RSg4qs=
 github.com/reliant-labs/forge/pkg v0.0.6 h1:on8O9LaGLzYTFNAfkMNohcQi9IhXrVGxeqFP1qXZ2Sg=
 github.com/reliant-labs/forge/pkg v0.0.6/go.mod h1:kbtwm4RMa5DTrbB/6TsgtKZoEsSc9Xc4+0nwXB5LTP0=
 github.com/reliant-labs/forge/pkg v0.0.7 h1:Gowl4rbC7BxdmtcZ9LJbgnr+YFyA5L8ODuTAdkoYBLA=
 github.com/reliant-labs/forge/pkg v0.0.7/go.mod h1:yVuNEMU2atdN1obN85YE/Qgv9lBY4m4l8JiCwtNxCRM=
+github.com/reliant-labs/forge/pkg v0.0.8 h1:8emTN9TiJu/svf5zDx6kDb/NgdJTWDTNBGkWbE1dFXI=
+github.com/reliant-labs/forge/pkg v0.0.8/go.mod h1:yVuNEMU2atdN1obN85YE/Qgv9lBY4m4l8JiCwtNxCRM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
Bumps both forge modules to `v0.0.8`.

Picks up the publishable `@reliantlabs/forge-web-runtime` rename (the old `@reliant-labs/web-runtime` scope was never published, so scaffolded frontends declared a dependency npm could not resolve), the CI license gate, and `forge env up --target` scoping the whole run rather than just the host and frontend phases.

`v0.0.8` is also the first root tag in a while whose go.mod requires the matching `forge/pkg` — `v0.0.7` shipped requiring `pkg v0.0.6`, so consumers pinned to it resolved a stale runtime library.

## Verification

`GOWORK=off go build ./...` passes against the published `v0.0.8` modules. The diff is the version bump and its go.sum entries; nothing else moved.