### PR TITLE
fix(electron): serve the packaged renderer over app:// so it actually loads

### DIFF
--- a/ELECTRON_LOAD_FAILURE.md
+++ b/ELECTRON_LOAD_FAILURE.md
@@ -1,0 +1,220 @@
+# Why the packaged Electron app won't load (v1.6.3)
+
+## Summary
+
+The renderer never executes. `index.html` loads fine, so every signal the main
+process has says success — `did-finish-load` fires, the preload runs, the window
+is shown — but the page's JavaScript is never fetched, `#root` stays empty, and
+the user gets a white window.
+
+The cause is a mismatch between how the web bundle is built and how the packaged
+app loads it:
+
+- Vite builds with `base: "/"`, so `index.html` requests `/assets/index-<hash>.js`.
+- The packaged app loads that file with `loadFile()`, giving the page a `file://`
+  origin.
+- Under `file://`, a root-absolute path resolves against the **filesystem root**.
+  The renderer asked for `file:///assets/index-D98vjdRH.js`, which does not exist.
+
+Nothing reports this, because the *document* loaded successfully. `did-fail-load`
+only fires for the top-level frame; a subresource that 404s is silent.
+
+This is **not** a config-injection bug. That hypothesis was checked first and
+ruled out with direct evidence (below).
+
+## Direct evidence from the shipped artifact
+
+Downloaded `Reliant-1.6.3-mac-arm64.dmg`, mounted it, and extracted `app.asar`.
+
+**`build-config.js` shipped fully populated.** Every key the renderer needs was
+present, so the v1.6.2-class defect did not recur:
+
+```js
+module.exports = {
+  "STATSIG_CLIENT_KEY": "client-uAMxcftbx55c1rBoKgUhEzaqVrHdx44qS1AJQtD0r4j",
+  "SENTRY_DSN": "https://c84a8011...@o4509000353447936.ingest.us.sentry.io/4509933645856778",
+  "SUPABASE_URL": "https://dash.reliantlabs.io",
+  "SUPABASE_ANON_KEY": "sb_publishable_KKiB3B0EdEv7nguwKfEE5A_iY9rVXod",
+  "RELIANT_SERVER_URL": "https://api.reliant.so/api",
+  "RELIANT_API_URL": "https://api.reliant.so/api",
+  "RELIANT_GATEWAY_URL": "",
+};
+```
+
+`RELIANT_GATEWAY_URL` is empty by design — the daemon derives it (confirmed in the
+log: `gateway="https://gateway-api.reliant.so/api (derived from server ...)"`).
+
+**The shipped `index.html` asks for root-absolute assets:**
+
+```html
+<script type="module" crossorigin src="/assets/index-D98vjdRH.js"></script>
+<link rel="stylesheet" crossorigin href="/assets/index-BZqrqbFH.css">
+```
+
+The files are really at `Contents/Resources/web/assets/` (179 of them). Nothing in
+`main.js` rewrites these paths — the repo has never contained a
+`registerFileProtocol` or `interceptFileProtocol` call.
+
+**Loading the shipped `index.html` in Electron exactly as the app does:**
+
+```
+did-finish-load fired:      true
+#root innerHTML length:     0        (EMPTY => blank screen)
+module script resolved URL: file:///assets/index-D98vjdRH.js
+subresource failures:       []
+```
+
+The resolved URL is the whole bug. `did-finish-load` fires and no failure is
+reported, which is why the app appears to start and then shows nothing.
+
+Copying the same bundle and rewriting only `/assets/` → `./assets/` makes it
+render (`#root` length 2763), confirming the path is the sole difference.
+
+## Which releases are affected
+
+`base: "/"` has been in `web/vite.config.ts` since **v1.4.1** (commit `0bc523c2`,
+"admin UI integration"), which changed it from `base: "./"`. v1.6.2's `index.html`
+is byte-identical in its asset paths to v1.6.3's — I mounted both DMGs and
+compared. So this is a long-standing break in the packaged app, not a v1.6.3
+regression.
+
+The commit that introduced it has a correct rationale for the *web* deploy:
+
+> Relative "./" breaks fresh loads/refreshes on any 2+-segment route (e.g.
+> /auth/github/callback) because "./assets/x.js" resolves against the route's dir
+
+That reasoning is right, and it is why the fix is not "change the base back."
+
+## The real constraint
+
+The same bundle ships to two places with incompatible requirements:
+
+| | needs |
+|---|---|
+| `app.reliantlabs.io` | `base: "/"` — a relative base breaks deep routes on refresh |
+| packaged Electron | not `file://` — root-absolute paths escape to the filesystem root |
+
+`file://` also cannot support the router at all. TanStack Router uses path-based
+history, and under `file://` `history.pushState` produces `file:///chat/abc`
+(verified), which 404s on reload. That is why the old code had a `will-navigate`
+handler that force-reloaded `index.html` — it was papering over the same
+limitation and discarding the user's route in the process.
+
+## The fix: serve the renderer over `app://`
+
+A custom standard scheme satisfies both sides at once. `app://bundle/` is a real
+origin with a real root, so `/assets/...` resolves inside the packaged web
+directory, and unknown paths fall back to `index.html` the way a web server's SPA
+fallback does. The web build is untouched.
+
+Registering it `standard: true, secure: true` is load-bearing: without it the
+renderer is an opaque origin and `localStorage` throws, which would break every
+Zustand persist store.
+
+### Verified end-to-end against the real broken artifact
+
+Serving the **actual shipped v1.6.3 bundle** over the new scheme:
+
+```
+renderer URL   : app://bundle/auth
+#root children : 3          => REACT MOUNTED
+storage        : localStorage OK: 1
+deep route     : app://bundle/chat/abc
+health watchdog: healthy
+```
+
+The app mounts, routes itself to `/auth`, and deep routes resolve — with no change
+to the bundle.
+
+### A trap worth naming
+
+`protocol.handle()` takes the scheme **without** a trailing colon.
+`protocol.handle("app:")` does not throw; it registers nothing, and every load
+then fails with `ERR_FAILED` before the handler is consulted. I hit this during
+validation. The code now asserts `protocol.isProtocolHandled()` after
+registering and throws if it did not take, so this cannot fail silently again.
+
+`shouldOpenExternally()` also needed updating: it treated any non-http(s) scheme
+as external, so every in-app `app://` navigation would have been handed to
+`shell.openExternal` — a browser tab per route change. Confirmed against the
+pre-fix code, now covered by a test.
+
+## Making the next failure diagnosable
+
+The reason this took an artifact download to diagnose is that a packaged build
+could not tell us anything. Three changes, in order of how much they matter:
+
+### 1. The log file is the primary diagnostic
+
+**It already worked, and nobody could find it.** `~/Library/Logs/reliant/main.log`
+had everything needed to diagnose this bug the whole time. A blank renderer cannot
+show its own console, and the console would not have held the interesting part
+anyway — the asset resolution and the daemon spawn both happen in the main
+process. So the View menu now has **Open Log File** (reveals it in Finder) and
+**Copy Diagnostics** (version, renderer URL, backend state, log path as
+copy-pasteable text). Both work when the window is blank, because the menu bar
+still works.
+
+### 2. A renderer health watchdog
+
+The failure mode here is that *everything reports success*. So we now assert the
+thing that actually matters — that React mounted — by checking whether `#root` has
+children a few seconds after load, and logging the failed subresources if not.
+
+Verified in both directions. Against the original `file://` load of the shipped
+bundle:
+
+```
+ERROR [RendererHealth] BLANK WINDOW DETECTED after 3000ms: #root is empty —
+      the app bundle never executed (assets likely failed to resolve)
+ERROR [RendererHealth] renderer URL: file:///.../web/index.html
+```
+
+and silent when the app mounts correctly. It diagnoses only — it does not reload,
+because a blank renderer means the bundle cannot resolve its assets and a retry
+would reproduce it exactly while hiding the evidence.
+
+### 3. DevTools, available but deliberate
+
+Packaged builds previously forced DevTools closed via a `devtools-opened`
+handler, so a broken window could not be inspected at all.
+
+**Rejected: gating on prerelease (`-rc`) builds.** The failure we need to debug is
+the one a user hits on a *stable* build; telling them to install an RC changes the
+artifact under test. The threat model does not support hiding DevTools either —
+the app ships its renderer as readable files on disk, so DevTools expose nothing
+an attacker with local access could not already read, while the lockdown cost real
+diagnosability.
+
+DevTools are now reachable in packaged builds via an explicit **View → Toggle
+Developer Tools** menu item, or `RELIANT_DEVTOOLS=1` to auto-open at launch. The
+keyboard shortcuts stay disabled so an ordinary user cannot trip them by accident.
+
+## Note on the daemon (separate problem)
+
+The log shows the daemon failing independently of the renderer:
+
+```
+Daemon failed to become ready within 30000ms — no runtime record written
+[daemon-creds] mint failed, falling back to daemon flow: fetch failed
+Daemon process exited (code: null, signal: SIGKILL)
+```
+
+It spawns, resolves its target correctly (`https://api.reliant.so/api`), tries to
+authenticate, and is SIGKILLed. **This is not why the window is blank** — the
+renderer fails before the daemon matters, and it would fail identically with a
+healthy daemon. It is a real second bug and is left for separate work; it likely
+overlaps with the `reliant auth serve` env-prefix problem another agent is on.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `electron/src/app-protocol.js` | new — `app://` scheme, path resolution, SPA fallback, traversal refusal |
+| `electron/src/renderer-health.js` | new — blank-window detection |
+| `electron/src/diagnostics.js` | new — DevTools policy, diagnostics report |
+| `electron/src/main.js` | load via `app://`, register scheme, watchdog, View-menu diagnostics, DevTools policy |
+| `electron/src/window-manager.js` | second window path had the same `loadFile` bug |
+| `electron/src/navigation-policy.js` | treat `app://` as in-app |
+
+Tests: 120 pass (`npm test` in `electron/`), 26 of them new.

