### PR TITLE
fix(auth): never send a loopback origin as the OAuth redirect

### DIFF
--- a/web/src/api/transport.ts
+++ b/web/src/api/transport.ts
@@ -156,6 +156,11 @@ const LONG_TIMEOUT_METHODS: Record<string, number> = {
   RevertFiles: WORKTREE_OPERATION_TIMEOUT_MS,
   // OAuth flows — no timeout, user can take as long as needed (cancelled via AbortController)
   StartOAuthFlow: OAUTH_TIMEOUT_MS,
+  // StartOAuthSignIn blocks on the SAME thing: the backend opens the system
+  // browser and waits for the user to finish signing in with the provider. It
+  // was missing here, so it inherited the 10s default and aborted while the
+  // user was still on the provider's consent screen.
+  StartOAuthSignIn: OAUTH_TIMEOUT_MS,
   // OAuth token exchange - external network call
   CompleteClaudeOAuth: OAUTH_EXCHANGE_TIMEOUT_MS,
   CompleteCodexOAuth: OAUTH_EXCHANGE_TIMEOUT_MS,

--- a/web/src/lib/__tests__/appUrl.test.ts
+++ b/web/src/lib/__tests__/appUrl.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getAppURL } from '@/lib/constants'
+
+/**
+ * getAppURL answers "what address does the outside world use to reach this
+ * app" — the base for OAuth redirects. The interesting case is the packaged
+ * desktop app, where the renderer's own origin is a local address that no
+ * identity provider can redirect back to.
+ */
+
+type TestWindow = Window & { electronAPI?: unknown }
+
+const setOrigin = (origin: string) => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, origin, href: `${origin}/` },
+  })
+}
+
+const runAsElectron = () => {
+  ;(window as TestWindow).electronAPI = {}
+}
+
+afterEach(() => {
+  delete (window as TestWindow).electronAPI
+  vi.unstubAllEnvs()
+})
+
+describe('getAppURL', () => {
+  it('uses the build-time override when one is configured', () => {
+    vi.stubEnv('VITE_APP_URL', 'https://staging.example.test')
+    expect(getAppURL()).toBe('https://staging.example.test')
+  })
+
+  it('strips a trailing slash from the override so callers can append a path', () => {
+    vi.stubEnv('VITE_APP_URL', 'https://staging.example.test/')
+    expect(getAppURL()).toBe('https://staging.example.test')
+  })
+
+  it('keeps the dev-server origin in a browser, which is a real redirect target', () => {
+    setOrigin('http://localhost:3000')
+    expect(getAppURL()).toBe('http://localhost:3000')
+  })
+
+  it('keeps the deployed origin in a browser', () => {
+    setOrigin('https://app.reliantlabs.io')
+    expect(getAppURL()).toBe('https://app.reliantlabs.io')
+  })
+
+  it.each([
+    ['an ephemeral loopback port', 'http://127.0.0.1:61655'],
+    ['a named localhost port', 'http://localhost:61851'],
+  ])('falls back to the hosted app in Electron served from %s', (_label, origin) => {
+    runAsElectron()
+    setOrigin(origin)
+    expect(getAppURL()).toBe('https://app.reliantlabs.io')
+  })
+
+  it('still trusts a remote origin inside Electron', () => {
+    runAsElectron()
+    setOrigin('https://app.reliantlabs.io')
+    expect(getAppURL()).toBe('https://app.reliantlabs.io')
+  })
+})

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -54,6 +54,70 @@ export const isElectron = (): boolean =>
  */
 export const isDev = getIsDev();
 
