### PR TITLE
fix(e2e): pass the daemonRouter argument to NewChatService

### DIFF
--- a/e2e/stories/harness_test.go
+++ b/e2e/stories/harness_test.go
@@ -230,7 +230,10 @@ func newHarness(t *testing.T, llmScript *ScriptedLLM, opts ...HarnessOption) *Ha
 	waitForWorkerPollers(t, s.Temporal, workersetup.TaskQueueName(taskQueueSuffix))
 
 	pause := workflow.NewPauseService(s.Temporal, s.Repo)
-	chatSvc := services.NewChatService(s.Repo, s.Temporal, pause, workersetup.TaskQueueName(taskQueueSuffix), hub)
+	// nil daemonRouter: these stories run without a daemon, and the router is
+	// only used for the greenfield code-presence probe, which skips itself when
+	// it is nil.
+	chatSvc := services.NewChatService(s.Repo, s.Temporal, pause, workersetup.TaskQueueName(taskQueueSuffix), hub, nil)
 	questionSvc := services.NewQuestionService(s.Repo, pause)
 
 	return &Harness{


### PR DESCRIPTION
## The failure

`E2E Backend (Go)` fails on every PR, including ones that change nothing but a version string:

```
e2e/stories/harness_test.go:233:108: not enough arguments in call to services.NewChatService
FAIL	github.com/reliant-labs/reliant/e2e/stories [build failed]
```

#142 added a `daemonRouter toolexec.DaemonRouter` parameter to `NewChatService` and updated the production wiring, but not the e2e story harness — the only other caller. The package has not compiled since.

## The fix

Pass `nil`.

That is the correct value rather than a convenient one. `daemonRouter` reaches the user's filesystem, which these stories do not have — they run without a daemon. Its only use on the chat path is the greenfield code-presence probe, and the field is documented as optional:

```go
// daemonRouter reaches the user's filesystem, which the api-server cannot
// see itself. Used to probe a project for existing code when a chat opens
// (see chat_greenfield.go). Optional: nil means the probe is skipped.
```

Both entry points in `chat_greenfield.go` open with `if s == nil || s.daemonRouter == nil || chat == nil { return nil }`, so a nil router skips the probe rather than panicking. Constructing a stub router would add a mock that asserts nothing.

## Verification

Reproduced and fixed in a clean worktree off `origin/main`, running the compile gate both ways:

Before (reverting just this line):
```
vet: e2e/stories/harness_test.go:233:111: not enough arguments in call to services.NewChatService
	have (*db.Repo, client.Client, *workflow.PauseService, string, noopStreamingHub)
	want (db.Repository, client.Client, *workflow.PauseService, string, streaming.StreamingHub, toolexec.DaemonRouter)
```

After:
```
go vet -tags e2e ./e2e/stories/   # exit 0
```

This is the compile error CI hits, so `go vet -tags e2e` is the gate that was failing.

## Still red after this

`Backend (Go)` fails separately on `TestHookTimeoutDoesNotHangFollow` in `internal/execfollow`, which times out at exactly 30s. Also pre-existing and unrelated to this change; I'm looking at it next and it is not fixed here.

Together with #148 (Artifact Registry 403) and #149 (sqlc generation for the drift guard), this is the third of four independent pre-existing CI failures.
