### PR TITLE
test(cli): pin that production renders a bare CLI command

### DIFF
--- a/web/src/lib/cli-commands.test.ts
+++ b/web/src/lib/cli-commands.test.ts
@@ -103,3 +103,50 @@ describe('daemonStartCommand gateway handling', () => {
     );
   });
 });
+
+describe('production renders a bare command', () => {
+  // The released binary carries the hosted server/gateway/admin/auth defaults
+  // compiled in (release.yml injects them into internal/builddefaults via -X),
+  // so prod must print `reliant auth serve` with NO env prefix.
+  //
+  // This shipped broken: isNonProd() keys off VITE_CLI_DEFAULTS_BAKED and
+  // NOTHING set it — not the release workflow, not the KCL frontend env — so
+  // production always took the non-prod branch and told users to paste five
+  // RELIANT_*= overrides, including the Supabase anon key, for a binary that
+  // already knew every one of them.
+  it('emits no env prefix when the CLI defaults are baked', async () => {
+    setEnv({
+      DEV: undefined,
+      VITE_CLI_DEFAULTS_BAKED: 'true',
+      VITE_API_URL: 'https://api.reliantapi.com',
+      VITE_GATEWAY_URL: 'https://gateway.reliantapi.com',
+      VITE_CONTROL_PLANE_API_URL: 'https://admin.reliantapi.com',
+      VITE_SUPABASE_URL: 'https://dash.reliantlabs.io',
+      VITE_SUPABASE_ANON_KEY: 'sb_publishable_example',
+    });
+    const { authServeCommand, daemonStartCommand } = await load();
+    expect(authServeCommand()).toBe('reliant auth serve');
+    expect(daemonStartCommand()).not.toContain('RELIANT_');
+  });
+
+  it('never leaks the auth key into a copy-pasteable prod command', async () => {
+    setEnv({
+      DEV: undefined,
+      VITE_CLI_DEFAULTS_BAKED: 'true',
+      VITE_SUPABASE_ANON_KEY: 'sb_publishable_secret_looking_value',
+    });
+    const { authServeCommand } = await load();
+    expect(authServeCommand()).not.toContain('sb_publishable');
+  });
+
+  it('still emits overrides for a non-prod build', async () => {
+    // staging/preprod/dev CLI builds carry no injected defaults, so their
+    // users genuinely need the prefix — the flag is absent there.
+    setEnv({
+      VITE_CLI_DEFAULTS_BAKED: undefined,
+      VITE_API_URL: 'https://preprod.reliantapi.com',
+    });
+    const { authServeCommand } = await load();
+    expect(authServeCommand()).toContain('RELIANT_SERVER_URL=');
+  });
+});


### PR DESCRIPTION
Production tells users to run `reliant auth serve` behind **five `RELIANT_*=` overrides — including the Supabase anon key** — for a binary that already has every one of those values compiled in.

```
RELIANT_SERVER_URL=https://api.reliantapi.com RELIANT_GATEWAY_URL=https://gateway.reliantapi.com \
RELIANT_API_BASE_URL=https://admin.reliantapi.com RELIANT_AUTH_URL=https://dash.reliantlabs.io \
RELIANT_AUTH_KEY=sb_publishable_... reliant auth serve
```

## The code was right; nothing turned it on

`cli-commands.ts` is correct and always was — `isNonProd()` returns `false` when `VITE_CLI_DEFAULTS_BAKED === "true"`, and the prefix is skipped. **The defect is that nothing ever set that flag.** Not `release.yml`, not the KCL frontend env. I grepped both repos: zero occurrences outside `cli-commands.ts` itself. So production silently took the non-prod branch every time.

I verified the values genuinely ARE baked by extracting the shipped v1.6.3 DMG — `dash.reliantlabs.io` and the `sb_publishable_...` key are both present in the binary, and the release run logged `Compiled-in ServerURL = ***`.

## Why no test caught it

No test exercised the baked-defaults branch at all. These three do:

1. **Bare command when the flag is set** — the actual contract.
2. **No auth key in a copy-pasteable prod command** — the user-facing symptom stated as an invariant.
3. **Overrides still present without the flag** — staging/preprod CLI builds carry no injected defaults and genuinely need them, so this must not regress.

Verified load-bearing: removing the `VITE_CLI_DEFAULTS_BAKED` check makes 2 of the 3 fail; restored, all 10 pass.

One subtlety worth knowing — the prod-branch tests must clear `import.meta.env.DEV`, which vitest sets `true`. It short-circuits `isNonProd()` before the flag is ever read, so without that the tests pass vacuously against the old behaviour.

## Companion PR

The flag itself is set for **prod only** in control-plane: reliant-labs/control-plane#111. Both are needed — this one pins the behaviour, that one enables it.

Not merged — awaiting review.