### PR TITLE
fix(auth): show a per-provider pending state on remote sign-in

### DIFF
--- a/web/src/components/AuthScreen.tsx
+++ b/web/src/components/AuthScreen.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useAuthStore } from '@/store/authStore'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import { OAuthButton } from './OAuthButton'
+import type { SocialProvider } from './icons/SocialProviderIcon'
 import { ForgotPassword } from './ForgotPassword'
 import { EmailVerification } from './EmailVerification'
 import { PasswordInput, ConfirmPasswordInput } from './PasswordInput'
@@ -17,6 +18,9 @@ export function AuthScreen() {
   const [signupEmailForVerification, setSignupEmailForVerification] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+  // The provider whose sign-in is currently starting, or null. On success the
+  // page navigates or redirects away, so this is only cleared on failure.
+  const [pendingProvider, setPendingProvider] = useState<SocialProvider | null>(null)
 
   const { signIn, signUp, signInAnonymously, signInWithGithub, signInWithGoogle, signInWithApple } = useAuthStore()
   const navigate = useNavigate()
@@ -125,6 +129,11 @@ export function AuthScreen() {
   }
 
   const handleOAuthSignIn = async (provider: 'google' | 'github' | 'apple') => {
+    // Track WHICH provider is starting, not just that something is. The button
+    // for the clicked provider shows the pending state; the others are merely
+    // disabled, so the UI never claims to be connecting to a provider the user
+    // did not choose.
+    setPendingProvider(provider)
     setLoading(true)
     setError(null)
 
@@ -160,6 +169,7 @@ export function AuthScreen() {
 
       setError(errorMessage)
       setLoading(false)
+      setPendingProvider(null)
     }
   }
 
@@ -283,12 +293,14 @@ export function AuthScreen() {
             <OAuthButton
               provider="github"
               onClick={() => handleOAuthSignIn('github')}
-              loading={loading}
+              loading={pendingProvider === 'github'}
+              disabled={loading}
             />
             <OAuthButton
               provider="google"
               onClick={() => handleOAuthSignIn('google')}
-              loading={loading}
+              loading={pendingProvider === 'google'}
+              disabled={loading}
             />
           </div>
 

--- a/web/src/components/OAuthButton.tsx
+++ b/web/src/components/OAuthButton.tsx
@@ -1,8 +1,19 @@
 import type { ComponentProps } from 'react'
+import { Loader2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
 import { SocialProviderIcon, type SocialProvider } from './icons/SocialProviderIcon'
 
 interface OAuthButtonProps extends Omit<ComponentProps<'button'>, 'children'> {
   provider: SocialProvider
+  /**
+   * This provider's sign-in is in flight. Starting a provider round-trip can
+   * take seconds before the browser moves, so the button must acknowledge the
+   * click — otherwise the screen looks inert and users click again.
+   *
+   * Pass this ONLY for the provider that was actually clicked. Driving every
+   * button from one shared flag makes the app look like it is signing in with
+   * a provider the user never chose.
+   */
   loading?: boolean
 }
 
@@ -29,30 +40,36 @@ const providerConfig = {
 
 export function OAuthButton({ provider, loading = false, disabled, ...props }: OAuthButtonProps) {
   const config = providerConfig[provider]
-  
+
   return (
     <button
       type="button"
+      // Disabled while ANY provider is in flight (the caller passes `disabled`
+      // for the others), so a second click cannot start a competing sign-in.
       disabled={loading || disabled}
-      className={`
-        w-full inline-flex justify-center items-center gap-3 py-2.5 px-4 
-        border rounded-lg shadow-sm text-sm font-medium 
-        transition-colors duration-200
-        disabled:opacity-50 disabled:cursor-not-allowed
-        focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2
-        ${config.bgColor}
-        ${config.textColor}
-        ${config.borderColor}
-      `}
+      // aria-busy tracks this provider alone: a screen reader should announce
+      // the one the user chose as busy, not the whole row.
+      aria-busy={loading}
+      data-testid={`oauth-button-${provider}`}
+      className={cn(
+        'w-full inline-flex justify-center items-center gap-3 py-2.5 px-4',
+        'border rounded-lg shadow-sm text-sm font-medium',
+        'transition-colors duration-200',
+        'disabled:opacity-50 disabled:cursor-not-allowed',
+        'focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2',
+        config.bgColor,
+        config.textColor,
+        config.borderColor,
+      )}
       {...props}
     >
       {loading ? (
-        <div className="w-5 h-5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+        <Loader2 className="w-5 h-5 animate-spin" aria-hidden="true" />
       ) : (
         <SocialProviderIcon provider={provider} />
       )}
       <span>
-        {loading ? 'Connecting...' : `Continue with ${config.name}`}
+        {loading ? `Connecting to ${config.name}...` : `Continue with ${config.name}`}
       </span>
     </button>
   )

--- a/web/src/components/UpgradeAccount.tsx
+++ b/web/src/components/UpgradeAccount.tsx
@@ -68,6 +68,9 @@ export function UpgradeAccount() {
   const [verificationEmail, setVerificationEmail] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
+  // Which provider's link is starting, or null. Cleared only on failure — a
+  // success navigates away to the provider.
+  const [pendingProvider, setPendingProvider] = useState<LinkableProvider | null>(null)
 
   // No-email-after-upgrade fallback (e.g. GitHub with a private email): the
   // user enters a billing email, verifies it via OTP, and only then do we
@@ -102,6 +105,10 @@ export function UpgradeAccount() {
 
   const handleLink = async (provider: LinkableProvider) => {
     setError(null)
+    // Only the clicked provider gets the pending state; the rest are disabled.
+    // A shared flag lit every button at once, which reads as the app linking an
+    // account the user never picked.
+    setPendingProvider(provider)
     setSubmitting(true)
     try {
       // Thread returnTo through the OAuth state so /auth/callback lands the
@@ -115,6 +122,7 @@ export function UpgradeAccount() {
     } catch (err) {
       setError(err instanceof Error ? err.message : `Failed to link ${provider}`)
       setSubmitting(false)
+      setPendingProvider(null)
     }
   }
 
@@ -436,12 +444,14 @@ export function UpgradeAccount() {
             <OAuthButton
               provider="github"
               onClick={() => handleLink('github')}
-              loading={submitting}
+              loading={pendingProvider === 'github'}
+              disabled={submitting}
             />
             <OAuthButton
               provider="google"
               onClick={() => handleLink('google')}
-              loading={submitting}
+              loading={pendingProvider === 'google'}
+              disabled={submitting}
             />
           </div>
 

--- a/web/src/components/__tests__/AuthScreen.oauth-pending.test.tsx
+++ b/web/src/components/__tests__/AuthScreen.oauth-pending.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Remote sign-in has to acknowledge the click.
+ *
+ * Starting a provider sign-in is slow: the app talks to the backend, which
+ * opens a browser, and the redirect can take seconds. With no visible change
+ * the screen looks inert and users click a second time. Two things have to be
+ * true while that is in flight:
+ *
+ *  1. The provider the user actually clicked shows a pending state.
+ *  2. The OTHER provider does not. A single shared flag put every button into
+ *     "Connecting..." at once, which reads as though the app is signing in with
+ *     something the user never chose.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+  useSearch: () => ({}),
+}))
+
+/** Resolves only when the test says so, standing in for a slow redirect. */
+let releaseGoogle: () => void
+const signInWithGoogle = vi.fn(
+  () =>
+    new Promise<void>((resolve) => {
+      releaseGoogle = resolve
+    }),
+)
+const signInWithGithub = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: () => ({
+    signIn: vi.fn(),
+    signUp: vi.fn(),
+    signInAnonymously: vi.fn(),
+    signInWithGoogle,
+    signInWithGithub,
+    signInWithApple: vi.fn(),
+  }),
+}))
+
+import { AuthScreen } from '../AuthScreen'
+
+const buttonFor = (name: RegExp) => screen.getByRole('button', { name })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('AuthScreen remote sign-in pending state', () => {
+  it('shows a pending state on the provider that was clicked', async () => {
+    render(<AuthScreen />)
+
+    fireEvent.click(buttonFor(/continue with google/i))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oauth-button-google')).toHaveAttribute(
+        'aria-busy',
+        'true',
+      )
+    })
+
+    releaseGoogle()
+  })
+
+  it('leaves the other provider idle rather than showing every button as busy', async () => {
+    render(<AuthScreen />)
+
+    fireEvent.click(buttonFor(/continue with google/i))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oauth-button-google')).toHaveAttribute(
+        'aria-busy',
+        'true',
+      )
+    })
+
+    // GitHub was not clicked: it must not claim to be connecting.
+    expect(screen.getByTestId('oauth-button-github')).toHaveAttribute(
+      'aria-busy',
+      'false',
+    )
+
+    releaseGoogle()
+  })
+
+  it('disables both providers while one is in flight so a stray click cannot start a second sign-in', async () => {
+    render(<AuthScreen />)
+
+    fireEvent.click(buttonFor(/continue with google/i))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oauth-button-github')).toBeDisabled()
+    })
+
+    fireEvent.click(screen.getByTestId('oauth-button-github'))
+    expect(signInWithGithub).not.toHaveBeenCalled()
+
+    releaseGoogle()
+  })
+})


