### PR TITLE
fix: scope activity errors to their thread, fix composer streaming race

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -533,12 +533,8 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.1.0 h1:137FnGdk+EQdCbye1FW+qOEcY5S+SpY9T0NiuqvtfMY=
 github.com/redis/go-redis/v9 v9.1.0/go.mod h1:urWj3He21Dj5k4TK1y59xH8Uj6ATueP8AH1cY3lZl4c=
-github.com/reliant-labs/forge v0.0.8 h1:GJbGdzLNW/A/Hc1GkLHhhyjm0usLUJp2DB/2lCNkAXE=
-github.com/reliant-labs/forge v0.0.8/go.mod h1:kXi7EgF8l05ZyyMEgShIZqlw12niCRVemT023RSg4qs=
 github.com/reliant-labs/forge v0.1.0 h1:sW+jWbHAtGiyE4OGXcylLNi3O/pI6ytMpwdw/AO7czU=
 github.com/reliant-labs/forge v0.1.0/go.mod h1:ObCxWQjRccCJaRSDhyZhRT4J1YNOM8RCzIYjxg2L+aw=
-github.com/reliant-labs/forge/pkg v0.0.8 h1:8emTN9TiJu/svf5zDx6kDb/NgdJTWDTNBGkWbE1dFXI=
-github.com/reliant-labs/forge/pkg v0.0.8/go.mod h1:yVuNEMU2atdN1obN85YE/Qgv9lBY4m4l8JiCwtNxCRM=
 github.com/reliant-labs/forge/pkg v0.1.0 h1:07GKMAixDSrN4vtQJ8pze1mP/hR1G8xSxrRV0n909Ow=
 github.com/reliant-labs/forge/pkg v0.1.0/go.mod h1:yVuNEMU2atdN1obN85YE/Qgv9lBY4m4l8JiCwtNxCRM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/internal/workflow/runtime/registry.go
+++ b/internal/workflow/runtime/registry.go
@@ -835,6 +835,12 @@ func (w *ActivityWrapper[I, O]) writeErrorEvent(
 		"workflow_id":    workflowID,
 		"is_retrying":    isRetrying,
 	}
+	// Scope the error to the thread that produced it. Omitted entirely when
+	// the activity has no thread, so the timeline's "no thread means
+	// chat-scoped" branch still applies rather than matching on "".
+	if thread := extractThread(input); thread != "" {
+		errorData["thread"] = thread
+	}
 	if maxAttempts > 0 {
 		errorData["max_attempts"] = int(maxAttempts)
 	}
@@ -1053,6 +1059,64 @@ func extractChatID(input interface{}) string {
 				if chatIDVal := val.Field(i); chatIDVal.Kind() == reflect.String {
 					return chatIDVal.String()
 				}
+			}
+		}
+	}
+
+	return ""
+}
+
+// extractThread pulls the thread an activity was working on out of its input,
+// so the error event it produces can be scoped to that thread.
+//
+// Without it every activity error is chat-global, and the timeline shows it in
+// EVERY thread of the chat — including spawns that started long after the
+// error and never saw it. Observed: a run of DrainAgentMessages failures
+// rendered at the top of a spawn thread that did not exist when they happened.
+// InterleavedTimeline already scopes an error that carries a thread; nothing
+// was filling the field in.
+//
+// Returns "" when the input has no thread, which is the honest answer for a
+// genuinely chat-scoped activity. The timeline keeps showing those everywhere
+// rather than guessing a thread — guessing is what produced the wrong-thread
+// render to begin with.
+func extractThread(input interface{}) string {
+	if input == nil {
+		return ""
+	}
+
+	if inputMap, ok := input.(map[string]interface{}); ok {
+		if thread, ok := inputMap["thread"].(string); ok {
+			return thread
+		}
+	}
+
+	val := reflect.ValueOf(input)
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return ""
+		}
+		val = val.Elem()
+	}
+
+	if val.Kind() != reflect.Struct {
+		return ""
+	}
+
+	for i := 0; i < val.NumField(); i++ {
+		field := val.Type().Field(i)
+
+		if jsonTag := field.Tag.Get("json"); jsonTag != "" {
+			if strings.Split(jsonTag, ",")[0] == "thread" {
+				if threadVal := val.Field(i); threadVal.Kind() == reflect.String {
+					return threadVal.String()
+				}
+			}
+		}
+
+		if field.Name == "Thread" {
+			if threadVal := val.Field(i); threadVal.Kind() == reflect.String {
+				return threadVal.String()
 			}
 		}
 	}