+/** Hosted app origin used when no build-time override is configured. */
+const DEFAULT_APP_URL = "https://app.reliantlabs.io";
+
+/**
+ * True for an origin that only means something on the machine that produced it.
+ * A loopback or file:// origin is never a valid public redirect target: handing
+ * one to an identity provider sends the user's browser to a port on their own
+ * machine that either isn't listening or belongs to an unrelated process.
+ */
+const isLocalOrigin = (origin: string): boolean => {
+  if (!origin || origin === "null") return true;
+  try {
+    const { protocol, hostname } = new URL(origin);
+    if (protocol === "file:") return true;
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "[::1]" ||
+      hostname === "::1" ||
+      hostname.endsWith(".localhost")
+    );
+  } catch {
+    return true;
+  }
+};
+
+/**
+ * Public origin of the web app — the base for any URL that leaves this process
+ * and comes back, such as an OAuth `redirectTo`.
+ *
+ * In a BROWSER the document origin is always the right answer, and that
+ * includes local development: a dev server on `localhost:3000` is a real,
+ * registered redirect target that the browser genuinely navigates back to.
+ *
+ * In the PACKAGED DESKTOP APP it is not. There the renderer is served locally,
+ * so its origin is `file://` or an ephemeral loopback port that changes every
+ * launch and is registered with no provider. Handing that to an identity
+ * provider is what produced the `http://127.0.0.1:61655/auth/callback`
+ * redirects seen in the field. Electron finishes OAuth by opening the system
+ * browser, so the redirect must name a URL that is reachable from outside this
+ * process — the hosted app.
+ *
+ * Lookup order: build-time override, then the document origin when it is
+ * trustworthy for this runtime, then the hosted default.
+ */
+export const getAppURL = (): string => {
+  const configured = import.meta.env.VITE_APP_URL;
+  if (typeof configured === "string" && configured.length > 0) {
+    return configured.replace(/\/$/, "");
+  }
+
+  if (typeof window !== "undefined") {
+    const origin = window.location.origin;
+    // In a browser the document origin is the app's real address, dev servers
+    // included. In Electron it is only usable when it is a remote host — a
+    // loopback or file:// origin there is local to the desktop shell and
+    // unreachable from the system browser that completes the OAuth round trip.
+    const originIsUsable = isElectron() ? !isLocalOrigin(origin) : origin !== "null";
+    if (originIsUsable) return origin;
+  }
+
+  return DEFAULT_APP_URL;
+};
+
 /**
  * URL for the admin-server (control-plane) API.
  *

--- a/web/src/store/__tests__/authStore.github-oauth.test.ts
+++ b/web/src/store/__tests__/authStore.github-oauth.test.ts
@@ -37,7 +37,8 @@ vi.mock('@/lib/logger', () => ({
   },
 }))
 
-vi.mock('@/lib/constants', () => ({
+vi.mock('@/lib/constants', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/constants')>()),
   getIsDev: () => false,
 }))
 

--- a/web/src/store/__tests__/authStore.redirect-origin.test.ts
+++ b/web/src/store/__tests__/authStore.redirect-origin.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Regression cover for the loopback OAuth redirect.
+ *
+ * A packaged Electron build exposes `window.electronAPI`, so `isElectron` is
+ * true, but the preload has never implemented `getOAuthRedirectUrl`. The
+ * redirect helper's guard therefore fell through to
+ * `${window.location.origin}/auth/callback`, and in a packaged build the
+ * renderer's origin is whatever local address the window happens to be served
+ * from — an ephemeral loopback port. That address was then handed to the
+ * identity provider as a public redirect target, which is what produced
+ * callbacks like `http://127.0.0.1:61655/auth/callback?code=...`.
+ *
+ * The fix routes the redirect through the hosted app URL instead of the
+ * renderer's own origin, so a loopback origin can never leak into a
+ * provider-facing redirect.
+ */
+
+const signInWithOAuthMock = vi.fn()
+const linkIdentityMock = vi.fn()
+const setSessionMock = vi.fn()
+const getSessionMock = vi.fn(async () => ({ data: { session: null }, error: null }))
+const onAuthStateChangeMock = vi.fn(() => ({
+  data: { subscription: { unsubscribe: vi.fn() } },
+}))
+const startOAuthSignInMock = vi.fn()
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: getSessionMock,
+      onAuthStateChange: onAuthStateChangeMock,
+      signInWithOAuth: signInWithOAuthMock,
+      linkIdentity: linkIdentityMock,
+      setSession: setSessionMock,
+    },
+  },
+}))
+
+vi.mock('@/api/grpc-unauth', () => ({
+  devAuthGrpc: {
+    startOAuthSignIn: startOAuthSignInMock,
+    load: vi.fn(async () => ({ success: false })),
+    save: vi.fn(async () => ({ success: true })),
+    clear: vi.fn(async () => ({ success: true })),
+  },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}))
+
+// Only getIsDev is stubbed; getAppURL is the real implementation under test.
+vi.mock('@/lib/constants', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/constants')>()),
+  getIsDev: () => false,
+}))
+
+vi.mock('@/lib/sentry', () => ({
+  setSentryUser: vi.fn(),
+}))
+
+type TestWindow = Window & { electronAPI?: unknown }
+
+/**
+ * Repoint the jsdom document at `origin`. The packaged renderer is served from
+ * a local address, so this is how we reproduce the origin the bug read from.
+ */
+const setDocumentOrigin = (origin: string) => {
+  const url = new URL(origin)
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, origin: url.origin, href: `${url.origin}/`, protocol: url.protocol },
+  })
+}
+
+/** The loopback origin a packaged renderer reports — never a valid redirect. */
+const LOOPBACK_ORIGIN = 'http://127.0.0.1:61655'
+
+const redirectTargetFrom = (mock: ReturnType<typeof vi.fn>): string => {
+  const call = mock.mock.calls.at(-1)
+  if (!call) throw new Error('provider redirect was never requested')
+  return (call[0] as { options: { redirectTo: string } }).options.redirectTo
+}
+
+describe('OAuth redirect target in a packaged Electron build', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    setDocumentOrigin(LOOPBACK_ORIGIN)
+
+    // A packaged build DOES expose electronAPI — but without
+    // getOAuthRedirectUrl, which is precisely the shipped 1.6.3 surface.
+    ;(window as TestWindow).electronAPI = { analyticsTrack: vi.fn(), openExternal: vi.fn() }
+
+    signInWithOAuthMock.mockResolvedValue({
+      data: { url: 'https://accounts.google.com/o/oauth2/auth?example=1' },
+      error: null,
+    })
+    linkIdentityMock.mockResolvedValue({
+      data: { url: 'https://accounts.google.com/o/oauth2/auth?example=1' },
+      error: null,
+    })
+  })
+
+  it('never sends a loopback address as the identity provider redirect', async () => {
+    // linkIdentity is the flow that runs in packaged Electron (sign-in proper
+    // goes through the daemon), so it is the one that leaked the port.
+    const { useAuthStore } = await import('@/store/authStore')
+
+    await useAuthStore.getState().linkOAuthIdentity('google')
+
+    const redirectTo = redirectTargetFrom(linkIdentityMock)
+    expect(redirectTo).not.toContain('127.0.0.1')
+    expect(redirectTo).not.toContain('localhost')
+    expect(new URL(redirectTo).hostname).not.toBe('127.0.0.1')
+  })
+
+  it('points the redirect at the hosted app URL', async () => {
+    const { useAuthStore } = await import('@/store/authStore')
+
+    await useAuthStore.getState().linkOAuthIdentity('google')
+
+    expect(redirectTargetFrom(linkIdentityMock)).toBe(
+      'https://app.reliantlabs.io/auth/callback',
+    )
+  })
+})

