### PR TITLE
ci: generate sqlc code before the schema drift guard

### DIFF
--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -161,6 +161,13 @@ jobs:
         run: |
           goose -dir internal/db/migrations/postgres postgres "$DATABASE_URL" up
 
+      # internal/db imports the sqlc output under internal/db/postgres/generated,
+      # which is generated rather than committed. Without this the drift guard
+      # below fails to compile and the job reports a failure that has nothing to
+      # do with the migrations it is checking.
+      - name: Generate sqlc code
+        run: make sqlc
+
       - name: Validate schema.sql agrees with the migrations
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/reliant_ci?sslmode=disable


### PR DESCRIPTION
## The failure

`Migration & DB Schema Check` has failed on every run since #138, including on `main`. The failing step is `Validate schema.sql agrees with the migrations`:

```
internal/db/postgres/agent_message_store.go:13:2: no required module provides package
    github.com/reliant-labs/reliant/internal/db/postgres/generated
FAIL	github.com/reliant-labs/reliant/internal/db [setup failed]
##[error]TestSchemaSQLMatchesMigrations did not run — the drift guard verified nothing
```

`internal/db` imports the sqlc output at `internal/db/postgres/generated`, which is generated rather than committed (`.gitignore` line 278's `generated/` matches it, the same way line 287 explicitly ignores the sqlite equivalent). This workflow never generated it, so the test binary could not compile.

Worth noting the failure mode was benign: the job's own assertion that the guards actually ran is what turned the compile error into a red build instead of a silent green one. That check did its job.

The `Backend (Go)` job doesn't hit this because it runs `make generate-go`, which includes `sqlc`.

## The fix

Run `make sqlc` before the drift guard. `sqlc` reads `schema.sql` and `queries/`, so it needs neither buf nor proto — the whole `generate-go` chain would be wasted time here.

The generated directory stays gitignored. Committing sqlc output to satisfy a compile step would create exactly the drift this workflow exists to catch.

## Verification

Reproduced and fixed locally against a clean worktree checked out from `origin/main`, mirroring the CI steps:

1. Fresh worktree — `internal/db/postgres/generated` absent, `go build ./internal/db/` fails as in CI.
2. `make sqlc` — regenerates the package on its own.
3. `go build ./internal/db/` — exit 0.
4. `goose -dir internal/db/migrations/postgres postgres "$DATABASE_URL" up` against a throwaway Postgres 16 container, then the exact test command:

```
--- PASS: TestSchemaSQLMatchesMigrations (1.19s)
--- PASS: TestSchemaSQLColumnsMatchMigrations (0.45s)
ok  	github.com/reliant-labs/reliant/internal/db	2.005s
```

Both guards run and pass, so the job's `grep -q -- "--- PASS: $t"` assertions are satisfied. The throwaway container was removed by name afterward.

Note this workflow only triggers on changes to `internal/db/migrations/**`, `schema.sql`, `scripts/check-migrations.sh`, or `sqlc.yaml` — this PR touches none of them, so the job will not run here. It will exercise on the next migration change.

This is unrelated to the Artifact Registry 403 fixed in #148; they were the two independent pre-existing CI failures.
