### PR TITLE
test(websearch): gate the live search in TestWebSearchTool too

### DIFF
--- a/internal/llm/tools/websearch_test.go
+++ b/internal/llm/tools/websearch_test.go
@@ -3,6 +3,7 @@ package tools
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/reliant-labs/reliant/internal/rctx"
@@ -32,10 +33,17 @@ func TestWebSearchTool(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, requiresPermission)
 
-	// Test actual search (this may fail if rate limited)
+	// Queries the live DuckDuckGo endpoint, so it is gated behind the same
+	// explicit opt-in as TestWebSearchDemo. A short-mode skip is not enough:
+	// CI runs the full suite, so this executed on every PR and failed on
+	// DuckDuckGo's bot challenge for reasons unrelated to the change under
+	// test. The offline coverage in websearch_mock_test.go is what actually
+	// pins parsing, formatting and count limits.
+	//
+	//	RELIANT_TEST_NETWORK=1 go test ./internal/llm/tools/ -run TestWebSearchTool
 	t.Run("ActualSearch", func(t *testing.T) {
-		if testing.Short() {
-			t.Skip("Skipping actual search in short mode")
+		if os.Getenv("RELIANT_TEST_NETWORK") == "" {
+			t.Skip("Skipping live-network test; set RELIANT_TEST_NETWORK=1 to run")
 		}
 
 		response, err := typedTool.tool.Execute(toolCtx, params)


### PR DESCRIPTION
**This is what has been failing the `Backend (Go)` check**, including on the v1.6.1 release PR (#160).

`TestWebSearchTool/ActualSearch` queries live DuckDuckGo behind only a `testing.Short()` skip. CI runs the full suite, not `-short`, so it executed on every PR and failed on DuckDuckGo's bot challenge — a 30s timeout for a reason unrelated to the change under test.

#159 gated `TestWebSearchDemo` for exactly this reason but missed its sibling in `websearch_test.go`. Same opt-in now applies:

```
RELIANT_TEST_NETWORK=1 go test ./internal/llm/tools/ -run TestWebSearchTool
```

Nothing is lost by gating it. `websearch_mock_test.go` covers parsing, formatting, metadata and count limits offline; what only the live call tells you is whether DuckDuckGo still answers us, which is a question about DuckDuckGo rather than about a pull request.

## Note on the other lint noise

The same job log shows ~168 `exportedvars`/`requirecontract` findings from `forge lint`. Those are **not** what fails the job — that step is `continue-on-error: true` and is tracked separately. The live network call is the actual failure.

## Testing

`go build ./...` clean, `go vet` clean, package tests pass, and `ActualSearch` now reports SKIP by default.