--- a/web/src/store/authStore.ts
+++ b/web/src/store/authStore.ts
@@ -2,21 +2,27 @@ import { create } from 'zustand'
 import type { User, Session, AuthChangeEvent } from '@supabase/supabase-js'
 import { supabase } from '@/lib/supabase'
 import { logger } from '@/lib/logger'
+import { getAppURL } from '@/lib/constants'
 import { setSentryUser } from '@/lib/sentry'
 import { devAuthGrpc } from '@/api/grpc-unauth'
 
 const isElectron = !!window.electronAPI
+
+/**
+ * Where the identity provider should send the user back to.
+ *
+ * This must be the PUBLIC app URL, never the renderer's own origin. In the
+ * packaged desktop app the renderer is served from a local address, so
+ * `window.location.origin` is an ephemeral loopback port — sending that to a
+ * provider produced the `http://127.0.0.1:<port>/auth/callback` redirects users
+ * hit in the field. `getAppURL()` resolves the hosted origin and only falls
+ * through to the document origin when that origin is genuinely public.
+ *
+ * Electron completes the round trip by opening the provider in the system
+ * browser (see linkOAuthIdentity), which lands on the hosted callback page.
+ */
 const getOAuthRedirectUrl = async (): Promise<string> => {
-  if (!isElectron || !window.electronAPI?.getOAuthRedirectUrl) {
-    return `${window.location.origin}/auth/callback`
-  }
-
-  const response = await window.electronAPI.getOAuthRedirectUrl()
-  if (!response?.success || !response.redirectUrl) {
-    throw new Error(response?.error || 'Failed to initialize OAuth callback listener')
-  }
-
-  return response.redirectUrl
+  return `${getAppURL()}/auth/callback`
 }
 
 // Append OAuth round-trip state to the redirect URL as query params. Replaces

