### PR TITLE
ci: authenticate to Artifact Registry before building the Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,7 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  id-token: write
 
 env:
   REGISTRY: ghcr.io
@@ -30,6 +31,23 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      # The Dockerfile's base images come from the private Artifact Registry
+      # mirror, so the build needs a GCP token as well as the GHCR one.
+      - name: Authenticate to GCP
+        id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER_NONPROD }}
+          service_account: ${{ secrets.WIF_SA_NONPROD }}
+          token_format: access_token
+
+      - name: Log in to Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: us-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
 
       - name: Extract metadata
         id: meta


### PR DESCRIPTION
## The failure

Every run of `Build & Push Docker Image` fails with a 403 pulling the base images.

`Dockerfile` lines 17 and 46 pull from the private Artifact Registry mirror `us-docker.pkg.dev/reliant-nonprod-490701/dockerhub/library/...`, but `docker.yml` only ran `docker/login-action` against GHCR. There was no GCP credential in the job at all, so the base-image pull was unauthenticated.

This is CI-only, which is why it went unnoticed: the same `docker pull ...debian@sha256:...` **succeeds on a developer machine**, because gcloud application-default credentials are already present there.

## The fix

Authenticate to GCP via Workload Identity Federation and log Docker in to `us-docker.pkg.dev` with the resulting short-lived access token, before the build step.

No new infrastructure was needed:

- The `github-actions` Workload Identity pool and its `github` provider already exist in `reliant-nonprod-490701`, and the provider's attribute condition is `assertion.repository_owner == 'reliant-labs'` — it already trusts this repo.
- The `github-actions@` service account already holds `roles/artifactregistry.writer`, which subsumes the reader access the pull needs.

Two things were changed outside this diff:

1. The service account's `roles/iam.workloadIdentityUser` binding previously listed only `reliant-labs/control-plane`; `reliant-labs/reliant` was added alongside it.
2. Repo secrets `WIF_PROVIDER_NONPROD` and `WIF_SA_NONPROD` were set, mirroring the names control-plane already uses.

`id-token: write` is added to the job permissions because WIF requires the OIDC token.

No long-lived service-account key is involved. The alternative — minting a JSON key as `GCP_SA_KEY` — was rejected since the federation path was already fully provisioned.

## Verification

Merging exercises this: `docker.yml` triggers on push to `main`, and the base-image pull is the step that currently 403s. YAML parses and step ordering is confirmed (auth precedes build). The credential path itself is the same one control-plane's `db-snapshot.yml` uses today.

Note this is one of two unrelated pre-existing CI failures; the other is `check-migrations.yml` failing because `internal/db/postgres/generated` is gitignored, so the drift-guard test cannot compile. That one is untouched here.