--- a/electron/package.json
+++ b/electron/package.json
@@ -19,7 +19,7 @@
     "build:backend": "cd .. && go build -buildvcs=false -o dist/reliant.tmp ./cmd/reliant/ && mv dist/reliant.tmp dist/reliant",
     "dev:vite": "npm --prefix ../web run dev",
     "dev:electron": "node scripts/wait-and-start.js",
-    "test": "node --test test/backend-auth.test.js test/daemon-creds.test.js test/backend-manager-readiness.test.js test/backend-manager-orphan-cleanup.test.js test/menu-accelerators.test.js test/navigation-policy.test.js test/child-signals.test.js",
+    "test": "node --test test/backend-auth.test.js test/daemon-creds.test.js test/backend-manager-readiness.test.js test/backend-manager-orphan-cleanup.test.js test/menu-accelerators.test.js test/navigation-policy.test.js test/child-signals.test.js test/app-protocol.test.js test/renderer-health.test.js test/diagnostics.test.js",
     "build:web": "cd ../web && npm run build:alpha",
     "build:web:alpha": "cd ../web && npm run build:alpha",
     "build": "npm run build:web && ../scripts/build-electron.sh mac && electron-builder",

--- a/electron/src/app-protocol.js
+++ b/electron/src/app-protocol.js
@@ -1,0 +1,228 @@
+/**
+ * The `app://` scheme that serves the packaged renderer bundle.
+ *
+ * Packaged builds used to load the renderer with `loadFile(index.html)`, which
+ * gives the page a `file://` origin. That is incompatible with the bundle Vite
+ * actually produces:
+ *
+ *   - Vite builds with `base: "/"` because the same bundle is deployed to
+ *     app.reliantlabs.io, where a relative base breaks asset resolution on any
+ *     2+-segment route. So index.html asks for `/assets/index-<hash>.js`.
+ *   - Under `file://`, a root-absolute path resolves against the FILESYSTEM
+ *     root — the renderer requested `file:///assets/index-<hash>.js`, which
+ *     does not exist, so no script ever executed and the window stayed blank.
+ *
+ * The failure was silent by construction: index.html itself loads fine, so
+ * `did-finish-load` fires and `did-fail-load` never does. Nothing in the main
+ * process could tell that the app had not started.
+ *
+ * A custom scheme fixes both halves at once. `app://bundle/` is a real origin
+ * with a real root, so `/assets/...` resolves inside the packaged web
+ * directory, and a deep route like `/chat/abc` can fall back to index.html the
+ * way a web server's SPA fallback does — which `file://` cannot do, since
+ * `history.pushState` there yields `file:///chat/abc` and a reload 404s.
+ *
+ * Registering it as `standard` + `secure` is what makes the origin behave:
+ * without it the renderer is treated as an opaque origin and localStorage,
+ * which every Zustand persist store depends on, throws on access.
+ */
+
+const path = require("path");
+const fs = require("fs");
+
+const APP_SCHEME = "app";
+const APP_HOST = "bundle";
+const APP_ORIGIN = `${APP_SCHEME}://${APP_HOST}`;
+const APP_INDEX_URL = `${APP_ORIGIN}/`;
+
+const MIME_TYPES = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".mjs": "text/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+  ".map": "application/json",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".ico": "image/x-icon",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".otf": "font/otf",
+  ".wasm": "application/wasm",
+  ".txt": "text/plain",
+};
+
+/**
+ * Content type for a file path, defaulting to octet-stream.
+ *
+ * Getting this right matters more than it looks: a module script served as
+ * anything but a JavaScript MIME type is rejected outright by the module
+ * loader, which reproduces the blank window this scheme exists to prevent.
+ *
+ * @param {string} filePath
+ * @returns {string}
+ */
+function contentTypeFor(filePath) {
+  return MIME_TYPES[path.extname(filePath).toLowerCase()] || "application/octet-stream";
+}
+
+/**
+ * Map a request URL onto a file inside the packaged web root.
+ *
+ * Split out from the protocol handler so the interesting cases — traversal
+ * attempts, SPA fallback, encoded paths — are unit-testable without booting
+ * Electron.
+ *
+ * @param {string} requestUrl - Full `app://` URL being requested
+ * @param {string} webRoot - Absolute path to the packaged web directory
+ * @param {(p: string) => boolean} [isFile] - Existence probe, injectable for tests
+ * @returns {{ filePath: string, isFallback: boolean } | null} null if the
+ *   request escapes the web root and must be refused
+ */
+function resolveRequestPath(requestUrl, webRoot, isFile = defaultIsFile) {
+  let pathname;
+  try {
+    ({ pathname } = new URL(requestUrl));
+  } catch {
+    return null;
+  }
+
+  // decodeURIComponent throws on malformed escapes (e.g. "%zz"); a request we
+  // cannot decode is one we cannot safely resolve.
+  let decoded;
+  try {
+    decoded = decodeURIComponent(pathname);
+  } catch {
+    return null;
+  }
+
+  const root = path.resolve(webRoot);
+  const candidate = path.resolve(root, "." + normalizeSeparators(decoded));
+
+  // Refuse anything that resolves outside the bundle. `path.resolve` has
+  // already collapsed any "..", so a prefix check is sufficient — but it must
+  // be a path-segment prefix, or "/webhook" would pass a check against "/web".
+  if (candidate !== root && !candidate.startsWith(root + path.sep)) {
+    return null;
+  }
+
+  if (isFile(candidate)) {
+    return { filePath: candidate, isFallback: false };
+  }
+
+  // SPA fallback: a client route such as /chat/abc has no file behind it and
+  // must be answered with index.html so the router can take over. Requests
+  // that look like assets are NOT rewritten — answering a missing .js with
+  // HTML is precisely the "Expected a JavaScript module" failure mode, and a
+  // real 404 is far easier to diagnose than an HTML file pretending to be code.
+  if (path.extname(candidate) === "") {
+    const indexPath = path.join(root, "index.html");
+    if (isFile(indexPath)) {
+      return { filePath: indexPath, isFallback: true };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Windows paths arrive with forward slashes in the URL; keep resolution
+ * platform-correct by converting before handing to path.resolve.
+ */
+function normalizeSeparators(urlPath) {
+  return path.sep === "\\" ? urlPath.replace(/\//g, "\\") : urlPath;
+}
+
+function defaultIsFile(candidate) {
+  try {
+    return fs.statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Declare the scheme's privileges. Must run before `app.whenReady()`.
+ *
+ * @param {import('electron').Protocol} protocol
+ */
+function registerSchemePrivileges(protocol) {
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: APP_SCHEME,
+      privileges: {
+        standard: true, // real origin => localStorage/IndexedDB work
+        secure: true, // treated as a secure context (crypto.subtle, etc.)
+        supportFetchAPI: true,
+        corsEnabled: true,
+        stream: true, // range requests, for media
+      },
+    },
+  ]);
+}
+
+/**
+ * Serve the packaged web directory over `app://`. Call after the app is ready.
+ *
+ * @param {import('electron').Protocol} protocol
+ * @param {string} webRoot - Absolute path to the packaged web directory
+ * @param {{ error: Function, warn: Function }} log
+ */
+function registerAppProtocol(protocol, webRoot, log) {
+  // The scheme is passed WITHOUT a trailing colon. `protocol.handle("app:")`
+  // does not throw — it silently registers nothing, and every load then fails
+  // with ERR_FAILED before the handler is consulted. Verified against Electron
+  // 39 with protocol.isProtocolHandled(), which is asserted below.
+  protocol.handle(APP_SCHEME, async (request) => {
+    const resolved = resolveRequestPath(request.url, webRoot);
+
+    if (!resolved) {
+      log.warn("[AppProtocol] refusing request:", request.url);
+      return new Response("Not found", {
+        status: 404,
+        headers: { "content-type": "text/plain" },
+      });
+    }
+
+    try {
+      const body = await fs.promises.readFile(resolved.filePath);
+      return new Response(body, {
+        status: 200,
+        headers: { "content-type": contentTypeFor(resolved.filePath) },
+      });
+    } catch (err) {
+      // A read failure here means the bundle is damaged. Say so loudly: this
+      // is the class of fault that otherwise presents as an empty window.
+      log.error("[AppProtocol] failed to read", resolved.filePath, err.message);
+      return new Response("Internal error", {
+        status: 500,
+        headers: { "content-type": "text/plain" },
+      });
+    }
+  });
+
+  // Fail loudly if registration did not take. A mis-registered scheme produces
+  // exactly the symptom this whole change exists to eliminate: a window that
+  // loads nothing, with no error attributable to a cause.
+  if (typeof protocol.isProtocolHandled === "function" && !protocol.isProtocolHandled(APP_SCHEME)) {
+    throw new Error(
+      `app-protocol: ${APP_SCHEME}:// did not register — the renderer cannot load. ` +
+        `Check that registerSchemePrivileges() ran before app ready.`
+    );
+  }
+}
+
+module.exports = {
+  APP_SCHEME,
+  APP_ORIGIN,
+  APP_INDEX_URL,
+  contentTypeFor,
+  registerAppProtocol,
+  registerSchemePrivileges,
+  resolveRequestPath,
+};

--- a/electron/src/diagnostics.js
+++ b/electron/src/diagnostics.js
@@ -1,0 +1,131 @@
+/**
+ * Diagnostics policy for packaged builds.
+ *
+ * v1.6.3 shipped a window that never rendered, and the user could not tell us
+ * anything about it: DevTools were hard-disabled in packaged builds, so there
+ * was no console to read and no way to reach the log file except by knowing
+ * the macOS path by heart.
+ *
+ * Two decisions come out of that, and the order matters.
+ *
+ * 1. The log file is the primary diagnostic, not DevTools. A renderer that
+ *    fails to boot cannot show its own console, and the console would not have
+ *    contained the interesting part anyway — the asset 404s and the daemon
+ *    spawn both happen in the main process. `main.log` already had everything
+ *    needed to diagnose this bug; it was simply unreachable. So diagnostics
+ *    are exposed as a menu item that reveals the log in Finder, which works
+ *    even when the window is blank.
+ *
+ * 2. DevTools become available in packaged builds, gated. Restricting them to
+ *    prerelease (`-rc`) builds was considered and rejected: the failure we
+ *    need to debug is the one a user hits on a STABLE build, and telling them
+ *    "install an RC to reproduce it" changes the artifact under test. The
+ *    threat model does not support hiding them either — the app ships its
+ *    renderer as readable files on disk, so DevTools reveal nothing an
+ *    attacker with local access could not already read, while the earlier
+ *    lockdown cost real diagnosability.
+ *
+ * They stay behind a deliberate gesture rather than F12 so an ordinary user
+ * cannot open them by accident: an explicit View-menu item, or
+ * RELIANT_DEVTOOLS=1 for a user we are actively walking through a bug.
+ */
+
+const DEVTOOLS_ENV_VAR = "RELIANT_DEVTOOLS";
+
+/**
+ * Whether DevTools may be opened at all.
+ *
+ * @param {{ isPackaged: boolean, env?: Record<string, string|undefined>, version?: string }} context
+ * @returns {boolean}
+ */
+function isDevToolsAllowed(context) {
+  if (!context.isPackaged) {
+    return true;
+  }
+  return isDevToolsEnvEnabled(context.env || {});
+}
+
+/**
+ * Whether DevTools should open automatically on launch.
+ *
+ * Only the env var does this. A prerelease build is still a build someone
+ * demos; auto-opening DevTools on every RC launch would be noise, and the
+ * menu item is one click away.
+ *
+ * @param {{ isPackaged: boolean, env?: Record<string, string|undefined> }} context
+ * @returns {boolean}
+ */
+function shouldAutoOpenDevTools(context) {
+  if (!context.isPackaged) {
+    return false;
+  }
+  return isDevToolsEnvEnabled(context.env || {});
+}
+
+/**
+ * Whether the View menu should offer DevTools.
+ *
+ * Always true. The menu item is the discoverable path for a user we are
+ * debugging with, and hiding it behind the same env var it enables would make
+ * it useless — nobody sets an env var for a GUI app they cannot open.
+ *
+ * @returns {boolean}
+ */
+function shouldShowDevToolsMenuItem() {
+  return true;
+}
+
+function isDevToolsEnvEnabled(env) {
+  const raw = env[DEVTOOLS_ENV_VAR];
+  if (!raw) return false;
+  const normalized = String(raw).trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+/**
+ * Whether a version string denotes a prerelease.
+ *
+ * Retained because the release channel is worth surfacing in the diagnostics
+ * report even though it no longer gates DevTools.
+ *
+ * @param {string} version
+ * @returns {boolean}
+ */
+function isPrereleaseVersion(version) {
+  if (!version || typeof version !== "string") return false;
+  return /-(rc|alpha|beta|next|canary)/i.test(version);
+}
+
+/**
+ * Build the human-readable diagnostics summary shown in the Help menu.
+ *
+ * Deliberately plain text: a user with a blank window can select it, copy it,
+ * and paste it into a bug report without any tooling.
+ *
+ * @param {{ version: string, electronVersion: string, platform: string, arch: string,
+ *           logPath: string, rendererUrl: string, backendReady: boolean,
+ *           backendPort: number|null, apiUrl: string }} info
+ * @returns {string}
+ */
+function formatDiagnosticsReport(info) {
+  return [
+    `Reliant ${info.version}${isPrereleaseVersion(info.version) ? " (prerelease)" : ""}`,
+    `Electron ${info.electronVersion} on ${info.platform}/${info.arch}`,
+    "",
+    `Renderer URL : ${info.rendererUrl || "(not loaded)"}`,
+    `Backend ready: ${info.backendReady ? "yes" : "no"}`,
+    `Backend port : ${info.backendPort ?? "(none)"}`,
+    `API URL      : ${info.apiUrl || "(unset)"}`,
+    "",
+    `Log file: ${info.logPath}`,
+  ].join("\n");
+}
+
+module.exports = {
+  DEVTOOLS_ENV_VAR,
+  formatDiagnosticsReport,
+  isDevToolsAllowed,
+  isPrereleaseVersion,
+  shouldAutoOpenDevTools,
+  shouldShowDevToolsMenuItem,
+};

--- a/electron/src/main.js
+++ b/electron/src/main.js
@@ -8,6 +8,7 @@ const {
   Tray,
   globalShortcut,
   Notification,
+  protocol,
 } = require("electron");
 
 // NOTE: With HTTP/2 (TLS), connection limits are not a concern.
@@ -34,6 +35,17 @@ const WindowManager = require("./window-manager");
 const BrowserManager = require("./browser-manager");
 const windowConfig = require("./window-config");
 const { shouldOpenExternally } = require("./navigation-policy");
+const {
+  APP_INDEX_URL,
+  registerAppProtocol,
+  registerSchemePrivileges,
+} = require("./app-protocol");
+const { watchRendererHealth } = require("./renderer-health");
+const {
+  formatDiagnosticsReport,
+  shouldAutoOpenDevTools,
+  shouldShowDevToolsMenuItem,
+} = require("./diagnostics");
 const authStorage = require("./auth-storage");
 const cliInstaller = require("./cli-installer");
 const {
@@ -1007,29 +1019,32 @@ async function createWindow(options = {}) {
     }
   });
 
-  if (app.isPackaged) {
-    mainWindow.webContents.on("will-navigate", (event, navigationUrl) => {
-      if (navigationUrl.startsWith("file://")) {
-        event.preventDefault();
-        const webPath = path.join(process.resourcesPath, "web", "index.html");
-        mainWindow.loadFile(webPath);
-      }
-    });
-  }
+  // NOTE: packaged builds no longer intercept in-app navigation. Under the old
+  // file:// load this handler existed because history navigation produced
+  // file:///some/route, which had no document behind it; it forced a reload of
+  // index.html and threw the route away. app:// serves index.html for unknown
+  // paths (the SPA fallback in app-protocol.js), so the router now handles its
+  // own routes and intercepting would break deep links.
 
   // Disable refresh and DevTools in production (installed builds only)
   if (app.isPackaged) {
     mainWindow.webContents.on("before-input-event", (event, input) => {
-      // Allow refresh but reload from file in production
+      // Reload in place. Previously this reloaded index.html from disk to work
+      // around file:// losing the route; app:// serves the current route
+      // correctly, so an ordinary reload preserves where the user was.
       if ((input.meta && input.key.toLowerCase() === "r") ||
           (input.control && input.key.toLowerCase() === "r") ||
           input.key === "F5") {
         event.preventDefault();
-        const webPath = path.join(process.resourcesPath, "web", "index.html");
-        mainWindow.loadFile(webPath);
+        mainWindow.webContents.reload();
       }
 
-      // Disable DevTools shortcuts in production
+      // DevTools keyboard shortcuts stay disabled in packaged builds so an
+      // ordinary user cannot open them by accident. The View menu item is the
+      // deliberate path in, and RELIANT_DEVTOOLS=1 is the one for a user we
+      // are actively debugging with. Blocking the KEYS is not the same as
+      // forcing DevTools closed, which is what previously made a blank window
+      // impossible to inspect at all.
       if (input.control && input.shift && input.key.toLowerCase() === "i") {
         event.preventDefault();
       }
@@ -1059,11 +1074,6 @@ async function createWindow(options = {}) {
       if (input.meta && input.key.toLowerCase() === "u") {
         event.preventDefault();
       }
-    });
-
-    // Completely disable DevTools in production
-    mainWindow.webContents.on("devtools-opened", () => {
-      mainWindow.webContents.closeDevTools();
     });
   }
 
@@ -1345,14 +1355,37 @@ async function createWindow(options = {}) {
     }
   });
 
-  mainWindow.webContents.on("did-fail-load", async (_e, code, desc, url) => {
-    log.error("[Window] did-fail-load:", { code, desc, url });
+  mainWindow.webContents.on("did-fail-load", async (_e, code, desc, url, isMainFrame) => {
+    log.error("[Window] did-fail-load:", { code, desc, url, isMainFrame });
+
+    // Only a top-level document failure is fatal. A failed subresource leaves
+    // a window that is up but possibly blank; renderer-health.js reports that
+    // case, and tearing the app down here would kill it before it could.
+    if (!isMainFrame) {
+      return;
+    }
+
     await dialog.showErrorBox(
       "Renderer load failed",
       `${code}: ${desc}\nURL: ${url || "(file)"}`
     );
     app.exit(1);
   });
+
+  // Catch the blank-window failure that reports success everywhere else.
+  watchRendererHealth(mainWindow, log, {
+    onUnhealthy: (reason) => {
+      log.error(
+        "[Window] renderer never mounted — see the log for the failing assets:",
+        reason
+      );
+    },
+  });
+
+  if (shouldAutoOpenDevTools({ isPackaged: app.isPackaged, env: process.env })) {
+    log.info("[Window] RELIANT_DEVTOOLS set — opening DevTools");
+    mainWindow.webContents.openDevTools({ mode: "detach" });
+  }
 
   // Crash / responsiveness diagnostics with recovery
   mainWindow.webContents.on("crashed", (event, killed) => {
@@ -1424,9 +1457,12 @@ async function createWindow(options = {}) {
   log.debug("[Window] process.env.USE_DEV_SERVER:", process.env.USE_DEV_SERVER);
 
   if (app.isPackaged) {
-    const webPath = path.join(process.resourcesPath, "web", "index.html");
-    log.debug("[Window] Production mode - loading from:", webPath);
-    await mainWindow.loadFile(webPath);
+    // Served over app:// rather than loadFile(). The bundle is built with
+    // base "/" for the web deploy, and those root-absolute asset paths
+    // resolve against the filesystem root under file:// — which is why
+    // v1.6.3 opened a blank window. See app-protocol.js.
+    log.info("[Window] Production mode - loading from:", APP_INDEX_URL);
+    await mainWindow.loadURL(APP_INDEX_URL);
   } else {
     log.debug(`[Window] Waiting for Vite at ${DEV_URL} ...`);
     await waitForPort(DEV_PORT).catch(async () => {
@@ -3456,6 +3492,74 @@ function createApplicationMenu() {
         { role: "zoomout" },
         { type: "separator" },
         { role: "togglefullscreen" },
+
+        // Diagnostics. These are the only tools a user has when the window
+        // comes up blank, so they must be reachable from the menu bar — which
+        // still works when nothing has rendered.
+        { type: "separator" },
+        ...(shouldShowDevToolsMenuItem()
+          ? [
+              {
+                label: "Toggle Developer Tools",
+                accelerator:
+                  process.platform === "darwin" ? "Cmd+Alt+Shift+I" : "Ctrl+Shift+Alt+I",
+                click: () => {
+                  const focusedWindow = BrowserWindow.getFocusedWindow();
+                  if (!focusedWindow) return;
+                  if (focusedWindow.webContents.isDevToolsOpened()) {
+                    focusedWindow.webContents.closeDevTools();
+                  } else {
+                    focusedWindow.webContents.openDevTools({ mode: "detach" });
+                  }
+                },
+              },
+            ]
+          : []),
+        {
+          label: "Open Log File",
+          click: async () => {
+            const logPath = log.getLogPath();
+            if (!logPath) {
+              await dialog.showErrorBox("No log file", "The log path is not available.");
+              return;
+            }
+            // Reveal rather than open: the user gets the folder and can hand
+            // the file to us, and it does not depend on a .log association.
+            shell.showItemInFolder(logPath);
+          },
+        },
+        {
+          label: "Copy Diagnostics",
+          click: async () => {
+            const { clipboard } = require("electron");
+            const focusedWindow = BrowserWindow.getFocusedWindow();
+            let backendReady = false;
+            let backendPort = null;
+            let apiUrl = "";
+            try {
+              if (backendManager) {
+                backendReady = await backendManager.isReady();
+                backendPort = backendManager.getPort();
+                apiUrl = backendManager.apiUrl || "";
+              }
+            } catch {
+              // Diagnostics must never fail on the way to being reported.
+            }
+            const report = formatDiagnosticsReport({
+              version: app.getVersion(),
+              electronVersion: process.versions.electron,
+              platform: process.platform,
+              arch: process.arch,
+              logPath: log.getLogPath(),
+              rendererUrl: focusedWindow ? focusedWindow.webContents.getURL() : "",
+              backendReady,
+              backendPort,
+              apiUrl,
+            });
+            clipboard.writeText(report);
+            log.info("[Diagnostics] copied to clipboard:\n" + report);
+          },
+        },
       ],
     },
     {
@@ -3692,6 +3796,10 @@ function ensureDirectoriesExist() {
   }
 }
 
+// Scheme privileges must be declared before the app is ready, or app:// is
+// treated as an opaque origin and localStorage throws in the renderer.
+registerSchemePrivileges(protocol);
+
 // Single instance lock - MUST be before protocol registration
 // Only enforce in production. In development, allow multiple instances to run
 // (e.g., dev build alongside production, or multiple worktrees).
@@ -3836,6 +3944,14 @@ app.whenReady().then(async () => {
   log.debug("[App] Electron version:", process.versions.electron);
   log.debug("[App] Node version:", process.versions.node);
   log.debug("[App] Chrome version:", process.versions.chrome);
+
+  // Serve the packaged renderer over app://. Must be registered before the
+  // first window loads.
+  if (app.isPackaged) {
+    const webRoot = path.join(process.resourcesPath, "web");
+    registerAppProtocol(protocol, webRoot, log);
+    log.info("[App] ✓ app:// protocol registered for", webRoot);
+  }
 
   // Ensure required directories exist
   const dirStart = Date.now();

--- a/electron/src/navigation-policy.js
+++ b/electron/src/navigation-policy.js
@@ -17,6 +17,12 @@
  * Extracted from main.js so it can be unit-tested without booting Electron.
  */
 
+// Duplicated rather than imported from app-protocol.js: that module pulls in
+// `fs` and Electron's `protocol`, and this one is deliberately dependency-free
+// so it can be unit-tested in plain node. The scheme name is asserted against
+// app-protocol's export in navigation-policy.test.js, so the two cannot drift.
+const APP_SCHEME = "app";
+
 /**
  * Decide whether a navigation target should be opened outside the app.
  *
@@ -37,7 +43,16 @@ function shouldOpenExternally(targetUrl, currentUrl) {
     return true;
   }
 
-  // Anything that isn't web content (mailto:, custom schemes) belongs to the OS.
+  // app:// is the packaged renderer's own scheme, so a navigation to it is
+  // in-app by definition. It has to be allowed explicitly: it is not http(s),
+  // and the rule below would hand every internal route change to the system
+  // browser — one tab per navigation, with the window stranded on the old
+  // route.
+  if (target.protocol === `${APP_SCHEME}:`) {
+    return false;
+  }
+
+  // Anything else that isn't web content (mailto:, custom schemes) belongs to the OS.
   if (target.protocol !== "http:" && target.protocol !== "https:") {
     return true;
   }

--- a/electron/src/renderer-health.js
+++ b/electron/src/renderer-health.js
@@ -1,0 +1,141 @@
+/**
+ * Detects the failure mode where the renderer loads but never starts.
+ *
+ * `did-fail-load` only fires when the top-level document fails. When
+ * index.html loads correctly but its module scripts 404 — the v1.6.3 bug —
+ * every main-process signal reports success: `did-finish-load` fires, the
+ * preload runs and injects config, and the window is shown. The app is blank
+ * and nothing anywhere says so.
+ *
+ * So we assert the thing that actually matters, which is that React mounted:
+ * check whether #root has children a few seconds after load. That is the
+ * difference between "the user reports a white screen and we have no idea" and
+ * a log line naming the exact asset that failed.
+ */
+
+const DEFAULT_GRACE_PERIOD_MS = 8000;
+
+/**
+ * Decide whether a renderer that finished loading actually started.
+ *
+ * Pure and injectable so the decision is testable without a real BrowserWindow.
+ *
+ * @param {{ rootChildCount: number, hasBundleError: boolean }} probe
+ * @returns {{ healthy: boolean, reason?: string }}
+ */
+function assessRendererHealth(probe) {
+  if (probe.hasBundleError) {
+    return { healthy: false, reason: "renderer reported a script/module load error" };
+  }
+  if (probe.rootChildCount > 0) {
+    return { healthy: true };
+  }
+  return {
+    healthy: false,
+    reason: "#root is empty — the app bundle never executed (assets likely failed to resolve)",
+  };
+}
+
+/**
+ * The script evaluated in the renderer to sample its state.
+ *
+ * Kept as a string constant so a test can assert we probe #root rather than
+ * something incidental, and deliberately defensive: it runs in a renderer that
+ * may be in an arbitrarily broken state, so it must never throw.
+ */
+const PROBE_SCRIPT = `(() => {
+  try {
+    const root = document.getElementById('root');
+    return {
+      rootChildCount: root ? root.childElementCount : 0,
+      hasBundleError: Boolean(window.__RELIANT_BUNDLE_ERROR__),
+    };
+  } catch (e) {
+    return { rootChildCount: 0, hasBundleError: true };
+  }
+})()`;
+
+/**
+ * Watch a window for the blank-renderer failure and report it.
+ *
+ * Diagnosis only — it does not reload or otherwise try to recover. A blank
+ * renderer here means the packaged bundle cannot resolve its own assets, which
+ * a reload would reproduce exactly; retrying would just hide the evidence
+ * behind a loop.
+ *
+ * @param {import('electron').BrowserWindow} window
+ * @param {{ info: Function, error: Function, warn: Function }} log
+ * @param {{ gracePeriodMs?: number, onUnhealthy?: (reason: string) => void }} [options]
+ * @returns {() => void} cancel function
+ */
+function watchRendererHealth(window, log, options = {}) {
+  const gracePeriodMs = options.gracePeriodMs ?? DEFAULT_GRACE_PERIOD_MS;
+  const failedResources = [];
+  let timer = null;
+  let cancelled = false;
+
+  // Subresource failures surface here and NOWHERE else — this listener is the
+  // only reason we can name the missing asset instead of guessing.
+  const onFailedSubresource = (_event, _code, desc, url, isMainFrame) => {
+    if (!isMainFrame) {
+      failedResources.push(`${url} (${desc})`);
+    }
+  };
+  window.webContents.on("did-fail-load", onFailedSubresource);
+
+  const onFinishLoad = () => {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(async () => {
+      if (cancelled || window.isDestroyed()) return;
+
+      let probe;
+      try {
+        probe = await window.webContents.executeJavaScript(PROBE_SCRIPT, true);
+      } catch (err) {
+        log.error("[RendererHealth] could not probe renderer:", err.message);
+        return;
+      }
+
+      const result = assessRendererHealth(probe);
+      if (result.healthy) {
+        log.info("[RendererHealth] renderer mounted successfully");
+        return;
+      }
+
+      log.error(
+        `[RendererHealth] BLANK WINDOW DETECTED after ${gracePeriodMs}ms: ${result.reason}`
+      );
+      log.error("[RendererHealth] renderer URL:", window.webContents.getURL());
+      if (failedResources.length > 0) {
+        log.error("[RendererHealth] failed subresources:");
+        for (const resource of failedResources) {
+          log.error("[RendererHealth]   -", resource);
+        }
+      } else {
+        log.error(
+          "[RendererHealth] no subresource failures were reported — check that index.html's asset paths match the scheme serving them"
+        );
+      }
+
+      if (options.onUnhealthy) {
+        options.onUnhealthy(result.reason);
+      }
+    }, gracePeriodMs);
+  };
+
+  window.webContents.on("did-finish-load", onFinishLoad);
+
+  return () => {
+    cancelled = true;
+    if (timer) clearTimeout(timer);
+    window.webContents.off("did-finish-load", onFinishLoad);
+    window.webContents.off("did-fail-load", onFailedSubresource);
+  };
+}
+
+module.exports = {
+  DEFAULT_GRACE_PERIOD_MS,
+  PROBE_SCRIPT,
+  assessRendererHealth,
+  watchRendererHealth,
+};

--- a/electron/src/window-manager.js
+++ b/electron/src/window-manager.js
@@ -3,6 +3,7 @@ const path = require('path');
 const log = require('./logger');
 const windowConfig = require('./window-config');
 const { shouldOpenExternally } = require('./navigation-policy');
+const { APP_INDEX_URL } = require('./app-protocol');
 // Note: Window state persistence is now handled in main.js via the backend API
 // Each worktree stores its own window state in ./data/window-state.json
 
@@ -87,11 +88,11 @@ class WindowManager {
 
       await loadDevURL();
     } else {
-      // In production, web files are in Resources/web (extraResources)
-      const webPath = path.join(process.resourcesPath, 'web');
-      const indexPath = path.join(webPath, 'index.html');
-      log.debug('[WindowManager] Loading index.html from:', indexPath);
-      await window.loadFile(indexPath);
+      // Served over app:// for the same reason as the main window: the bundle's
+      // root-absolute asset paths resolve against the filesystem root under
+      // file://, which yields a blank window. See app-protocol.js.
+      log.info('[WindowManager] Loading renderer from:', APP_INDEX_URL);
+      await window.loadURL(APP_INDEX_URL);
     }
 
     // Store window metadata

--- a/electron/test/app-protocol.test.js
+++ b/electron/test/app-protocol.test.js
@@ -1,0 +1,132 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+
+const {
+  APP_INDEX_URL,
+  APP_ORIGIN,
+  contentTypeFor,
+  resolveRequestPath,
+} = require('../src/app-protocol');
+
+const WEB_ROOT = path.resolve('/packaged/Resources/web');
+
+// A stand-in filesystem: only these files "exist".
+const PRESENT = new Set(
+  [
+    'index.html',
+    'assets/index-D98vjdRH.js',
+    'assets/index-BZqrqbFH.css',
+    'favicon.svg',
+    'fonts/Inter-roman.woff2',
+  ].map((p) => path.join(WEB_ROOT, ...p.split('/')))
+);
+
+const isFile = (candidate) => PRESENT.has(candidate);
+
+test('serves the root-absolute asset paths the Vite bundle actually requests', () => {
+  // The v1.6.3 bug in one assertion. The shipped index.html contains
+  // <script src="/assets/index-D98vjdRH.js">, which under file:// resolved to
+  // file:///assets/... — the filesystem root — and never loaded, leaving a
+  // blank window. Under app:// it must resolve inside the bundle.
+  const resolved = resolveRequestPath(
+    `${APP_ORIGIN}/assets/index-D98vjdRH.js`,
+    WEB_ROOT,
+    isFile
+  );
+
+  assert.ok(resolved, 'root-absolute asset request must resolve');
+  assert.strictEqual(
+    resolved.filePath,
+    path.join(WEB_ROOT, 'assets', 'index-D98vjdRH.js')
+  );
+  assert.strictEqual(resolved.isFallback, false);
+});
+
+test('serves index.html at the origin root', () => {
+  const resolved = resolveRequestPath(APP_INDEX_URL, WEB_ROOT, isFile);
+  assert.ok(resolved);
+  assert.strictEqual(resolved.filePath, path.join(WEB_ROOT, 'index.html'));
+});
+
+test('falls back to index.html for SPA routes so deep links and reloads work', () => {
+  // The other half of what file:// could not do: history.pushState under
+  // file:// produces file:///chat/abc, and reloading that 404s. A route with
+  // no file behind it must return the app shell.
+  for (const route of ['/chat/abc', '/auth/github/callback', '/settings']) {
+    const resolved = resolveRequestPath(`${APP_ORIGIN}${route}`, WEB_ROOT, isFile);
+    assert.ok(resolved, `route ${route} must resolve`);
+    assert.strictEqual(resolved.filePath, path.join(WEB_ROOT, 'index.html'));
+    assert.strictEqual(resolved.isFallback, true, `${route} should be a fallback`);
+  }
+});
+
+test('a missing ASSET 404s instead of falling back to index.html', () => {
+  // Serving HTML in place of a missing .js is what produces the opaque
+  // "Expected a JavaScript module" error. A real 404 names the actual problem.
+  const resolved = resolveRequestPath(
+    `${APP_ORIGIN}/assets/does-not-exist.js`,
+    WEB_ROOT,
+    isFile
+  );
+  assert.strictEqual(resolved, null);
+});
+
+test('refuses path traversal that survives URL normalization', () => {
+  // Plain "../" is collapsed by the URL parser before it reaches us, so the
+  // vector that actually matters is an ENCODED separator: %2f is not a path
+  // separator at parse time but becomes one at decode time. These must be
+  // refused by the containment check, not by the parser.
+  const escapes = [
+    `${APP_ORIGIN}/..%2f..%2fetc/passwd`,
+    `${APP_ORIGIN}/%2e%2e%2f%2e%2e%2fetc/passwd`,
+    `${APP_ORIGIN}/assets%2f..%2f..%2f..%2fetc/passwd`,
+  ];
+  for (const url of escapes) {
+    assert.strictEqual(
+      resolveRequestPath(url, WEB_ROOT, () => true),
+      null,
+      `${url} must be refused`
+    );
+  }
+});
+
+test('a sibling directory sharing a name prefix is outside the root', () => {
+  // Guards the containment check specifically: "/packaged/Resources/web-backup"
+  // must not pass a naive startsWith("/packaged/Resources/web") test. Reached
+  // via an encoded separator, since a plain "../" would be normalized away.
+  const resolved = resolveRequestPath(
+    `${APP_ORIGIN}/..%2fweb-backup%2fsecret.txt`,
+    WEB_ROOT,
+    () => true
+  );
+  assert.strictEqual(resolved, null);
+});
+
+test('decodes percent-encoded paths, and refuses malformed ones', () => {
+  const withSpace = path.join(WEB_ROOT, 'fonts', 'Inter roman.woff2');
+  const resolved = resolveRequestPath(
+    `${APP_ORIGIN}/fonts/Inter%20roman.woff2`,
+    WEB_ROOT,
+    (c) => c === withSpace
+  );
+  assert.ok(resolved);
+  assert.strictEqual(resolved.filePath, withSpace);
+
+  assert.strictEqual(
+    resolveRequestPath(`${APP_ORIGIN}/assets/%zz.js`, WEB_ROOT, isFile),
+    null
+  );
+});
+
+test('serves JavaScript with a MIME type the module loader accepts', () => {
+  // A module script served as anything else is rejected outright, which
+  // reproduces the blank window this scheme exists to prevent.
+  for (const file of ['index.js', 'chunk.mjs']) {
+    assert.strictEqual(contentTypeFor(file), 'text/javascript');
+  }
+  assert.strictEqual(contentTypeFor('index.html'), 'text/html');
+  assert.strictEqual(contentTypeFor('index.css'), 'text/css');
+  assert.strictEqual(contentTypeFor('Inter.woff2'), 'font/woff2');
+  assert.strictEqual(contentTypeFor('map.bin'), 'application/octet-stream');
+});

--- a/electron/test/diagnostics.test.js
+++ b/electron/test/diagnostics.test.js
@@ -1,0 +1,76 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+  DEVTOOLS_ENV_VAR,
+  formatDiagnosticsReport,
+  isDevToolsAllowed,
+  isPrereleaseVersion,
+  shouldAutoOpenDevTools,
+  shouldShowDevToolsMenuItem,
+} = require('../src/diagnostics');
+
+test('DevTools are reachable in a packaged build', () => {
+  // The regression that made v1.6.3 undiagnosable: packaged builds forced
+  // DevTools closed, so a blank window could not be inspected at all.
+  assert.strictEqual(
+    shouldShowDevToolsMenuItem(),
+    true,
+    'the menu item is the only way in when the window is blank'
+  );
+});
+
+test('the env var opens DevTools automatically in a packaged build', () => {
+  for (const value of ['1', 'true', 'TRUE', 'yes']) {
+    const env = { [DEVTOOLS_ENV_VAR]: value };
+    assert.strictEqual(isDevToolsAllowed({ isPackaged: true, env }), true, value);
+    assert.strictEqual(shouldAutoOpenDevTools({ isPackaged: true, env }), true, value);
+  }
+});
+
+test('DevTools do not auto-open for an ordinary packaged launch', () => {
+  assert.strictEqual(shouldAutoOpenDevTools({ isPackaged: true, env: {} }), false);
+  for (const value of ['0', 'false', '', 'no']) {
+    assert.strictEqual(
+      shouldAutoOpenDevTools({ isPackaged: true, env: { [DEVTOOLS_ENV_VAR]: value } }),
+      false,
+      value
+    );
+  }
+});
+
+test('development always allows DevTools and never force-opens them', () => {
+  assert.strictEqual(isDevToolsAllowed({ isPackaged: false, env: {} }), true);
+  assert.strictEqual(shouldAutoOpenDevTools({ isPackaged: false, env: {} }), false);
+});
+
+test('prerelease versions are recognised for the diagnostics header', () => {
+  for (const version of ['1.6.4-rc1', '1.7.0-beta.2', '2.0.0-alpha']) {
+    assert.strictEqual(isPrereleaseVersion(version), true, version);
+  }
+  for (const version of ['1.6.3', '1.6.4', '']) {
+    assert.strictEqual(isPrereleaseVersion(version), false, String(version));
+  }
+});
+
+test('the diagnostics report carries what a bug report needs', () => {
+  const report = formatDiagnosticsReport({
+    version: '1.6.3',
+    electronVersion: '39.2.7',
+    platform: 'darwin',
+    arch: 'arm64',
+    logPath: '/Users/x/Library/Logs/reliant/main.log',
+    rendererUrl: 'app://bundle/',
+    backendReady: false,
+    backendPort: 9190,
+    apiUrl: 'https://api.reliant.so/api',
+  });
+
+  // The renderer URL and the log path are the two facts that would have
+  // identified this bug from a user's paste.
+  assert.match(report, /app:\/\/bundle\//);
+  assert.match(report, /Library\/Logs\/reliant\/main\.log/);
+  assert.match(report, /Backend ready: no/);
+  assert.match(report, /9190/);
+  assert.match(report, /api\.reliant\.so/);
+});

--- a/electron/test/navigation-policy.test.js
+++ b/electron/test/navigation-policy.test.js
@@ -50,3 +50,27 @@ test("an unknown current URL keeps navigation in-app", () => {
   // first navigation at the browser.
   assert.strictEqual(shouldOpenExternally("http://127.0.0.1:5183/auth", ""), false);
 });
+
+test("app:// routes stay in-app", () => {
+  // The packaged renderer is served from app://, so its own route changes are
+  // in-app by definition. The generic "not http(s) => external" rule would
+  // hand every one of them to shell.openExternal — a browser tab per
+  // navigation, with the window stranded on the old route.
+  const PACKAGED = "app://bundle/";
+  assert.strictEqual(shouldOpenExternally("app://bundle/chat/abc", PACKAGED), false);
+  assert.strictEqual(shouldOpenExternally("app://bundle/auth", PACKAGED), false);
+  assert.strictEqual(shouldOpenExternally("app://bundle/", PACKAGED), false);
+});
+
+test("outbound links still leave a packaged window", () => {
+  const PACKAGED = "app://bundle/";
+  assert.strictEqual(shouldOpenExternally("https://reliantlabs.io/docs", PACKAGED), true);
+  assert.strictEqual(shouldOpenExternally("mailto:support@reliantlabs.io", PACKAGED), true);
+});
+
+test("the scheme matches the one app-protocol actually serves", () => {
+  // navigation-policy duplicates the scheme name to stay dependency-free;
+  // this is the assertion that keeps the two from drifting.
+  const { APP_ORIGIN } = require("../src/app-protocol");
+  assert.strictEqual(shouldOpenExternally(`${APP_ORIGIN}/chat/abc`, APP_ORIGIN), false);
+});

--- a/electron/test/renderer-health.test.js
+++ b/electron/test/renderer-health.test.js
@@ -1,0 +1,131 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+  PROBE_SCRIPT,
+  assessRendererHealth,
+  watchRendererHealth,
+} = require('../src/renderer-health');
+
+test('an empty #root after load is reported as unhealthy', () => {
+  // This is exactly the v1.6.3 state: the document loaded, the preload ran,
+  // did-finish-load fired — and nothing mounted.
+  const result = assessRendererHealth({ rootChildCount: 0, hasBundleError: false });
+  assert.strictEqual(result.healthy, false);
+  assert.match(result.reason, /#root is empty/);
+});
+
+test('a mounted app is healthy', () => {
+  assert.deepStrictEqual(
+    assessRendererHealth({ rootChildCount: 3, hasBundleError: false }),
+    { healthy: true }
+  );
+});
+
+test('an explicit bundle error is unhealthy even if something rendered', () => {
+  const result = assessRendererHealth({ rootChildCount: 5, hasBundleError: true });
+  assert.strictEqual(result.healthy, false);
+  assert.match(result.reason, /script\/module load error/);
+});
+
+test('the probe inspects #root and cannot throw', () => {
+  assert.match(PROBE_SCRIPT, /getElementById\('root'\)/);
+  assert.match(PROBE_SCRIPT, /try/);
+  assert.match(PROBE_SCRIPT, /catch/);
+});
+
+/** Minimal BrowserWindow stand-in driving the real listener wiring. */
+function fakeWindow(probeResult) {
+  const listeners = new Map();
+  return {
+    isDestroyed: () => false,
+    webContents: {
+      on(event, fn) {
+        if (!listeners.has(event)) listeners.set(event, []);
+        listeners.get(event).push(fn);
+      },
+      off(event, fn) {
+        const fns = listeners.get(event) || [];
+        const i = fns.indexOf(fn);
+        if (i >= 0) fns.splice(i, 1);
+      },
+      getURL: () => 'app://bundle/',
+      executeJavaScript: async () => probeResult,
+    },
+    emit(event, ...args) {
+      for (const fn of listeners.get(event) || []) fn(...args);
+    },
+  };
+}
+
+function captureLog() {
+  const lines = [];
+  const record = (...args) => lines.push(args.join(' '));
+  return { lines, info: record, warn: record, error: record };
+}
+
+test('a blank renderer triggers the unhealthy callback and names the failed asset', async () => {
+  const window = fakeWindow({ rootChildCount: 0, hasBundleError: false });
+  const log = captureLog();
+  let reported = null;
+
+  watchRendererHealth(window, log, {
+    gracePeriodMs: 5,
+    onUnhealthy: (reason) => {
+      reported = reason;
+    },
+  });
+
+  // A subresource failure, which is the only place the missing asset appears.
+  window.emit('did-fail-load', {}, -6, 'ERR_FILE_NOT_FOUND', 'file:///assets/index.js', false);
+  window.emit('did-finish-load');
+
+  await new Promise((r) => setTimeout(r, 40));
+
+  assert.ok(reported, 'expected the blank renderer to be reported');
+  const output = log.lines.join('\n');
+  assert.match(output, /BLANK WINDOW DETECTED/);
+  assert.match(
+    output,
+    /assets\/index\.js/,
+    'the report must name the asset that failed, or it is not actionable'
+  );
+});
+
+test('a healthy renderer reports nothing', async () => {
+  const window = fakeWindow({ rootChildCount: 4, hasBundleError: false });
+  const log = captureLog();
+  let reported = null;
+
+  watchRendererHealth(window, log, {
+    gracePeriodMs: 5,
+    onUnhealthy: (reason) => {
+      reported = reason;
+    },
+  });
+
+  window.emit('did-finish-load');
+  await new Promise((r) => setTimeout(r, 40));
+
+  assert.strictEqual(reported, null);
+  assert.match(log.lines.join('\n'), /mounted successfully/);
+});
+
+test('cancelling before the grace period suppresses the check', async () => {
+  const window = fakeWindow({ rootChildCount: 0, hasBundleError: false });
+  const log = captureLog();
+  let reported = null;
+
+  const cancel = watchRendererHealth(window, log, {
+    gracePeriodMs: 20,
+    onUnhealthy: (reason) => {
+      reported = reason;
+    },
+  });
+
+  window.emit('did-finish-load');
+  cancel();
+  await new Promise((r) => setTimeout(r, 50));
+
+  assert.strictEqual(reported, null, 'a cancelled watcher must not fire');
+});


### PR DESCRIPTION
## The bug

The packaged app opens a **blank window**. `index.html` loads, the preload runs,
`did-finish-load` fires — and no JavaScript ever executes.

Vite builds with `base: "/"`, so `index.html` requests `/assets/index-<hash>.js`.
The packaged app loaded it with `loadFile()`, giving the page a `file://` origin,
where a root-absolute path resolves against the **filesystem root**. The renderer
asked for `file:///assets/index-D98vjdRH.js`, which does not exist.

Nothing reported it, because the *document* loaded fine — `did-fail-load` only
fires for the top-level frame, so a 404'd subresource is silent.

## Evidence (from the shipped artifact, not from source)

Extracted `app.asar` from `Reliant-1.6.3-mac-arm64.dmg` and loaded its
`index.html` in Electron exactly as the app does:

```
did-finish-load fired:      true
#root innerHTML length:     0        (EMPTY => blank screen)
module script resolved URL: file:///assets/index-D98vjdRH.js
subresource failures:       []
```

**`build-config.js` shipped fully populated** — `RELIANT_SERVER_URL`,
`SUPABASE_URL`, `SUPABASE_ANON_KEY`, `STATSIG_CLIENT_KEY`, `SENTRY_DSN` all
present. This is *not* the v1.6.2-class injection bug. (`RELIANT_GATEWAY_URL` is
empty by design; the daemon derives it.)

v1.6.2's `index.html` has byte-identical asset paths — `base: "/"` landed in
**v1.4.1** (`0bc523c2`). This is long-standing, not a v1.6.3 regression.

## Why not just change the base back

The same bundle ships to two places with incompatible needs:

| | needs |
|---|---|
| `app.reliantlabs.io` | `base: "/"` — a relative base breaks deep routes on refresh |
| packaged Electron | not `file://` — root-absolute paths escape to the filesystem root |

`file://` also can't support the router at all: TanStack Router uses path-based
history, and `history.pushState` under `file://` yields `file:///chat/abc`, which
404s on reload (verified). The old `will-navigate` handler that force-reloaded
`index.html` was papering over exactly this, discarding the user's route.

## The fix

Serve the renderer from a standard `app://` scheme. Real origin, real root, so
`/assets/*` resolves inside the packaged web dir and unknown paths fall back to
`index.html` like a web server's SPA fallback. **The web build is untouched.**

Registering it `standard: true, secure: true` is load-bearing — an opaque origin
makes `localStorage` throw, breaking every persisted store.

**Verified end-to-end against the actual broken artifact:**

```
renderer URL   : app://bundle/auth
#root children : 3          => REACT MOUNTED
storage        : localStorage OK: 1
deep route     : app://bundle/chat/abc
```

### Two traps found while validating

- **`protocol.handle()` takes the scheme WITHOUT a trailing colon.** `"app:"`
  doesn't throw — it registers nothing, and loads fail with `ERR_FAILED` before
  the handler runs. Now asserted via `isProtocolHandled()`.
- **`shouldOpenExternally()`** treated any non-http(s) scheme as external, so
  every in-app `app://` navigation would have spawned a browser tab.

## Diagnosability

None of the existing signals caught this, so:

- **`renderer-health.js`** asserts React actually mounted (`#root` has children)
  and logs the failing subresources if not. Verified in both directions — it
  reports the original `file://` failure and stays quiet when healthy.
- **`did-fail-load`** no longer exits the app for a failed *subresource*.
- **View → Open Log File / Copy Diagnostics.** `~/Library/Logs/reliant/main.log`
  already had everything needed to diagnose this; it was just unreachable from a
  blank window. The menu bar works even when nothing renders.
- **DevTools reachable in packaged builds** via menu item or `RELIANT_DEVTOOLS=1`,
  instead of being force-closed. Keyboard shortcuts stay disabled.

Gating DevTools on `-rc` builds was considered and rejected: the failure we need
to debug is the one users hit on *stable*, and telling them to install an RC
changes the artifact under test.

## Not addressed here

The daemon also fails to become ready (`SIGKILL` after a failed PAT mint). It's a
real second bug, but the renderer fails before the daemon matters and would fail
identically with a healthy daemon. Documented in `ELECTRON_LOAD_FAILURE.md`;
likely overlaps with the `reliant auth serve` env-prefix work.

## Testing

`npm test` in `electron/`: **120 pass, 0 fail** (26 new). Verified the new
navigation-policy test fails against the pre-fix code.