--- a/web/src/types/electron.d.ts
+++ b/web/src/types/electron.d.ts
@@ -94,8 +94,13 @@ export interface ElectronAPI {
   onOpenProject: (callback: (projectPath: string) => void) => () => void;
 
   // OAuth
-  getOAuthRedirectUrl: () => Promise<{ success: boolean; redirectUrl?: string; error?: string }>;
-  onOAuthCallback: (callback: (callbackUrl: string) => void) => void;
+  //
+  // These two were declared here but never implemented in preload.js, so at
+  // runtime they are `undefined` in every build that has ever shipped. They are
+  // typed as optional so a call site cannot assume the main process provides
+  // them — the OAuth redirect target now comes from getAppURL() instead.
+  getOAuthRedirectUrl?: () => Promise<{ success: boolean; redirectUrl?: string; error?: string }>;
+  onOAuthCallback?: (callback: (callbackUrl: string) => void) => void;
 
   // Auth storage
   authLoad: () => Promise<{ success: boolean; session?: any; error?: string }>;


### PR DESCRIPTION
## The bug

Packaged builds sent identity providers redirect targets like `http://127.0.0.1:61655/auth/callback` — an ephemeral local port, registered with no provider, pointing at a different process on the next launch.

## Root cause

`authStore.ts` resolved the redirect with this guard:

```ts
const isElectron = !!window.electronAPI
if (!isElectron || !window.electronAPI?.getOAuthRedirectUrl) {
  return `${window.location.origin}/auth/callback`   // ← the bug
}
```

In the packaged app **both halves are true at once**: `window.electronAPI` exists (so `isElectron` is `true`), but `getOAuthRedirectUrl` does not. It is declared in `electron/src/../types/electron.d.ts` and was **never implemented in `preload.js`** — the type declaration made it look implemented; nothing at runtime ever provided it.

So the guard always fell through and handed the desktop app's own local origin to the provider as a public redirect.

## Verified against the shipped 1.6.3 build

Not just the source — I downloaded and mounted the released DMG:

```
$ grep -c "getOAuthRedirectUrl" Reliant.app/Contents/Resources/preload.js
0
```

The shipped preload exposes ~40 `electronAPI` methods and neither OAuth method among them. The shipped renderer bundle contains the faulty fallback verbatim, with `bQ=!!window.electronAPI`:

```
f(!bQ||!window.electronAPI?.getOAuthRedirectUrl)return`${window.location.origin}/auth/callback`;
```

The port is whatever address the renderer was served from that launch, which is why reports show different ports and why it is intermittent.

## The fix

New `getAppURL()` resolves the app's *public* origin.

The subtlety worth reviewing: **a local origin is not always wrong.** In web dev the app is served from `localhost:3000` and that is a real redirect target. Rejecting all loopback origins broke three existing tests — which is what surfaced the right discriminator. It is the *runtime*, not the address:

- **Browser** (dev or deployed) — the document origin *is* the app's address. Use it.
- **Electron** — OAuth completes in the *system browser*, which cannot reach the desktop shell's local address, so a loopback/`file://` origin falls back to the hosted app.

`VITE_APP_URL` overrides for staging/preview.

### Also fixed here

`StartOAuthSignIn` was missing from the long-timeout table, inheriting the 10s default while the user was still on the consent screen. Its sibling `StartOAuthFlow`, which blocks on the same thing, was already registered at no-timeout.

The two unimplemented preload declarations are marked optional so no call site can assume the main process provides them.

## Tests

`authStore.redirect-origin.test.ts` reproduces the report exactly. Before the fix:

```
Expected: "https://app.reliantlabs.io/auth/callback"
Received: "http://127.0.0.1:61655/auth/callback"
```

`appUrl.test.ts` covers 7 cases, including the one that matters: a browser on `localhost:3000` keeps its origin, Electron on the same origin does not.

Full web suite: **256 files / 1908 tests passing**; `tsc --noEmit` clean.

## Note on the "back to first project" report

Investigated together with this one. That control is a `<button>` with no URL, so I could not reproduce it directly — but this helper is the only thing in the app that turns a local address into a navigation target, and a bare origin with no path is the shape of an origin used as a base URL. Most likely it was observed after an OAuth round trip had already left the window on the bad origin, making it a downstream symptom this fix removes. Full reasoning and the caveat are in `OAUTH_REDIRECT_FINDINGS.md`.

Not merging — flagging for review.