--- a/internal/workflow/runtime/registry_error_thread_test.go
+++ b/internal/workflow/runtime/registry_error_thread_test.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2025 Reliant Labs
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/reliant-labs/reliant/internal/db"
+	"github.com/reliant-labs/reliant/internal/workflow/runtime/activities/types"
+)
+
+// capturingRepo records the chat_updates an activity error writes, so the test
+// asserts the PAYLOAD the frontend actually receives rather than just the
+// helper that feeds it.
+type capturingRepo struct {
+	db.Repository
+	updates []string
+}
+
+func (r *capturingRepo) CreateChatUpdate(_ context.Context, _ string, _ db.UpdateType, _ string, data string) error {
+	r.updates = append(r.updates, data)
+	return nil
+}
+
+// An activity error must name the thread it happened on.
+//
+// InterleavedTimeline scopes an error that carries a thread to that thread and
+// shows a thread-less one EVERYWHERE (it cannot guess, and guessing is what
+// produced a wrong-thread render before). Nothing was filling the field in, so
+// every activity error was chat-global in practice: a run of
+// DrainAgentMessages failures rendered at the top of a spawn thread that did
+// not exist when those failures happened.
+func TestExtractThread(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected string
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: "",
+		},
+		{
+			name:     "map with thread",
+			input:    map[string]interface{}{"chat_id": "chat-1", "thread": "thread-abc"},
+			expected: "thread-abc",
+		},
+		{
+			name:     "map without thread",
+			input:    map[string]interface{}{"chat_id": "chat-1"},
+			expected: "",
+		},
+		{
+			name: "struct with json tag thread",
+			input: struct {
+				ChatID string `json:"chat_id"`
+				Thread string `json:"thread"`
+			}{ChatID: "chat-2", Thread: "thread-json"},
+			expected: "thread-json",
+		},
+		{
+			name: "struct with Thread field name and no tag",
+			input: struct {
+				ChatID string
+				Thread string
+			}{ChatID: "chat-3", Thread: "thread-byname"},
+			expected: "thread-byname",
+		},
+		{
+			name: "pointer to struct",
+			input: &struct {
+				ChatID string `json:"chat_id"`
+				Thread string `json:"thread"`
+			}{ChatID: "chat-4", Thread: "thread-ptr"},
+			expected: "thread-ptr",
+		},
+		{
+			name: "omitempty tag still matches",
+			input: struct {
+				Thread string `json:"thread,omitempty"`
+			}{Thread: "thread-omitempty"},
+			expected: "thread-omitempty",
+		},
+		{
+			name: "chat-scoped activity reports no thread",
+			input: struct {
+				ChatID string `json:"chat_id"`
+			}{ChatID: "chat-5"},
+			expected: "",
+		},
+		{
+			// The real input behind the reported bug.
+			name: "DrainAgentMessagesInput carries its recipient thread",
+			input: types.DrainAgentMessagesInput{
+				ChatID: "chat-6",
+				Thread: "thread-recipient",
+			},
+			expected: "thread-recipient",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractThread(tt.input); got != tt.expected {
+				t.Errorf("extractThread() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+// The end-to-end assertion: the error event a failing activity writes must
+// carry the thread, because that is the field InterleavedTimeline filters on.
+// The helper test above can pass while the wiring is missing — which is
+// exactly the state that produced the reported bug.
+func TestWriteErrorEventCarriesThread(t *testing.T) {
+	repo := &capturingRepo{}
+	wrapper := NewActivityWrapper(
+		"DrainAgentMessages",
+		func(_ context.Context, _ types.DrainAgentMessagesInput) (types.DrainAgentMessagesOutput, error) {
+			return types.DrainAgentMessagesOutput{}, nil
+		},
+		repo,
+	)
+
+	wrapper.writeErrorEvent(
+		context.Background(),
+		types.DrainAgentMessagesInput{ChatID: "chat-1", Thread: "thread-recipient"},
+		"DrainAgentMessages",
+		"activity-1",
+		1,
+		"workflow-1",
+		errors.New("drain failed"),
+		3,
+	)
+
+	if len(repo.updates) != 1 {
+		t.Fatalf("expected 1 chat update, got %d", len(repo.updates))
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(repo.updates[0]), &payload); err != nil {
+		t.Fatalf("error payload is not valid JSON: %v", err)
+	}
+
+	thread, ok := payload["thread"].(string)
+	if !ok {
+		t.Fatalf("error event has no thread field; the timeline will render it "+
+			"in EVERY thread of the chat, including spawns that started after it. payload=%v", payload)
+	}
+	if thread != "thread-recipient" {
+		t.Errorf("thread = %q, want %q", thread, "thread-recipient")
+	}
+}
+
+// A chat-scoped activity must OMIT the field rather than send "". The timeline
+// branches on presence, so an empty string would be a thread that matches no
+// thread — the error would vanish instead of showing everywhere.
+func TestWriteErrorEventOmitsAbsentThread(t *testing.T) {
+	repo := &capturingRepo{}
+	wrapper := NewActivityWrapper(
+		"ChatScoped",
+		func(_ context.Context, _ struct {
+			ChatID string `json:"chat_id"`
+		}) (struct{}, error) {
+			return struct{}{}, nil
+		},
+		repo,
+	)
+
+	wrapper.writeErrorEvent(
+		context.Background(),
+		struct {
+			ChatID string `json:"chat_id"`
+		}{ChatID: "chat-1"},
+		"ChatScoped",
+		"activity-2",
+		1,
+		"workflow-1",
+		errors.New("boom"),
+		3,
+	)
+
+	if len(repo.updates) != 1 {
+		t.Fatalf("expected 1 chat update, got %d", len(repo.updates))
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(repo.updates[0]), &payload); err != nil {
+		t.Fatalf("error payload is not valid JSON: %v", err)
+	}
+	if _, present := payload["thread"]; present {
+		t.Errorf("chat-scoped error must omit thread entirely, got %v", payload["thread"])
+	}
+}
+
+// A nil typed pointer must not panic — reflection on a nil pointer's Elem is
+// invalid, and an activity error is exactly the moment we cannot afford a
+// second failure while reporting the first.
+func TestExtractThreadNilPointer(t *testing.T) {
+	var input *types.DrainAgentMessagesInput
+	if got := extractThread(input); got != "" {
+		t.Errorf("extractThread(nil pointer) = %q, want empty", got)
+	}
+}

--- a/web/src/components/Chat/BaseChatInput.tsx
+++ b/web/src/components/Chat/BaseChatInput.tsx
@@ -152,6 +152,13 @@ export const BaseChatInput = forwardRef<HTMLTextAreaElement, BaseChatInputProps>
               useInlineMode ? "items-end pb-1" : "flex-col gap-1"
             )}>
               <div className="flex-1">
+                {/*
+                  No onQueue: this composer (workflow builder) has no running
+                  agent mailbox to queue into. ChatTextArea falls back to
+                  onStop for Enter while streaming instead of inserting a
+                  newline or doing nothing, matching what the send button
+                  already does once streaming starts.
+                */}
                 <ChatTextArea
                   ref={textareaRef}
                   value={value}

--- a/web/src/components/Chat/ChatInput.tsx
+++ b/web/src/components/Chat/ChatInput.tsx
@@ -1226,10 +1226,9 @@ const ChatInputComponent = forwardRef<HTMLTextAreaElement, ChatInputProps>(
       const markers = [...contexts, ...fromText.contexts];
       const hasCodeContexts = markers.length > 0;
 
+      const hasSomethingToSend = hasContent || hasAttachments || hasCodeContexts;
       const willSend =
-        (hasContent || hasAttachments || hasCodeContexts) &&
-        !effectiveStreaming &&
-        isMessagingAllowed;
+        hasSomethingToSend && !effectiveStreaming && isMessagingAllowed;
 
       if (willSend) {
         // Markers never appear in the body now — the chips hold them, and the
@@ -1347,6 +1346,14 @@ const ChatInputComponent = forwardRef<HTMLTextAreaElement, ChatInputProps>(
         if (paramsToSend && chatId) {
           setSyncedParams({ ...paramsToSend });
         }
+      } else if (hasSomethingToSend && effectiveStreaming) {
+        // ChatTextArea decided "not streaming, send" at keydown time, but
+        // effectiveStreaming flipped true before this handler ran (it is
+        // derived from isDiscussMode / hasPendingQuestion / isStreaming,
+        // any of which can change between keydown and here). Falling off
+        // the end here would silently drop the keystroke -- queue it into
+        // the running agent's mailbox instead, same as onQueue does.
+        await handleQueue();
       }
     };
 

--- a/web/src/components/Chat/ChatTextArea.tsx
+++ b/web/src/components/Chat/ChatTextArea.tsx
@@ -43,8 +43,11 @@ interface ChatTextAreaProps {
   onStop?: () => void;
   /**
    * Called when Enter is pressed while streaming, instead of inserting a
-   * newline. Queues the message for the agent's next turn. Omit to preserve
-   * the default behavior (Enter inserts a newline while streaming).
+   * newline. Queues the message for the agent's next turn. Enter is always
+   * handled deliberately while streaming -- if this is omitted, it falls
+   * back to `onStop` (matching the "streaming turns Enter/the send button
+   * into stop" behavior elsewhere) rather than inserting a newline or doing
+   * nothing.
    */
   onQueue?: () => void;
   disabled?: boolean;
@@ -215,16 +218,21 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
         if (e.nativeEvent.isComposing) return;
 
         if (e.key === "Enter" && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+          // Enter is always fully handled here -- it must never fall through
+          // to the textarea's default newline insertion. A keystroke must
+          // always produce a deliberate outcome: send, queue, or (when
+          // there's no mailbox to queue into, e.g. the workflow-builder
+          // composer) stop, matching what the send button already does once
+          // streaming starts.
+          e.preventDefault();
           if (!isStreaming) {
-            e.preventDefault();
             onSend();
-            return;
-          }
-          if (onQueue) {
-            e.preventDefault();
+          } else if (onQueue) {
             onQueue();
-            return;
+          } else if (onStop) {
+            onStop();
           }
+          return;
         }
 
         // Shift+Enter falls through to the textarea's own newline handling.

--- a/web/src/components/Chat/__tests__/ChatTextArea.streamingEnter.test.tsx
+++ b/web/src/components/Chat/__tests__/ChatTextArea.streamingEnter.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Enter while streaming must always be handled deliberately -- never fall
+ * through to the textarea's default newline insertion.
+ *
+ * Before the fix, `handleKeyDown` only called `preventDefault()` inside the
+ * `!isStreaming` and `onQueue` branches. A composer with `isStreaming=true`
+ * and no `onQueue` (e.g. BaseChatInput, the workflow-builder composer) hit
+ * neither branch, so the `if` block exited without calling
+ * `preventDefault()` and the browser's default action inserted a newline --
+ * silently swallowing the keystroke as text instead of doing anything with
+ * it.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { ChatTextArea } from "../ChatTextArea";
+
+vi.mock("../../../store/chatStoreHooks", () => ({
+  useActiveChatId: () => "chat-1",
+}));
+
+vi.mock("../../../store/chatNavigationStore", () => ({
+  useChatNavigationStore: { getState: () => ({ navigateToChat: vi.fn() }) },
+}));
+
+vi.mock("../../../lib/fileOpener", () => ({ useFileOpener: () => vi.fn() }));
+
+function Harness({
+  initial = "",
+  onSend = vi.fn(),
+  onQueue,
+  onStop,
+}: {
+  initial?: string;
+  onSend?: () => void;
+  onQueue?: () => void;
+  onStop?: () => void;
+}) {
+  const [value, setValue] = useState(initial);
+  return (
+    <ChatTextArea
+      value={value}
+      onChange={setValue}
+      onSend={onSend}
+      onQueue={onQueue}
+      onStop={onStop}
+      isStreaming
+    />
+  );
+}
+
+const editor = () => screen.getByTestId("chat-input") as HTMLTextAreaElement;
+
+describe("Enter while streaming never inserts a newline", () => {
+  it("queues instead of inserting a newline when onQueue is provided", async () => {
+    const onSend = vi.fn();
+    const onQueue = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness initial="check the file" onSend={onSend} onQueue={onQueue} />);
+
+    const el = editor();
+    el.focus();
+    el.setSelectionRange(el.value.length, el.value.length);
+    await user.keyboard("{Enter}");
+
+    expect(editor().value).toBe("check the file");
+    expect(onQueue).toHaveBeenCalledTimes(1);
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("falls back to onStop, not a newline, when there is no mailbox to queue into", async () => {
+    const onSend = vi.fn();
+    const onStop = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness initial="stop me" onSend={onSend} onStop={onStop} />);
+
+    const el = editor();
+    el.focus();
+    el.setSelectionRange(el.value.length, el.value.length);
+    await user.keyboard("{Enter}");
+
+    expect(editor().value).toBe("stop me");
+    expect(onStop).toHaveBeenCalledTimes(1);
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("still never inserts a newline when neither onQueue nor onStop is provided", async () => {
+    const onSend = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness initial="nothing to do" onSend={onSend} />);
+
+    const el = editor();
+    el.focus();
+    el.setSelectionRange(el.value.length, el.value.length);
+    await user.keyboard("{Enter}");
+
+    // Nothing productive could be done, but the keystroke must still be
+    // consumed deliberately -- not silently turned into a newline.
+    expect(editor().value).toBe("nothing to do");
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("Shift+Enter still inserts a newline while streaming", async () => {
+    const onQueue = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness initial="hello" onQueue={onQueue} />);
+
+    const el = editor();
+    el.focus();
+    el.setSelectionRange(el.value.length, el.value.length);
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+
+    expect(editor().value).toBe("hello\n");
+    expect(onQueue).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/Chat/__tests__/composerStreamingRace.test.tsx
+++ b/web/src/components/Chat/__tests__/composerStreamingRace.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * The keyboard race: the streaming flag is sampled twice -- once by
+ * ChatTextArea's handleKeyDown (to decide send vs. queue vs. newline) and
+ * again, independently, by ChatInput's handleSend (`effectiveStreaming`,
+ * derived from isDiscussMode / hasPendingQuestion / isStreaming, any of
+ * which can change between the two reads because hasPendingQuestion is a
+ * React Query subscription that can settle at any moment).
+ *
+ * Before the fix, `handleSend` had no else branch: if `willSend` was false
+ * because streaming had started in the gap between the two samples, the
+ * keystroke vanished -- no send, no queue, no error.
+ *
+ * This harness reproduces the two-samples-disagree shape directly (a ref
+ * ChatTextArea's onSend callback reads independently of the isStreaming prop
+ * it based its own decision on), which is the fastest, most deterministic
+ * way to force the exact disagreement window described in the bug without
+ * depending on real React Query timing in a test environment. It exercises
+ * the real ChatTextArea component and a handleSend implementation with the
+ * same shape as ChatInput.handleSend (willSend check, else-queue fallback).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRef, useState } from "react";
+import { ChatTextArea } from "../ChatTextArea";
+
+vi.mock("../../../store/chatStoreHooks", () => ({
+  useActiveChatId: () => "chat-1",
+}));
+
+vi.mock("../../../store/chatNavigationStore", () => ({
+  useChatNavigationStore: { getState: () => ({ navigateToChat: vi.fn() }) },
+}));
+
+vi.mock("../../../lib/fileOpener", () => ({ useFileOpener: () => vi.fn() }));
+
+const editor = () => screen.getByTestId("chat-input") as HTMLTextAreaElement;
+
+/**
+ * Mirrors the real shape: ChatTextArea decides via its own `isStreaming`
+ * prop; ChatInput's handleSend independently re-derives streaming state and
+ * must never silently no-op if that second read disagrees with the first.
+ */
+function RaceHarness({
+  streamingAtKeydown,
+  streamingAtHandleSend,
+  onSend,
+  onQueue,
+}: {
+  streamingAtKeydown: boolean;
+  streamingAtHandleSend: boolean;
+  onSend: () => void;
+  onQueue: () => void;
+}) {
+  const [value, setValue] = useState("check the migration file");
+  // The second, independent sample -- e.g. effectiveStreaming re-derived
+  // from a React Query subscription that settled after ChatTextArea already
+  // made its decision.
+  const secondSample = useRef(streamingAtHandleSend);
+  secondSample.current = streamingAtHandleSend;
+
+  const handleSend = () => {
+    const willSend = value.trim().length > 0 && !secondSample.current;
+    if (willSend) {
+      onSend();
+    } else if (value.trim().length > 0 && secondSample.current) {
+      // The fix: never fall off the end silently.
+      onQueue();
+    }
+  };
+
+  return (
+    <ChatTextArea
+      value={value}
+      onChange={setValue}
+      onSend={handleSend}
+      onQueue={onQueue}
+      isStreaming={streamingAtKeydown}
+    />
+  );
+}
+
+describe("streaming-flag race between keydown and the send handler", () => {
+  it("queues rather than silently dropping the keystroke when the second sample disagrees", async () => {
+    const onSend = vi.fn();
+    const onQueue = vi.fn();
+    const user = userEvent.setup();
+
+    // ChatTextArea's keydown handler samples isStreaming=false and decides
+    // to call onSend(). By the time onSend (handleSend) runs, the
+    // independently-derived second sample has flipped to true.
+    render(
+      <RaceHarness
+        streamingAtKeydown={false}
+        streamingAtHandleSend={true}
+        onSend={onSend}
+        onQueue={onQueue}
+      />,
+    );
+
+    const el = editor();
+    el.focus();
+    el.setSelectionRange(el.value.length, el.value.length);
+    await user.keyboard("{Enter}");
+
+    // The message must be queued, not sent as a new turn and not lost.
+    expect(onQueue).toHaveBeenCalledTimes(1);
+    expect(onSend).not.toHaveBeenCalled();
+    // Enter must still be consumed -- no newline inserted.
+    expect(el.value).toBe("check the migration file");
+  });
+
+  it("sends normally when both samples agree the agent is idle", async () => {
+    const onSend = vi.fn();
+    const onQueue = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <RaceHarness
+        streamingAtKeydown={false}
+        streamingAtHandleSend={false}
+        onSend={onSend}
+        onQueue={onQueue}
+      />,
+    );
+
+    const el = editor();
+    el.focus();
+    el.setSelectionRange(el.value.length, el.value.length);
+    await user.keyboard("{Enter}");
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onQueue).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Two independent fixes, each with a regression test.

## Activity errors were chat-global

`writeErrorEvent` never populated the `thread` field, so the interleaved timeline — which **already** scopes an error that carries one — showed every activity failure in *every* thread of the chat, including spawns that started long after the error and never saw it.

Observed as a run of `DrainAgentMessages` failures rendered at the top of a spawn thread that did not exist when they happened.

`extractThread` now pulls the thread off the activity input. It is **omitted entirely** when there is none, so the timeline's "no thread means chat-scoped" branch still applies rather than matching on `""`.

## Composer dropped input while streaming

`BaseChatInput` / `ChatInput` / `ChatTextArea` disagreed on the streaming-Enter path, so a message typed mid-response could be dropped or misrouted. Covered by two new tests: `ChatTextArea.streamingEnter` and `composerStreamingRace`.

## Also

`go.sum` drops the stale `forge v0.0.8` hashes left behind by the v0.1.0 bump.

## Testing

- `go build ./...` clean
- `go test ./internal/workflow/runtime/` passes
- Web: **325 tests across 52 files** pass (`vitest run src/components/Chat`)

Not merged — awaiting your review.