### PR TITLE
fix(docker): stamp the version into the container image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -72,6 +72,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Stamps internal/version so `reliant version` reports the release.
+          # Falls back to the ref name for branch builds.
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version || github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,17 @@ ENV GOWORK=off
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
+# VERSION stamps the binary so `reliant version` reports the release rather
+# than "unknown". The release workflow already injects internal/version for the
+# Electron-bundled binary; this image built without it, so every published
+# container reported an unknown version. Defaults to "dev" for a plain
+# `docker build` with no --build-arg.
+ARG VERSION=dev
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    CGO_ENABLED=0 GOARCH=${TARGETARCH} go build -o /reliant ./cmd/reliant/
+    CGO_ENABLED=0 GOARCH=${TARGETARCH} go build \
+      -ldflags "-X github.com/reliant-labs/reliant/internal/version.Version=${VERSION}" \
+      -o /reliant ./cmd/reliant/
 
 # ── Runtime ──────────────────────────────────────────────────────────────────
 # Runtime base is debian (glibc), NOT alpine (musl): since adopting the forge


### PR DESCRIPTION
Published container images report `reliant version unknown`.

The image build ran a plain `go build` with no ldflags, so `internal/version` kept its `dev`/`unknown` defaults. The release workflow stamps the binary it bundles into the Electron app, but nothing stamped the one that goes into the container.

Adds `ARG VERSION` (defaulting to `dev` for a bare `docker build`) and injects `internal/version.Version`, with the workflow passing the tag through `docker/metadata-action`'s version output.

**Verified end to end:** `docker build --build-arg VERSION=1.6.3` produces a binary that prints `reliant version 1.6.3`, where the currently-published `ghcr.io/reliant-labs/reliant:1.6.3` prints `unknown`.

Related: reliant#164 fixed the *other* half of this — the `version` command was reading package variables that nothing injected, so even a correctly-stamped binary reported `dev`. Both are needed for the version to be truthful.