### PR TITLE
fix(web): give stranded users a way to settings, and keep modals off /onboarding

### DIFF
--- a/web/src/components/AuthInitializer.tsx
+++ b/web/src/components/AuthInitializer.tsx
@@ -38,6 +38,25 @@ export function AuthInitializer({ children }: AuthInitializerProps) {
         logger.info("[AuthInitializer] User logged out, resetting prefetch and API check state");
         hasPrefetched.current = false;
         resetApiKeyCheck();
+
+        // The onboarding checklist is per-user, but it mirrors itself to
+        // localStorage (`reliant.checklist.*`) so a reload can decide offline
+        // whether the guide was already dismissed. That mirror is device-wide
+        // and outlives the session, so without this reset the NEXT account to
+        // sign in on this device inherits the previous user's progress.
+        //
+        // `welcomeShown` is the damaging one: apiKeySetupStore treats it as
+        // "this user has been introduced to the product" and defers the
+        // api-key-setup modal until it is true. Inherited, it reads as true
+        // for a brand-new user, so the modal fires immediately — including
+        // over `/onboarding`, whose z-40 overlay it outranks at z-50.
+        void import("../store/onboardingChecklistStore").then(
+          ({ useOnboardingChecklistStore }) => {
+            useOnboardingChecklistStore.getState().reset();
+          },
+        ).catch((error) => {
+          logger.warn("[AuthInitializer] Checklist reset failed:", error);
+        });
       }
 
       if (hasInitializedAuthenticatedStartup.current) {

--- a/web/src/components/Layout/Header.tsx
+++ b/web/src/components/Layout/Header.tsx
@@ -7,6 +7,7 @@ import {
   PanelRight,
   PanelLeft,
   FolderGit2,
+  Settings,
 } from "lucide-react";
 import {
   useState,
@@ -59,6 +60,7 @@ export const Header = forwardRef<HeaderRef, HeaderProps>(
   (
     {
       windowAligned = true,
+      onNavigateToSettings,
       onNavigateToWorktrees,
       onNavigateToSettingsSection: _onNavigateToSettingsSection,
       onNavigateToChats: _onNavigateToChats,
@@ -317,6 +319,31 @@ export const Header = forwardRef<HeaderRef, HeaderProps>(
 
             {/* Config Health Indicator */}
             {!projectPickerMode && <ConfigHealthIndicator />}
+
+            {/* Settings. Deliberately NOT gated on `projectPickerMode`, unlike
+                every other control on this row. The Sidebar — which holds the
+                app's only other Settings link — renders solely inside the main
+                app shell, and that shell requires a selected project. A user
+                whose daemon never provisions never gets a project, so without
+                this button they cannot reach /settings at all, and therefore
+                cannot sign out. /settings itself needs neither a daemon nor a
+                project; it is gated only on auth. */}
+            {onNavigateToSettings && (
+              <Tooltip
+                content={`Settings (${formatShortcut("onToggleSettings")})`}
+                placement="bottom"
+                delay={300}
+              >
+                <button
+                  onClick={onNavigateToSettings}
+                  className="header-icon-btn p-1.5 rounded text-xs transition-colors"
+                  aria-label="Settings"
+                  data-testid="header-settings-button"
+                >
+                  <Settings className="w-4 h-4" />
+                </button>
+              </Tooltip>
+            )}
 
             {/* Window controls for non-Mac Electron only — browsers can't drive these */}
             {showWindowControls && (

--- a/web/src/components/Layout/__tests__/Header.settings.test.tsx
+++ b/web/src/components/Layout/__tests__/Header.settings.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * The Header's Settings button must survive project-picker mode.
+ *
+ * The app's only other Settings link lives in the Sidebar, which renders
+ * exclusively inside ModernApp's main app shell — and that shell requires a
+ * selected project. A user whose daemon never provisions never gets a project,
+ * so if this button is gated on `!projectPickerMode` (as every other control
+ * on the row is) there is no route to /settings at all, and therefore no way
+ * to sign out.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("../../../store/projectStore", () => ({
+  useProjectStore: (selector: (s: unknown) => unknown) =>
+    selector({ currentProject: null }),
+}));
+
+vi.mock("../../../store/worktreeStore", () => ({
+  useWorktreeStore: (selector: (s: unknown) => unknown) =>
+    selector({ currentWorktree: null, worktrees: [] }),
+}));
+
+vi.mock("../../../store/shortcutsStore", () => ({
+  useShortcutsStore: (selector: (s: unknown) => unknown) =>
+    selector({ shortcuts: {} }),
+}));
+
+vi.mock("../../../hooks/useTitleBarChrome", () => ({
+  useTitleBarChrome: () => ({
+    isElectron: false,
+    trafficLightPadding: 0,
+    dragRegionStyle: {},
+    noDragRegionStyle: {},
+    showWindowControls: false,
+  }),
+}));
+
+// Chrome that only renders outside picker mode — stubbed so the Header can
+// mount without their data dependencies.
+vi.mock("../ConfigHealthIndicator", () => ({
+  ConfigHealthIndicator: () => null,
+}));
+vi.mock("../DaemonStatusDot", () => ({ DaemonStatusDot: () => null }));
+vi.mock("../DetectedPortsChip", () => ({ DetectedPortsChip: () => null }));
+
+import { Header } from "../Header";
+
+describe("Header settings escape hatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The Header's theme effect reads matchMedia, which jsdom does not
+    // implement. Irrelevant to what these tests assert.
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the Settings button in project-picker mode", async () => {
+    const onNavigateToSettings = vi.fn();
+    render(
+      <Header projectPickerMode onNavigateToSettings={onNavigateToSettings} />,
+    );
+
+    const button = screen.getByTestId("header-settings-button");
+    await userEvent.click(button);
+
+    expect(onNavigateToSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders it outside picker mode too", () => {
+    render(
+      <Header projectPickerMode={false} onNavigateToSettings={vi.fn()} />,
+    );
+    expect(screen.getByTestId("header-settings-button")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/Modals/ModalLayer.tsx
+++ b/web/src/components/Modals/ModalLayer.tsx
@@ -10,11 +10,13 @@
  * stay visible regardless of which branch is currently rendering.
  */
 
+import { useLocation } from "@tanstack/react-router";
 import {
   useModalStore,
   type UpgradeRequiredData,
   type BillingEmailRequiredData,
 } from "@/store/modalStore";
+import { isModalAllowedOnRoute } from "./modalRoutePolicy";
 import { ApiKeySetupModal } from "../ApiKeySetupModal";
 import { UpgradeRequiredModal } from "../UpgradeRequiredModal";
 import { BillingEmailRequiredModal } from "../BillingEmailRequiredModal";
@@ -23,6 +25,16 @@ export function ModalLayer() {
   const activeModal = useModalStore((s) => s.activeModal);
   const data = useModalStore((s) => s.data);
   const closeModal = useModalStore((s) => s.closeModal);
+  const { pathname } = useLocation();
+
+  // Some routes own the screen while they are active — see modalRoutePolicy.
+  // Suppressing here rather than clearing `activeModal` is deliberate: the
+  // modal is hidden for as long as the user is on that route and reappears if
+  // it is still relevant once they leave, so a request the user actually made
+  // is deferred rather than silently dropped.
+  if (activeModal && !isModalAllowedOnRoute(activeModal, pathname)) {
+    return null;
+  }
 
   if (activeModal === "api-key-setup") {
     return <ApiKeySetupModal isOpen onClose={closeModal} />;

--- a/web/src/components/Modals/__tests__/ModalLayer.onboarding.test.tsx
+++ b/web/src/components/Modals/__tests__/ModalLayer.onboarding.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * ModalLayer must respect the route it is rendering over.
+ *
+ * The layer is mounted on the root route so modals survive navigation, which
+ * also means it renders on `/onboarding` — a `fixed inset-0 z-40` overlay that
+ * every modal (z-50) outranks. These tests pin that an api-key-setup modal
+ * raised while onboarding is active stays hidden, and comes back once the user
+ * is somewhere it belongs.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+
+vi.mock("../../ApiKeySetupModal", () => ({
+  ApiKeySetupModal: () => <div data-testid="api-key-setup-modal" />,
+}));
+vi.mock("../../UpgradeRequiredModal", () => ({
+  UpgradeRequiredModal: () => <div data-testid="upgrade-required-modal" />,
+}));
+vi.mock("../../BillingEmailRequiredModal", () => ({
+  BillingEmailRequiredModal: () => (
+    <div data-testid="billing-email-required-modal" />
+  ),
+}));
+
+import { ModalLayer } from "../ModalLayer";
+import { useModalStore } from "@/store/modalStore";
+
+/**
+ * Renders ModalLayer under a real router at `pathname`, and does not return
+ * until the route has actually resolved.
+ *
+ * The await matters. RouterProvider mounts asynchronously, so a synchronous
+ * `queryByTestId` immediately after `render` finds nothing whether or not the
+ * modal was suppressed — a "modal is absent" assertion would pass vacuously
+ * even with the route policy deleted. Waiting for the route marker proves the
+ * tree is mounted, so a later absence is a real absence.
+ */
+async function renderAt(pathname: string) {
+  const rootRoute = createRootRoute({
+    component: () => (
+      <>
+        <Outlet />
+        <ModalLayer />
+      </>
+    ),
+  });
+  const routes = ["/", "/onboarding", "/settings"].map((path) =>
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path,
+      component: () => <div data-testid="route-ready" />,
+    }),
+  );
+  const router = createRouter({
+    routeTree: rootRoute.addChildren(routes),
+    history: createMemoryHistory({ initialEntries: [pathname] }),
+  });
+  const result = render(<RouterProvider router={router as any} />);
+  await screen.findByTestId("route-ready");
+  return result;
+}
+
+describe("ModalLayer route awareness", () => {
+  beforeEach(() => {
+    useModalStore.setState({ activeModal: null, data: undefined });
+  });
+
+  it("does not render the api-key-setup modal on /onboarding", async () => {
+    useModalStore.getState().openModal("api-key-setup");
+    await renderAt("/onboarding");
+
+    expect(
+      screen.queryByTestId("api-key-setup-modal"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders it on a route that does not own the screen", async () => {
+    useModalStore.getState().openModal("api-key-setup");
+    await renderAt("/");
+
+    expect(await screen.findByTestId("api-key-setup-modal")).toBeInTheDocument();
+  });
+
+  it("suppresses rather than clears, so the request is not silently dropped", async () => {
+    useModalStore.getState().openModal("api-key-setup");
+    await renderAt("/onboarding");
+
+    // Still "open" in the store — it simply has nowhere legitimate to draw.
+    // Leaving /onboarding re-renders it if it is still relevant.
+    expect(useModalStore.getState().activeModal).toBe("api-key-setup");
+  });
+
+  it("still renders billing modals on /onboarding", async () => {
+    useModalStore.getState().openModal("billing-email-required", {
+      message: "billing email required",
+    });
+    await renderAt("/onboarding");
+
+    expect(
+      await screen.findByTestId("billing-email-required-modal"),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/Modals/__tests__/modalRoutePolicy.test.ts
+++ b/web/src/components/Modals/__tests__/modalRoutePolicy.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Route policy for globally-mounted modals.
+ *
+ * ModalLayer is mounted at the root route, so it renders on every screen with
+ * no idea what is underneath it. `/onboarding` is a full-screen z-40 overlay
+ * and modals are z-50, so a modal opened while onboarding is active covers the
+ * setup flow. These tests pin which modals each route tolerates.
+ */
+import { describe, expect, it } from "vitest";
+import { isModalAllowedOnRoute } from "../modalRoutePolicy";
+
+describe("isModalAllowedOnRoute", () => {
+  it("suppresses the api-key-setup modal on /onboarding", () => {
+    expect(isModalAllowedOnRoute("api-key-setup", "/onboarding")).toBe(false);
+  });
+
+  it("suppresses it on nested onboarding paths and trailing slashes", () => {
+    expect(isModalAllowedOnRoute("api-key-setup", "/onboarding/")).toBe(false);
+    expect(isModalAllowedOnRoute("api-key-setup", "/onboarding/step-2")).toBe(
+      false,
+    );
+  });
+
+  it("allows it everywhere else", () => {
+    for (const pathname of ["/", "/project/p1", "/settings", "/m/chats"]) {
+      expect(isModalAllowedOnRoute("api-key-setup", pathname)).toBe(true);
+    }
+  });
+
+  it("does not match a sibling route that merely shares the prefix", () => {
+    expect(isModalAllowedOnRoute("api-key-setup", "/onboarding-help")).toBe(
+      true,
+    );
+  });
+
+  it("still allows billing modals on /onboarding", () => {
+    // These are raised in direct response to a request the user just made and
+    // explain why it failed. Suppressing them would turn a clear error into a
+    // silent no-op, which is worse than the overlap.
+    expect(isModalAllowedOnRoute("upgrade-required", "/onboarding")).toBe(true);
+    expect(isModalAllowedOnRoute("billing-email-required", "/onboarding")).toBe(
+      true,
+    );
+  });
+});

--- a/web/src/components/Modals/modalRoutePolicy.ts
+++ b/web/src/components/Modals/modalRoutePolicy.ts
@@ -1,0 +1,59 @@
+/**
+ * Which globally-mounted modals a given route will tolerate.
+ *
+ * `ModalLayer` is mounted on the root route so modals survive navigation, but
+ * that also means it has no idea what is underneath it. Some routes own the
+ * whole screen for the duration of a flow, and a modal that lands on top of
+ * one is wrong regardless of how it got opened.
+ *
+ * `/onboarding` is the clear case. It renders a `fixed inset-0 z-40` overlay
+ * and every modal renders at `z-50`, so a modal drawn while onboarding is
+ * active covers the setup flow — the user is asked to configure a credential
+ * before they have been told what the product is, and dismissing it returns
+ * them to a step they had not yet seen.
+ *
+ * This is a policy layer, not the fix for any particular trigger. It is
+ * expressed as a pure function of the pathname so it can be tested without a
+ * router and so adding a route means editing one list.
+ */
+
+import type { ModalId } from "@/store/modalStore";
+
+/**
+ * Modals that may never render over `/onboarding`.
+ *
+ * `api-key-setup` is here because onboarding's own ModelStep already collects
+ * a provider credential — the modal duplicates a step the user is in the
+ * middle of, using different copy.
+ *
+ * The billing modals are deliberately NOT listed. They are raised in direct
+ * response to a request the user just made (a backend 402 / billing-email
+ * error) and explain why that request failed, so suppressing them would
+ * replace a clear explanation with a silent no-op.
+ */
+const SUPPRESSED_ON_ONBOARDING: readonly ModalId[] = ["api-key-setup"];
+
+/**
+ * True when `modalId` is allowed to render on `pathname`.
+ *
+ * Unknown routes allow everything: this is a narrow deny-list, so a route
+ * that has not opted in behaves exactly as it did before.
+ */
+export function isModalAllowedOnRoute(
+  modalId: ModalId,
+  pathname: string,
+): boolean {
+  if (isOnboardingRoute(pathname) && SUPPRESSED_ON_ONBOARDING.includes(modalId)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Matches `/onboarding` and any nested path, but not sibling routes that
+ * merely share the prefix (`/onboarding-help`). Trailing slashes are
+ * tolerated because the router appends one on some navigations.
+ */
+function isOnboardingRoute(pathname: string): boolean {
+  return pathname === "/onboarding" || pathname.startsWith("/onboarding/");
+}

--- a/web/src/components/OnboardingFlow/OnboardingEscapeHatch.tsx
+++ b/web/src/components/OnboardingFlow/OnboardingEscapeHatch.tsx
@@ -1,0 +1,87 @@
+/**
+ * The way out of `/onboarding`.
+ *
+ * Onboarding is a `fixed inset-0 z-40` overlay on its own route, so none of
+ * the app chrome that normally carries a Settings link renders behind it —
+ * the Header is suppressed (`showHeader` gates on `!inOnboarding`) and the
+ * Sidebar needs a selected project, which is precisely what a user stuck here
+ * does not have.
+ *
+ * That made the flow a dead end whenever it could not be completed: a user
+ * whose daemon never provisions cannot finish onboarding, cannot reach
+ * `/settings`, and therefore cannot sign out. Sign-out in particular has to
+ * work from here, because switching accounts is the one repair a stranded
+ * user can perform without our help.
+ *
+ * `/settings` is reachable mid-onboarding: it is gated on auth alone, and the
+ * only redirects back to `/onboarding` come from `ModernApp` (which mounts on
+ * `/` and `/project/$projectId`) and `MobileShell` (`/m/*`), so neither fires
+ * on the settings route.
+ */
+import { useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { LogOut, Settings } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { logger } from "@/lib/logger";
+import { useAuthStore } from "@/store/authStore";
+
+export function OnboardingEscapeHatch({ className }: { className?: string }) {
+  const navigate = useNavigate();
+  const signOut = useAuthStore((s) => s.signOut);
+  const [isSigningOut, setIsSigningOut] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSignOut = async () => {
+    if (isSigningOut) return;
+    setIsSigningOut(true);
+    setError(null);
+    try {
+      await signOut();
+      // Navigate explicitly rather than leaving it to AuthGuard. The guard
+      // does bounce an unauthenticated user eventually, but there is a render
+      // gap in which this route's own "needs onboarding" logic can re-assert
+      // itself and put the user straight back here.
+      await navigate({ to: "/auth", search: { redirect: undefined } });
+    } catch (err) {
+      logger.warn("[OnboardingEscapeHatch] sign out failed", err);
+      setError(err instanceof Error ? err.message : "Could not sign out");
+      setIsSigningOut(false);
+    }
+  };
+
+  const buttonClass =
+    "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium " +
+    "text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground " +
+    "disabled:cursor-not-allowed disabled:opacity-60";
+
+  return (
+    <div className={cn("flex flex-col items-end gap-1", className)}>
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          onClick={() => navigate({ to: "/settings" })}
+          className={buttonClass}
+          data-testid="onboarding-settings-link"
+        >
+          <Settings className="h-3.5 w-3.5" />
+          Settings
+        </button>
+        <button
+          type="button"
+          onClick={handleSignOut}
+          disabled={isSigningOut}
+          className={buttonClass}
+          data-testid="onboarding-sign-out"
+        >
+          <LogOut className="h-3.5 w-3.5" />
+          {isSigningOut ? "Signing out…" : "Sign out"}
+        </button>
+      </div>
+      {error && (
+        <p className="text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/OnboardingFlow/OnboardingPage.tsx
+++ b/web/src/components/OnboardingFlow/OnboardingPage.tsx
@@ -1,6 +1,7 @@
 import { ChevronLeft } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ProgressBar } from './ProgressBar';
+import { OnboardingEscapeHatch } from './OnboardingEscapeHatch';
 import { useOnboardingPlan } from './useOnboardingPlan';
 import { BACK_CLEARS, deriveStep, getStepsForPlan, stepMaxWidth, STEP_COMPONENTS, STEP_LABELS } from './stepConfig';
 import { useOnboardingTracking } from './analytics';
@@ -85,11 +86,15 @@ export function OnboardingPage() {
       >
         <div className="absolute inset-x-0 top-0 h-40 bg-[radial-gradient(circle_at_18%_0%,rgba(14,165,233,0.18),transparent_38%),radial-gradient(circle_at_82%_0%,rgba(168,85,247,0.16),transparent_34%)]" aria-hidden="true" />
 
-        {/* Progress bar */}
-        <div className="relative flex items-center justify-between border-b border-white/10 bg-white/[0.035] px-6 py-4">
+        {/* Progress bar, plus the way out. The escape hatch lives on this row
+            because onboarding suppresses the app Header and renders above
+            every other surface — without it, a user whose setup cannot
+            complete has no route to settings and no way to sign out. */}
+        <div className="relative flex items-center justify-between gap-4 border-b border-white/10 bg-white/[0.035] px-6 py-4">
           <div className="flex-1">
             <ProgressBar steps={progressSteps} currentStepIndex={safeIndex} />
           </div>
+          <OnboardingEscapeHatch className="flex-shrink-0" />
         </div>
 
         {/* Step content */}

--- a/web/src/components/OnboardingFlow/__tests__/OnboardingEscapeHatch.test.tsx
+++ b/web/src/components/OnboardingFlow/__tests__/OnboardingEscapeHatch.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * A user stuck in onboarding must still be able to leave.
+ *
+ * Onboarding renders as a fixed z-40 overlay on its own route, so the app
+ * Header is suppressed (`showHeader` gates on `!inOnboarding`) and the Sidebar
+ * — which needs a selected project — never mounts. Without an affordance on
+ * this surface, a user whose daemon fails to provision cannot reach settings
+ * and cannot sign out.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const navigate = vi.fn(async () => undefined);
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigate,
+}));
+
+const signOut = vi.fn(async () => undefined);
+vi.mock("@/store/authStore", () => ({
+  useAuthStore: (selector: (s: unknown) => unknown) => selector({ signOut }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { OnboardingEscapeHatch } from "../OnboardingEscapeHatch";
+
+describe("OnboardingEscapeHatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("navigates to settings without needing a daemon or project", async () => {
+    render(<OnboardingEscapeHatch />);
+    await userEvent.click(screen.getByTestId("onboarding-settings-link"));
+    expect(navigate).toHaveBeenCalledWith({ to: "/settings" });
+  });
+
+  it("signs the user out and sends them to /auth", async () => {
+    render(<OnboardingEscapeHatch />);
+    await userEvent.click(screen.getByTestId("onboarding-sign-out"));
+
+    await waitFor(() => expect(signOut).toHaveBeenCalledTimes(1));
+    expect(navigate).toHaveBeenCalledWith({
+      to: "/auth",
+      search: { redirect: undefined },
+    });
+  });
+
+  it("surfaces a failed sign-out instead of appearing to succeed", async () => {
+    signOut.mockRejectedValueOnce(new Error("network down"));
+    render(<OnboardingEscapeHatch />);
+    await userEvent.click(screen.getByTestId("onboarding-sign-out"));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("network down");
+    // The button must return to an actionable state so the user can retry.
+    expect(screen.getByTestId("onboarding-sign-out")).not.toBeDisabled();
+  });
+});

--- a/web/src/components/OnboardingFlow/__tests__/OnboardingPage.escapeHatch.test.tsx
+++ b/web/src/components/OnboardingFlow/__tests__/OnboardingPage.escapeHatch.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Onboarding must always render an escape hatch.
+ *
+ * This is the regression guard that matters: `OnboardingEscapeHatch` existing
+ * is worth nothing if the page stops mounting it. Onboarding suppresses the
+ * app Header and renders above every other surface, so if this row goes away a
+ * user whose daemon never provisions has no route to settings and no way to
+ * sign out — the exact dead end this change exists to close.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("../useOnboardingPlan", () => ({
+  useOnboardingPlan: () => ({ plan: {}, updatePlan: vi.fn() }),
+}));
+
+vi.mock("../analytics", () => ({
+  useOnboardingTracking: vi.fn(),
+  markOnboardingFinalized: vi.fn(),
+}));
+
+vi.mock("@/hooks/useTitleBarChrome", () => ({
+  useTitleBarChrome: () => ({ isElectron: false, dragRegionStyle: {} }),
+}));
+
+// The real step registry drags in the whole compute/model/GitHub graph. A
+// single stub step is enough — this test is about the chrome around it.
+vi.mock("../stepConfig", () => ({
+  BACK_CLEARS: { compute: [] },
+  deriveStep: () => "compute",
+  getStepsForPlan: () => ["compute"],
+  stepMaxWidth: () => "max-w-2xl",
+  STEP_COMPONENTS: { compute: () => <div data-testid="step" /> },
+  STEP_LABELS: { compute: "Compute" },
+}));
+
+vi.mock("../steps", () => ({}));
+
+vi.mock("../OnboardingEscapeHatch", () => ({
+  OnboardingEscapeHatch: () => <div data-testid="onboarding-escape-hatch" />,
+}));
+
+import { OnboardingPage } from "../OnboardingPage";
+
+describe("OnboardingPage escape hatch", () => {
+  it("mounts the escape hatch alongside the step content", () => {
+    render(<OnboardingPage />);
+
+    expect(screen.getByTestId("step")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("onboarding-escape-hatch"),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/__tests__/AuthInitializer.checklistReset.test.tsx
+++ b/web/src/components/__tests__/AuthInitializer.checklistReset.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Sign-out must not leak onboarding-checklist state into the next account.
+ *
+ * This is the confirmed trigger behind "the API-key modal appeared before the
+ * onboarding screen for a brand-new user":
+ *
+ *   1. The checklist mirrors itself to localStorage (`reliant.checklist.*`) so
+ *      a reload can decide offline whether the guide was dismissed. That
+ *      mirror is device-wide, not per-user.
+ *   2. `authStore.signOut()` resets seven stores — chat, project, worktree,
+ *      navigation, attachment, tasks, process — but NOT the checklist, and it
+ *      never clears the mirror.
+ *   3. `apiKeySetupStore` defers the api-key-setup modal until
+ *      `welcomeShown` is true, reading it as "this user has met the product".
+ *
+ * So a second user signing in on the same device inherits `welcomeShown: true`,
+ * the deferral gate passes immediately, and with no credentials configured the
+ * modal opens on top of onboarding.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { waitFor } from "@testing-library/react";
+
+const checklistReset = vi.fn();
+
+vi.mock("@/store/onboardingChecklistStore", () => ({
+  useOnboardingChecklistStore: { getState: () => ({ reset: checklistReset }) },
+}));
+vi.mock("../../store/onboardingChecklistStore", () => ({
+  useOnboardingChecklistStore: { getState: () => ({ reset: checklistReset }) },
+}));
+
+let authState: Record<string, unknown>;
+vi.mock("@/store/authStore", () => ({
+  useAuthStore: Object.assign(
+    (selector?: (s: unknown) => unknown) =>
+      selector ? selector(authState) : authState,
+    { getState: () => authState },
+  ),
+}));
+
+const resetApiKeyCheck = vi.fn();
+vi.mock("@/store/apiKeySetupStore", () => ({
+  useApiKeySetupStore: (selector: (s: unknown) => unknown) =>
+    selector({ checkApiKeys: vi.fn(), reset: resetApiKeyCheck }),
+}));
+
+vi.mock("@/store/globalDataStore", () => ({
+  useGlobalDataStore: (selector: (s: unknown) => unknown) =>
+    selector({ prefetch: vi.fn(async () => undefined) }),
+}));
+vi.mock("@/store/privacyStore", () => ({
+  usePrivacyStore: (selector: (s: unknown) => unknown) =>
+    selector({ initialize: vi.fn(async () => undefined) }),
+}));
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: {
+    getState: () => ({ loadProjects: vi.fn(async () => undefined) }),
+  },
+}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@/lib/supabase", () => ({
+  supabase: { auth: { getSession: vi.fn(async () => ({ data: { session: null } })) } },
+}));
+vi.mock("@/lib/sentry", () => ({ initSentry: vi.fn(async () => undefined) }));
+vi.mock("@/lib/analytics", () => ({
+  identifyUser: vi.fn(),
+  resetUser: vi.fn(async () => undefined),
+}));
+vi.mock("@/services/settingsSync", () => ({
+  settingsSync: {
+    initialize: vi.fn(async () => undefined),
+    applyAppearanceSettingsToDOM: vi.fn(),
+  },
+}));
+
+import { AuthInitializer } from "../AuthInitializer";
+
+const signedIn = {
+  initialize: vi.fn(async () => undefined),
+  user: { id: "user-1", email: "a@example.com" },
+  session: { access_token: "t" },
+  loading: false,
+  initialized: true,
+};
+
+const signedOut = { ...signedIn, user: null, session: null };
+
+describe("AuthInitializer checklist reset on sign-out", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  it("resets the onboarding checklist when the user signs out", async () => {
+    authState = signedIn;
+    const { rerender } = render(
+      <AuthInitializer>
+        <div />
+      </AuthInitializer>,
+    );
+
+    // Let the post-login prefetch effect run so `hasPrefetched` flips — that
+    // ref is what marks "a session actually started here", and the logout
+    // branch is gated on it.
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(checklistReset).not.toHaveBeenCalled();
+
+    authState = signedOut;
+    rerender(
+      <AuthInitializer>
+        <div />
+      </AuthInitializer>,
+    );
+
+    vi.useRealTimers();
+    await waitFor(() => expect(checklistReset).toHaveBeenCalledTimes(1));
+  });
+});


### PR DESCRIPTION
Two client-side dead ends, both reachable by a user whose daemon never provisions — the exact state several other open bugs produce.

## Trap 1 — settings (and sign-out) unreachable without a working daemon

`/settings` is gated on auth alone; it needs neither a daemon nor a project. The problem was never the route, it was that nothing **linked** to it.

The Sidebar held the app's only Settings link, and the Sidebar renders solely inside `ModernApp`'s main app shell — which requires a selected project. A user whose daemon fails to provision never gets a project, so they never got a Settings link, and therefore **could not log out**. `Header.tsx` had declared `onNavigateToSettings` in its props since forever and never destructured it: a dead prop.

- **Header** — wired the prop to a real Settings button, deliberately **not** gated on `projectPickerMode` the way every other control on that row is. The project picker is precisely where a stranded user lands, so it is the one surface that must keep the button.
- **Onboarding** — renders a `fixed inset-0 z-40` overlay on its own route with the Header suppressed (`showHeader` gates on `!inOnboarding`), so it gets its own affordance: a small **Settings / Sign out** row on the progress bar. Sign-out matters most here, because switching accounts is the one repair a stranded user can perform unaided.

## Trap 2 — a global modal could cover onboarding

**The trigger is real and reproduces — this is not a defensive guard.**

`welcomeShown` leaks across sign-out. The onboarding checklist mirrors itself to `localStorage` (`reliant.checklist.*`) so a reload can decide offline whether the guide was dismissed, but that mirror is **device-wide, not per-user**, and `authStore.signOut()` resets seven stores (chat, project, worktree, navigation, attachment, tasks, process) while touching neither the checklist store nor the mirror.

`apiKeySetupStore` defers the api-key-setup modal until `welcomeShown` is true, reading it as "this user has been introduced to the product". So:

1. User A completes the tour, and `welcomeShown: true` is written to localStorage
2. User A signs out, and the mirror survives
3. A brand-new user B signs in on the same device, and `loadState()` reads `welcomeShown: true`
4. The deferral gate passes immediately; B has no credentials, so the modal opens at `z-50` over onboarding's `z-40`

That is the reported "set your API key screen appeared first for a brand-new mobile user".

Fixed at both levels:

- **Root cause** — `AuthInitializer` resets the checklist store on sign-out, so per-user state stops outliving the session.
- **Policy** — a route may declare which globally-mounted modals it tolerates (`modalRoutePolicy.ts`, a pure function of the pathname). `/onboarding` suppresses `api-key-setup`, whose job onboarding's own ModelStep already does with different copy. Billing modals are deliberately **still allowed**: they explain a request the user just made, so hiding them would turn a clear error into a silent no-op. Suppressed rather than cleared, so the modal returns if still relevant once the user leaves.

## Verification

- `npx vitest run` — **262 files / 1921 tests pass**
- `npx tsc --noEmit` — clean
- **Every new test was verified to fail with its fix reverted**, then pass with it restored:

| Reverted | Result |
|---|---|
| Re-gate Settings button on `!projectPickerMode` | `Unable to find [data-testid="header-settings-button"]` |
| Remove ModalLayer route guard | `expect(element).not.toBeInTheDocument()` |
| Remove checklist reset on logout | `expected "spy" to be called 1 times, but got 0` |
| Remove escape hatch mount from OnboardingPage | `Unable to find [data-testid="onboarding-escape-hatch"]` |

One issue caught mid-review and worth noting: the ModalLayer test initially passed *with the guard deleted*. `RouterProvider` mounts asynchronously, so a synchronous `queryByTestId` found nothing either way and the absence assertion was vacuous. It now awaits a route marker before asserting, which is what makes the revert fail properly.

### Pre-existing flake (not from this branch)

The full suite occasionally reports one unhandled error — a leaked `setTimeout` in `OnboardingSpotlight.tsx:247` firing after teardown. I verified this on a **pristine `origin/main` worktree with none of this code present: it reproduced in 2 of 6 runs.** Unrelated to these changes and left alone.

## Coordination with open PRs

No overlap. `Header.tsx`, `OnboardingPage.tsx`, `ModalLayer.tsx` and `AuthInitializer.tsx` are untouched by #169, #170, #171 and #172.

I deliberately **did not edit `ProjectPicker.tsx`** even though it is a stranded user's main surface — that file belongs to #172. The Header button sits above the picker and covers it without contending for the file, so this merges cleanly in either order.