### PR DESCRIPTION
## The bug

Clicking a remote sign-in appeared to do nothing. Starting the provider round-trip can take seconds before the browser moves, so users clicked again thinking the first click was lost.

## What was actually wrong

Subtler than "the loading state is missing" — one *did* exist. `OAuthButton` already accepted a `loading` prop.

The defect is that `AuthScreen` passed the **same shared `loading` flag to every provider button**. Clicking Google put *both* Google and GitHub into "Connecting...", so the UI claimed to be signing in with a provider the user never chose. `UpgradeAccount` had the identical problem with its `submitting` flag.

## The fix

Both screens now track *which* provider is pending:

- the clicked provider gets the spinner, names itself (`Connecting to Google...`), and sets `aria-busy` so assistive tech announces the one the user chose rather than the whole row;
- the others are disabled but visually idle, so a stray second click cannot start a competing sign-in.

`OAuthButton` also moves onto the styling contract in `reliant.md`: `cn()` instead of a template-literal `className`, and the shared `Loader2` spinner instead of a hand-rolled bordered `div`. Colors and layout are unchanged.

## Tests

`AuthScreen.oauth-pending.test.tsx` — confirmed failing before the fix, passing after. Covers the clicked provider going busy, the other one staying idle (the actual regression), and a second click being refused while one is in flight.

Full web suite: **255 files / 1902 tests passing**; `tsc --noEmit` clean.

Independent of #170 — separate branch, no overlapping files.

Not merging — flagging for review.
