### PR TITLE
fix(web): don't leave /onboarding while the cloud daemon is still provisioning

### DIFF
--- a/web/src/components/OnboardingFlow/__tests__/finalizeOnboarding.cloudGate.test.ts
+++ b/web/src/components/OnboardingFlow/__tests__/finalizeOnboarding.cloudGate.test.ts
@@ -1,0 +1,86 @@
+/**
+ * finalizeOnboardingSideEffects must not navigate away from /onboarding while
+ * a cloud daemon is still provisioning.
+ *
+ * THE BUG THIS CLOSES: all three terminal steps (ProjectChoiceStep,
+ * ProjectPickerStep, GitHubConnectStep) do
+ *
+ *     await finalizeOnboardingSideEffects(...)
+ *     if (isCloud) setShowDaemonGate(true);
+ *
+ * but finalizeOnboardingSideEffects itself ends with an UNCONDITIONAL
+ * `router.navigate({ to: "/" })`. For a cloud user the router leaves
+ * /onboarding before the gate can render, so DaemonConnectingGate — the screen
+ * that exists to say "your machine is still starting" — is never seen.
+ *
+ * The user lands on `/` with onboarding_completed=true and no ACTIVE daemon,
+ * which is exactly the state ModernApp renders ProjectPicker for. That is why
+ * a brand-new user reported being dropped onto "Connect a daemon" and
+ * "Resume a daemon — Starting" instead of finishing onboarding.
+ *
+ * The tour param must still be set for the local path, which has no gate and
+ * genuinely is finished at this point.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockNavigate = vi.fn();
+const mockResetTourProgress = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/routes", () => ({ router: { navigate: mockNavigate } }));
+
+vi.mock("@/store/tourStore", () => ({
+  useTourStore: { getState: () => ({ resetTourProgress: mockResetTourProgress }) },
+}));
+
+vi.mock("@/services/controlPlane/onboarding", () => ({
+  onboardingService: { provisionManagedKey: vi.fn().mockResolvedValue({ synced: true }) },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  finalizeOnboardingSideEffects,
+  navigateAfterOnboarding,
+} from "../useOnboardingComplete";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("finalizeOnboardingSideEffects — cloud daemon gate", () => {
+  it("does NOT navigate away when the caller still has to show the daemon gate", async () => {
+    await finalizeOnboardingSideEffects("reliant_credits", { navigate: false });
+
+    // The caller (a cloud terminal step) owns navigation from here: it renders
+    // DaemonConnectingGate and navigates on the gate's Continue.
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("still resets tour progress when navigation is deferred", async () => {
+    await finalizeOnboardingSideEffects("reliant_credits", { navigate: false });
+
+    expect(mockResetTourProgress).toHaveBeenCalled();
+  });
+
+  it("navigates to / with the first tour step on the local path", async () => {
+    await finalizeOnboardingSideEffects("anthropic");
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "/" }),
+    );
+  });
+
+  // The deferred half. Cloud's finalize never touched the URL, so the tour
+  // param has to be SET here — preserving it from `prev` would silently drop
+  // the post-onboarding tour for every cloud user.
+  it("navigateAfterOnboarding sets the tour param on the way out", async () => {
+    await navigateAfterOnboarding();
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/",
+      search: { tour: "chat-and-sidebars" },
+    });
+  });
+});

--- a/web/src/components/OnboardingFlow/steps/GitHubConnectStep.tsx
+++ b/web/src/components/OnboardingFlow/steps/GitHubConnectStep.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "@tanstack/react-router";
 import { Code, ConnectError } from "@connectrpc/connect";
 import { Github, Lock } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -10,7 +9,10 @@ import { useEventBus } from "@/lib/event-context";
 import { useCloneRepo, useCompleteOnboarding, useCreateDaemon } from "@/hooks/useOnboardingQueries";
 import { trackEvent } from "@/lib/analytics";
 import { gitService } from "@/services/controlPlane/git";
-import { finalizeOnboardingSideEffects } from "../useOnboardingComplete";
+import {
+  finalizeOnboardingSideEffects,
+  navigateAfterOnboarding,
+} from "../useOnboardingComplete";
 import { markOnboardingFinalized } from "../analytics";
 import { DaemonConnectingGate } from "../DaemonConnectingGate";
 import type { StepProps } from "../types";
@@ -63,7 +65,6 @@ function findProjectByPath(projects: Project[], path: string): Project | undefin
 }
 
 export function GitHubConnectStep({ plan, updatePlan, onBack }: StepProps) {
-  const navigate = useNavigate();
   const createProject = useProjectStore((state) => state.createProject);
   const loadProjects = useProjectStore((state) => state.loadProjects);
   const projects = useProjectStore((state) => state.projects);
@@ -247,7 +248,9 @@ export function GitHubConnectStep({ plan, updatePlan, onBack }: StepProps) {
         modelProvider: plan.modelProvider,
       });
       markOnboardingFinalized(plan, "github");
-      await finalizeOnboardingSideEffects(plan.modelProvider);
+      // This path always shows the gate below, so navigation is always the
+      // gate's job — see FinalizeOptions.navigate.
+      await finalizeOnboardingSideEffects(plan.modelProvider, { navigate: false });
       // Show the daemon gate before navigating — the daemon may still be
       // provisioning. We hand the gate the UUID we already used for the
       // CloneRepo call so its polling looks up the same row.
@@ -286,19 +289,9 @@ export function GitHubConnectStep({ plan, updatePlan, onBack }: StepProps) {
       <div className="space-y-6">
         <DaemonConnectingGate
           daemonRef={gateDaemonRef}
-          onContinue={() =>
-            // Preserve any search params finalizeOnboardingSideEffects set
-            // (notably ?tour=<first-step> for the post-onboarding wizard).
-            // Stripping legacy `step`/`plan` keeps reload-safe URLs from
-            // re-entering the onboarding flow.
-            navigate({
-              to: "/",
-              search: (prev: Record<string, unknown>) => {
-                const { step: _step, plan: _plan, ...rest } = prev;
-                return rest;
-              },
-            })
-          }
+          // finalize ran with `navigate: false` so this gate could render, so
+          // it never set ?tour=<first-step>. This sets it on the way out.
+          onContinue={() => void navigateAfterOnboarding()}
         />
       </div>
     );

--- a/web/src/components/OnboardingFlow/steps/ProjectChoiceStep.tsx
+++ b/web/src/components/OnboardingFlow/steps/ProjectChoiceStep.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
 import { Github, Loader2, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { logger } from "@/lib/logger";
@@ -8,13 +7,16 @@ import { trackEvent } from "@/lib/analytics";
 import { useCompleteOnboarding } from "@/hooks/useOnboardingQueries";
 import { useGitHubCredential } from "@/hooks/useGitHubCredential";
 import { gitService } from "@/services/controlPlane/git";
-import { ensureProject, finalizeOnboardingSideEffects } from "../useOnboardingComplete";
+import {
+  ensureProject,
+  finalizeOnboardingSideEffects,
+  navigateAfterOnboarding,
+} from "../useOnboardingComplete";
 import { markOnboardingFinalized } from "../analytics";
 import { DaemonConnectingGate } from "../DaemonConnectingGate";
 import type { LaunchPlan, StepProps } from "../types";
 
 export function ProjectChoiceStep({ plan, updatePlan }: StepProps) {
-  const navigate = useNavigate();
   const completeOnboardingMutation = useCompleteOnboarding();
   const { hasToken: hasGithubCredential } = useGitHubCredential();
   const [busy, setBusy] = useState(false);
@@ -28,20 +30,13 @@ export function ProjectChoiceStep({ plan, updatePlan }: StepProps) {
 
   const isCloud = plan.compute === "cloud_free_trial";
 
-  // Mirrors ProjectPickerStep.goToChat: leave /onboarding for the home route
-  // while preserving any search params finalizeOnboardingSideEffects set
-  // (notably ?tour=<first-step>, which the post-onboarding wizard reads to
-  // auto-start). Stripping legacy `step` / `plan` keeps reload-safe URLs from
-  // re-entering the onboarding flow.
+  // Leave /onboarding for the home route, starting the post-onboarding tour.
+  // The cloud path's finalize ran with `navigate: false` so this gate could
+  // render, which means it never put ?tour=<first-step> in the URL — so this
+  // sets it rather than trying to preserve it from `prev`.
   const goToChat = useCallback(() => {
-    navigate({
-      to: "/",
-      search: (prev: Record<string, unknown>) => {
-        const { step: _step, plan: _plan, ...rest } = prev;
-        return rest;
-      },
-    });
-  }, [navigate]);
+    void navigateAfterOnboarding();
+  }, []);
 
   const handleStartNew = useCallback(async () => {
     if (!plan.compute) {
@@ -79,7 +74,12 @@ export function ProjectChoiceStep({ plan, updatePlan }: StepProps) {
       // the tour doesn't spotlight empty surfaces while the hosted daemon is
       // still provisioning. The gate's "Continue" handoff navigates to / and
       // preserves the tour param, so the wizard then kicks in normally.
-      await finalizeOnboardingSideEffects(finalPlan.modelProvider);
+      // Cloud defers navigation to the gate's Continue — otherwise the router
+      // leaves /onboarding before the gate can render and the user lands on /
+      // with no ACTIVE daemon.
+      await finalizeOnboardingSideEffects(finalPlan.modelProvider, {
+        navigate: !isCloud,
+      });
       if (isCloud) {
         setShowDaemonGate(true);
       }

--- a/web/src/components/OnboardingFlow/steps/ProjectPickerStep.tsx
+++ b/web/src/components/OnboardingFlow/steps/ProjectPickerStep.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
 import { FolderOpen, GitBranch, Loader2, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { logger } from "@/lib/logger";
@@ -7,13 +6,15 @@ import { useCompleteOnboarding } from "@/hooks/useOnboardingQueries";
 import { useProjectStore } from "@/store/projectStore";
 import type { Project } from "@/store/projectStore";
 import { ProjectPickerModal } from "@/components/Projects/ProjectPickerModal";
-import { finalizeOnboardingSideEffects } from "../useOnboardingComplete";
+import {
+  finalizeOnboardingSideEffects,
+  navigateAfterOnboarding,
+} from "../useOnboardingComplete";
 import { markOnboardingFinalized } from "../analytics";
 import { DaemonConnectingGate } from "../DaemonConnectingGate";
 import type { StepProps } from "../types";
 
 export function ProjectPickerStep({ plan, onBack }: StepProps) {
-  const navigate = useNavigate();
   const completeOnboardingMutation = useCompleteOnboarding();
 
   const projects = useProjectStore((state) => state.projects);
@@ -43,19 +44,13 @@ export function ProjectPickerStep({ plan, onBack }: StepProps) {
 
   const isCloud = plan.compute === "cloud_free_trial";
 
-  // Leaves /onboarding for the home route while preserving any search params
-  // finalizeOnboardingSideEffects set (notably ?tour=<first-step>, which the
-  // post-onboarding wizard reads to auto-start). Stripping legacy `step` /
-  // `plan` keeps reload-safe URLs from re-entering the onboarding flow.
+  // Leave /onboarding for the home route, starting the post-onboarding tour.
+  // The cloud path's finalize ran with `navigate: false` so this gate could
+  // render, which means it never put ?tour=<first-step> in the URL — so this
+  // sets it rather than trying to preserve it from `prev`.
   const goToChat = useCallback(() => {
-    navigate({
-      to: "/",
-      search: (prev: Record<string, unknown>) => {
-        const { step: _step, plan: _plan, ...rest } = prev;
-        return rest;
-      },
-    });
-  }, [navigate]);
+    void navigateAfterOnboarding();
+  }, []);
 
   const finalize = useCallback(
     async (source: "existing" | "new") => {
@@ -75,7 +70,9 @@ export function ProjectPickerStep({ plan, onBack }: StepProps) {
         // for the local-daemon path; the wizard takes it from there. For
         // cloud we still need the daemon-connecting gate, which renders
         // here and hands control to goToChat() on continue.
-        await finalizeOnboardingSideEffects(plan.modelProvider);
+        await finalizeOnboardingSideEffects(plan.modelProvider, {
+          navigate: !isCloud,
+        });
         if (isCloud) {
           setShowDaemonGate(true);
         }

--- a/web/src/components/OnboardingFlow/useOnboardingComplete.ts
+++ b/web/src/components/OnboardingFlow/useOnboardingComplete.ts
@@ -62,7 +62,25 @@ export async function ensureProject(plan: Partial<LaunchPlan>): Promise<string> 
   return created.id;
 }
 
-export async function finalizeOnboardingSideEffects(modelProvider: ModelProvider | undefined): Promise<void> {
+/** Options for {@link finalizeOnboardingSideEffects}. */
+export interface FinalizeOptions {
+  /**
+   * Whether to navigate to `/` once the side effects are done.
+   *
+   * Cloud callers pass `false`: they still have to render
+   * `DaemonConnectingGate`, which only exists to tell the user their machine
+   * is still provisioning. Navigating here unmounted the step before the gate
+   * could render, dropping the user on `/` with onboarding marked complete and
+   * no ACTIVE daemon — the state ModernApp answers with ProjectPicker's
+   * "Connect a daemon" / "Resume a daemon" screens.
+   */
+  navigate?: boolean;
+}
+
+export async function finalizeOnboardingSideEffects(
+  modelProvider: ModelProvider | undefined,
+  { navigate = true }: FinalizeOptions = {},
+): Promise<void> {
   if (modelProvider === "reliant_credits") {
     onboardingService.provisionManagedKey().then(
       (result) => logger.info("[OnboardingComplete] Reliant provider synced", { synced: result.synced }),
@@ -79,8 +97,26 @@ export async function finalizeOnboardingSideEffects(modelProvider: ModelProvider
     import("@/components/Onboarding/constants"),
   ]);
   await useTourStore.getState().resetTourProgress();
+  if (!navigate) return;
   void router.navigate({
     to: "/",
     search: { tour: ONBOARDING_STEPS[0].id },
   });
+}
+
+/**
+ * Leave onboarding for the app, starting the post-onboarding tour.
+ *
+ * This is the deferred half of {@link finalizeOnboardingSideEffects}: callers
+ * that passed `navigate: false` so they could show `DaemonConnectingGate` call
+ * this from the gate's Continue. Setting the tour param HERE rather than
+ * relying on it surviving in `prev` is what keeps the tour starting for cloud
+ * users, whose finalize never touched the URL.
+ */
+export async function navigateAfterOnboarding(): Promise<void> {
+  const [{ router }, { ONBOARDING_STEPS }] = await Promise.all([
+    import("@/routes"),
+    import("@/components/Onboarding/constants"),
+  ]);
+  void router.navigate({ to: "/", search: { tour: ONBOARDING_STEPS[0].id } });
 }


### PR DESCRIPTION
## What the user saw

A brand-new user on mobile in production reported onboarding "showing the wrong screens in the wrong order": an API-key screen, then **"Connect a daemon"**, then after clicking provision, **"Resume a daemon — Starting"** on `workspace-daemon`.

## What actually happened

Screens 2–4 are not onboarding at all. Every one of those strings lives in `web/src/components/Projects/ProjectPicker.tsx` (`"Connect a daemon"` L315/500/510, `"Cloud daemon requested"` L395, `"Resume a daemon"` L526, `"Pick a daemon to wake up…"` L530). The daemon name `"workspace-daemon"` appears in exactly one place in the codebase — `ProjectPicker.tsx:299`. Onboarding's own cloud path names its daemon `"onboarding-daemon"`.

So the user was **ejected from onboarding into the post-onboarding project picker**, and everything after that was the picker's own daemon-connect UI.

## Root cause

All three terminal steps (`ProjectChoiceStep`, `ProjectPickerStep`, `GitHubConnectStep`) do:

```ts
await finalizeOnboardingSideEffects(...)
if (isCloud) setShowDaemonGate(true);
```

…but `finalizeOnboardingSideEffects` ended with an **unconditional** `router.navigate({ to: "/" })`. For a cloud user the router leaves `/onboarding` before the gate can render, so `DaemonConnectingGate` — the screen that exists to say "your machine is still starting" — is never seen.

The user arrives at `/` with `onboarding_completed=true` and no ACTIVE daemon. That is exactly the state `ModernApp` answers with `ProjectPicker` (`!currentProject`), whose `NoActiveDaemonState` renders "Connect a daemon" / "Resume a daemon".

## The fix

Navigation becomes opt-out via `FinalizeOptions.navigate`. Cloud callers defer it to the gate's Continue, which routes through a new `navigateAfterOnboarding()`.

That helper **sets** `?tour=<first-step>` rather than preserving it from `prev`. This is load-bearing: cloud's `finalize` no longer touches the URL, so the previous "preserve from `prev`" approach would have silently dropped the post-onboarding tour for every cloud user.

## Testing

New `finalizeOnboarding.cloudGate.test.ts` — **verified failing before the fix** (`navigate` was called with `to: "/"` when the caller still had to show the gate) and passing after.

- Onboarding suite: 81 passed
- Full web suite: **1903 passed / 255 files**, no regressions
- `tsc --noEmit`: clean

## Scope

Client-side only, and deliberately narrow. It does **not** address the server-side billing bypass in `internal/svcdaemon` (owned by another agent), nor the missing client-side eligibility gate in `ProjectPicker` — that one is written up separately in `ONBOARDING_FINDINGS.md` and gets its own PR.

**Do not merge without review.**