### PR TITLE
chore: bump forge to v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,8 +28,8 @@ require (
 	github.com/pdfcpu/pdfcpu v0.13.0
 	github.com/pressly/goose/v3 v3.25.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/reliant-labs/forge v0.0.8
-	github.com/reliant-labs/forge/pkg v0.0.8
+	github.com/reliant-labs/forge v0.1.0
+	github.com/reliant-labs/forge/pkg v0.1.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/sqlc-dev/pqtype v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -537,12 +537,16 @@ github.com/reliant-labs/forge v0.0.7 h1:A1Cp1nXYfw5QvofBEoYTEEzkx/mI5diKUBVb4/6u
 github.com/reliant-labs/forge v0.0.7/go.mod h1:75fduMaWa7N0tm9T4inY+0pYLqnvv9BMyaBxcn6J81w=
 github.com/reliant-labs/forge v0.0.8 h1:GJbGdzLNW/A/Hc1GkLHhhyjm0usLUJp2DB/2lCNkAXE=
 github.com/reliant-labs/forge v0.0.8/go.mod h1:kXi7EgF8l05ZyyMEgShIZqlw12niCRVemT023RSg4qs=
+github.com/reliant-labs/forge v0.1.0 h1:sW+jWbHAtGiyE4OGXcylLNi3O/pI6ytMpwdw/AO7czU=
+github.com/reliant-labs/forge v0.1.0/go.mod h1:ObCxWQjRccCJaRSDhyZhRT4J1YNOM8RCzIYjxg2L+aw=
 github.com/reliant-labs/forge/pkg v0.0.6 h1:on8O9LaGLzYTFNAfkMNohcQi9IhXrVGxeqFP1qXZ2Sg=
 github.com/reliant-labs/forge/pkg v0.0.6/go.mod h1:kbtwm4RMa5DTrbB/6TsgtKZoEsSc9Xc4+0nwXB5LTP0=
 github.com/reliant-labs/forge/pkg v0.0.7 h1:Gowl4rbC7BxdmtcZ9LJbgnr+YFyA5L8ODuTAdkoYBLA=
 github.com/reliant-labs/forge/pkg v0.0.7/go.mod h1:yVuNEMU2atdN1obN85YE/Qgv9lBY4m4l8JiCwtNxCRM=
 github.com/reliant-labs/forge/pkg v0.0.8 h1:8emTN9TiJu/svf5zDx6kDb/NgdJTWDTNBGkWbE1dFXI=
 github.com/reliant-labs/forge/pkg v0.0.8/go.mod h1:yVuNEMU2atdN1obN85YE/Qgv9lBY4m4l8JiCwtNxCRM=
+github.com/reliant-labs/forge/pkg v0.1.0 h1:07GKMAixDSrN4vtQJ8pze1mP/hR1G8xSxrRV0n909Ow=
+github.com/reliant-labs/forge/pkg v0.1.0/go.mod h1:yVuNEMU2atdN1obN85YE/Qgv9lBY4m4l8JiCwtNxCRM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
Bumps both forge modules from v0.0.8 to [v0.1.0](https://github.com/reliant-labs/forge/releases/tag/v0.1.0) — the embedded CLI (`github.com/reliant-labs/forge`) and the runtime library (`forge/pkg`).

Picks up the `ScaffoldStub` sentinel that makes generated scaffold test rows falsifiable, target-scoped `forge env up`, and the npm license gate for the published web-runtime.

## What changed

`go.mod` and `go.sum` only — both modules move together, as forge releases them.

## What deliberately did not change

**CI needs no pin.** `.github/workflows/pr-ci.yml` installs `github.com/reliant-labs/forge/cmd/forge@latest`, not a version, so it picks up v0.1.0 on its own.

**No Dockerfile carries a forge version.** The managed workspace daemon image is this binary cross-compiled (control-plane's `docker/Dockerfile.reliant.dev` COPYs it), so its forge version flows transitively from this `go.mod`. control-plane's `workspace-base` image likewise shims `forge` to the embedded `reliant forge` rather than pinning its own copy.

## Testing

- `go build ./...` — clean.
- `go test` across every package that imports forge (`internal/grpc/...`, `internal/skills/...`, `internal/llm/tools/...`, `cmd/reliant/...`, `internal/buildmode/...`) — all pass.

Run in an isolated worktree off `origin/main`. Two notes on getting a trustworthy result there:

- `gen/` and `internal/db/postgres/generated/` are gitignored, so the worktree needed `buf generate` and `make sqlc` before it could build. Neither is part of this commit.
- `TestResolveServerPrecedence` and `TestResolveGatewayPrecedence` initially failed. That is **not** caused by this bump: `RELIANT_SERVER_URL` and `RELIANT_GATEWAY_URL` leak from the forge-hosted dev session into the test process. The same failures reproduce at v0.0.8 with the same generated code, and all tests pass at v0.1.0 once those two variables are unset. Worth knowing that these tests are sensitive to a developer's ambient env, but it is a separate issue from this PR.
