### PR TITLE
test(websearch): gate the live-network demo test behind an opt-in

### DIFF
--- a/internal/llm/tools/websearch_demo_test.go
+++ b/internal/llm/tools/websearch_demo_test.go
@@ -4,6 +4,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
@@ -12,10 +13,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestWebSearchDemo demonstrates the web search tool with actual output
+// TestWebSearchDemo demonstrates the web search tool with actual output.
+//
+// This queries the live DuckDuckGo endpoint, so it is gated behind an explicit
+// opt-in rather than run by default. DuckDuckGo answers a share of automated
+// requests with a bot challenge — CI saw `status 202` on one query while the
+// other two in this same test succeeded — which fails the run for a reason
+// that has nothing to do with the change under test.
+//
+// Nothing is lost by gating it. The parsing, formatting, metadata and count
+// limits are all covered offline in websearch_mock_test.go; what only this
+// test can tell you is whether the live endpoint still answers us, and that is
+// a question about DuckDuckGo rather than about a pull request.
+//
+//	RELIANT_TEST_NETWORK=1 go test ./internal/llm/tools/ -run TestWebSearchDemo
 func TestWebSearchDemo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping demo test in short mode")
+	}
+	if os.Getenv("RELIANT_TEST_NETWORK") == "" {
+		t.Skip("Skipping live-network test; set RELIANT_TEST_NETWORK=1 to run")
 	}
 
 	tool := NewWebSearchTool()


### PR DESCRIPTION
## The failure

`Backend (Go)` fails intermittently on `TestWebSearchDemo`:

```
--- FAIL: TestWebSearchDemo/SearchForGoTesting (0.12s)
    Error:      Received unexpected error:
                search failed: search failed with status 202: <!DOCTYPE html> ... DuckDuckGo ...
    Messages:   Search should not return an error
```

The test queries the live DuckDuckGo endpoint (`websearch.go:215`) from the default unit-test lane. HTTP 202 with an HTML body is DuckDuckGo's bot challenge, not a search result.

The other two subtests in that same run passed, which is what makes this throttling rather than a broken tool — the same code path succeeded twice in the same second.

## The fix

Skip unless `RELIANT_TEST_NETWORK` is set.

Gating rather than deleting, because the test is worth keeping — it is the only thing that would catch DuckDuckGo changing its HTML shape out from under the parser. It just should not be able to fail an unrelated PR.

Nothing is lost from the default lane. `websearch_mock_test.go` already covers URL extraction, result formatting, empty results, metadata and count limits, all offline. What only this test proves is that the live endpoint still answers us, which is a question about DuckDuckGo rather than about a pull request.

## Verification

Both directions, locally:

Default lane (what CI runs):
```
--- SKIP: TestWebSearchDemo (0.00s)
ok  	github.com/reliant-labs/reliant/internal/llm/tools	0.447s
```

Opted in, still exercising the real endpoint:
```
RELIANT_TEST_NETWORK=1 go test ./internal/llm/tools/ -run TestWebSearchDemo
--- PASS: TestWebSearchDemo (2.08s)
    --- PASS: TestWebSearchDemo/SearchForGoTesting (0.81s)
    --- PASS: TestWebSearchDemo/SearchWithSiteFilter (0.60s)
    --- PASS: TestWebSearchDemo/SearchForErrorMessage (0.67s)
```

Whole package green: `ok github.com/reliant-labs/reliant/internal/llm/tools 7.782s`.

This is the fifth and last of the independent pre-existing CI failures, with #148 (Artifact Registry 403), #149 (sqlc for the drift guard), #151 (e2e harness compile) and #152 (hook WaitDelay).
