### PR TITLE
fix(execfollow): bound Wait so a backgrounded hook child cannot stall follow

### DIFF
--- a/internal/execfollow/hook.go
+++ b/internal/execfollow/hook.go
@@ -16,6 +16,12 @@ import (
 // never stall the follow stream.
 const DefaultHookTimeout = 60 * time.Second
 
+// hookWaitDelay bounds how long Wait may block after the timeout fires, for
+// output pipes still held open by processes the hook left behind. Generous
+// enough that a hook writing its last diagnostics is not truncated, short
+// enough that the follow stream keeps moving.
+const hookWaitDelay = 2 * time.Second
+
 // HookRunner executes hooks via `sh -c` with the event JSON on stdin and
 // RELIANT_EVENT_* environment variables. Hook failures are logged to Stderr
 // and never propagate — a broken hook must not kill the follow.
@@ -64,6 +70,13 @@ func (r *HookRunner) runOne(ctx context.Context, h Hook, ev Event, evJSON []byte
 	cmd.Stdout = r.stderr() // hook output is diagnostics; keep stdout NDJSON-clean
 	cmd.Stderr = r.stderr()
 	cmd.Env = append(os.Environ(), hookEnv(ev)...)
+	// Killing the shell on timeout is not enough to unblock Wait. Stdout and
+	// Stderr are not *os.File, so exec copies them through a pipe, and Wait
+	// blocks until every writer closes it — including a grandchild the hook
+	// backgrounded, which outlives the shell and inherits the write end. A
+	// hook ending in `&` would otherwise hold the follow stream for as long
+	// as that process lives, defeating the timeout entirely.
+	cmd.WaitDelay = hookWaitDelay
 
 	if err := cmd.Run(); err != nil {
 		fmt.Fprintf(r.stderr(), "reliant: hook failed (on=%s cmd=%q): %v\n", h.On, h.Cmd, err)

--- a/internal/execfollow/hook_test.go
+++ b/internal/execfollow/hook_test.go
@@ -147,3 +147,31 @@ func TestHookTimeoutDoesNotHangFollow(t *testing.T) {
 		t.Errorf("expected timeout to be logged as failure, got: %s", stderr.String())
 	}
 }
+
+// Killing the shell does not release the output pipe: a process the hook
+// backgrounded inherits the write end and keeps Wait blocked for as long as it
+// runs, so the timeout above can be honored and the follow still stall.
+//
+// `sleep 30` alone does not prove this. Many shells exec a lone command,
+// leaving no grandchild to hold the pipe, so the case passes or hangs
+// depending on which shell ran it — which is why the plain version passed on
+// macOS and hung for the full 30s in CI. Backgrounding forces the fork
+// unconditionally.
+func TestHookTimeoutWithBackgroundedChildDoesNotHangFollow(t *testing.T) {
+	ev := sampleEvent()
+	evJSON, _ := marshalEvent(ev)
+
+	var stderr bytes.Buffer
+	runner := &HookRunner{Stderr: &stderr, Timeout: 200 * time.Millisecond}
+
+	start := time.Now()
+	runner.Run(context.Background(), []Hook{{On: "any", Cmd: "sleep 30 & wait"}}, ev, evJSON)
+	elapsed := time.Since(start)
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("hook run took %v — a backgrounded child held the output pipe past the timeout", elapsed)
+	}
+	if !strings.Contains(stderr.String(), "hook failed") {
+		t.Errorf("expected timeout to be logged as failure, got: %s", stderr.String())
+	}
+}


### PR DESCRIPTION
## The failure

`Backend (Go)` fails on every PR — including ones that change only a version string — on a single test:

```
--- FAIL: TestHookTimeoutDoesNotHangFollow (30.00s)
FAIL	github.com/reliant-labs/reliant/internal/execfollow	30.155s
```

The test sets a 200ms hook timeout, runs `sleep 30`, and asserts the call returns in under 5s. It takes the full 30s in CI and passes in 0.2s locally.

## The bug is real, not just a flaky test

`HookRunner.runOne` kills the shell when the context expires, but that does not unblock `cmd.Run()`.

`Stdout` and `Stderr` are set to `r.stderr()`, an `io.Writer` rather than an `*os.File`. `os/exec` therefore copies output through a pipe, and `Wait` blocks until every writer closes the write end — including any process the hook backgrounded, which outlives the shell and inherits that descriptor.

So a hook ending in `&` holds the follow stream open for as long as its child lives, no matter what timeout is configured. The timeout appears to be honored (the shell dies on schedule) while the stream stalls anyway. That is a production defect in the follow path, and the test was reporting it accurately.

The fix is `cmd.WaitDelay`, which is precisely the knob for bounding this post-kill copy. Two seconds: long enough not to truncate a hook writing final diagnostics, short enough to keep the stream moving.

## Why it passed locally and failed in CI

`sleep 30` on its own does not reliably reproduce it. Many shells `exec` a lone command rather than forking, leaving no grandchild to hold the pipe — so the outcome depends on which `/bin/sh` ran the test. It execs on macOS (passes in 0.2s) and forks under CI's `sh` (hangs 30s).

Rather than rely on that, I added `TestHookTimeoutWithBackgroundedChildDoesNotHangFollow`, which uses `sleep 30 & wait` to force the fork on every platform. The original test is kept — it still covers the ordinary path.

## Verification

The new test was confirmed to fail before the fix and pass after, by reverting only the `cmd.WaitDelay` line:

Without it:
```
--- FAIL: TestHookTimeoutWithBackgroundedChildDoesNotHangFollow (30.02s)
    hook_test.go:172: hook run took 30.017040667s — a backgrounded child held the output pipe past the timeout
```

With it, the full package, including under `-race`:
```
--- PASS: TestHookTimeoutDoesNotHangFollow (0.21s)
--- PASS: TestHookTimeoutWithBackgroundedChildDoesNotHangFollow (2.20s)
ok  	github.com/reliant-labs/reliant/internal/execfollow	2.826s
ok  	github.com/reliant-labs/reliant/internal/execfollow	8.709s   (-race)
```

The 2.20s is the `WaitDelay` ceiling doing its job.

This is the last of four independent pre-existing CI failures, alongside #148 (Artifact Registry 403), #149 (sqlc for the drift guard), and #151 (e2e harness compile).
