### PR TITLE
docs: investigation findings for the OAuth and onboarding bugs

### DIFF
--- a/OAUTH_REDIRECT_FINDINGS.md
+++ b/OAUTH_REDIRECT_FINDINGS.md
@@ -1,0 +1,232 @@
+# OAuth / redirect findings
+
+Investigation of three reported issues in the released desktop app (1.6.3).
+
+## Summary
+
+| # | Report | Verdict |
+|---|---|---|
+| 1 | "Back to first project" navigates to `http://127.0.0.1:61851/` | **Not reproduced as a separate bug.** No code builds a URL for that control. Best-supported explanation is the same root cause as #2 — see below. |
+| 2 | Google sign-in calls back to `http://127.0.0.1:61655/auth/callback?code=…` | **Root cause found and fixed.** A redirect helper fell back to the packaged renderer's own local origin. |
+| 3 | No loading signal on remote sign-in | **Confirmed and fixed.** A pending state existed but was driven by a shared flag, so it was wrong in a way that also lit unrelated buttons. |
+
+Bugs 1 and 2 were investigated together, as instructed. They are **the same
+defect** to the extent that #1 is real: a single helper is the only thing in the
+codebase that turns a local address into a user-visible navigation target, and
+fixing it removes the mechanism behind both reports. Details in "Are #1 and #2
+the same?" below.
+
+The observed ports (61851, 61655) are **not** the documented `reliant auth serve`
+receiver on 19284, and they are not the daemon either — the daemon allocates
+from the fixed 9190–9290 range (`electron/src/backend-manager.js`). That
+correctly ruled both out, as the task suspected.
+
+---
+
+## Bug 2 — the root cause
+
+### The defect
+
+`web/src/store/authStore.ts` resolved the OAuth redirect like this:
+
+```ts
+const isElectron = !!window.electronAPI
+const getOAuthRedirectUrl = async (): Promise<string> => {
+  if (!isElectron || !window.electronAPI?.getOAuthRedirectUrl) {
+    return `${window.location.origin}/auth/callback`   // ← the bug
+  }
+  ...
+}
+```
+
+The guard reads "if we're not in Electron, or Electron can't give us a redirect
+URL, use our own origin". In the packaged app **both halves are true at once**:
+
+- `window.electronAPI` **exists**, so `isElectron` is `true`.
+- `window.electronAPI.getOAuthRedirectUrl` **does not exist**, so the guard
+  still falls through.
+
+`getOAuthRedirectUrl` is declared in `web/src/types/electron.d.ts` but was
+**never implemented in `electron/src/preload.js`**. The type declaration made it
+look implemented; nothing at runtime ever provided it. The same is true of
+`onOAuthCallback`, which `authStore.initialize()` also tries to register.
+
+So every packaged build fell through to `window.location.origin` and handed the
+desktop app's *own* local address to the identity provider as a public redirect
+target.
+
+### Verified against the shipped build, not just the source
+
+Downloaded and mounted `Reliant-1.6.3-mac-arm64.dmg`:
+
+```
+$ grep -c "getOAuthRedirectUrl" .../Reliant.app/Contents/Resources/preload.js
+0
+$ grep -c "onOAuthCallback"     .../Reliant.app/Contents/Resources/preload.js
+0
+```
+
+The shipped preload exposes `electronAPI` with ~40 methods (`openExternal`,
+`authLoad`, `analyticsTrack`, …) and neither OAuth method among them. The
+shipped renderer bundle contains the faulty fallback verbatim:
+
+```
+f(!bQ||!window.electronAPI?.getOAuthRedirectUrl)return`${window.location.origin}/auth/callback`;
+```
+
+…where `bQ=!!window.electronAPI`. That is the exact code path, in the exact
+binary users are running.
+
+### Why the port differs every time, and why it is intermittent
+
+The port is whatever local address the renderer was served from for that
+launch, so it changes per launch — which is why the two reports show different
+ports (61851, 61655) and why it does not reproduce every time. Anything that
+changes how the window was loaded on a given run changes the origin, and a
+`file://` origin fails differently again (`"null"`), which is consistent with
+"sometimes, not everytime".
+
+### The fix
+
+New `getAppURL()` in `web/src/lib/constants.ts` resolves the app's *public*
+origin, and the redirect is built from that.
+
+The important subtlety: **a local origin is not always wrong.** In web
+development the app is served from `localhost:3000`, and that is a perfectly
+real redirect target the browser navigates back to. Rejecting all loopback
+origins would have broken local dev — an early version of this fix did exactly
+that and broke three existing tests, which is what surfaced the distinction.
+
+The real discriminator is the runtime, not the address:
+
+- **Browser** (dev or deployed): the document origin *is* the app's address. Use it.
+- **Electron**: OAuth completes in the *system browser*, which cannot reach the
+  desktop shell's local address. A loopback/`file://` origin there is
+  unusable, so fall back to the hosted app URL.
+
+A `VITE_APP_URL` build-time override takes precedence for staging/preview.
+
+### Second defect found and fixed alongside it
+
+`StartOAuthSignIn` was missing from the long-timeout table in
+`web/src/api/transport.ts`, so it inherited the 10s default while the user was
+still on the provider's consent screen. Its sibling `StartOAuthFlow` — which
+blocks on the same thing — was already registered at no-timeout. This is an
+independent contributor to flaky sign-in and is fixed in the same PR.
+
+---
+
+## Are #1 and #2 the same?
+
+**Probably yes, and the fix covers both — but I could not reproduce #1
+directly, and I want to be straight about that.**
+
+What I checked. The "Back to <project>" control is
+`web/src/components/Projects/ProjectPicker.tsx:1133`. It is **not a link** — no
+`href`, no URL. It is a `<button>` whose handler calls `handleProjectClick` →
+`onProjectSelected` → `selectProject`, which is in-app state plus a client-side
+router navigation. There is no code path there that constructs
+`http://127.0.0.1:61851/`, and I found none anywhere else for that control.
+
+Why they are still very likely one bug:
+
+- `getAppURL()`/`window.location.origin` is the **only** mechanism in the app
+  that turns an ephemeral local address into a user-visible navigation target.
+- Both reports show the same signature: loopback host, ephemeral high port,
+  differing between sightings.
+- A bare origin with no path (`http://127.0.0.1:61851/`) is what you get when
+  the renderer's own origin is treated as the app's home — the shape of an
+  origin used as a base URL, not of a route.
+
+The most likely sequence is that #1 was observed *after* an OAuth round trip had
+already put the window on the bad origin: once the renderer is sitting on
+`http://127.0.0.1:61851`, any in-app navigation resolves against that origin and
+"back to project" lands on its root. That makes #1 a downstream symptom rather
+than a separate defect, and removing the loopback origin removes it.
+
+**Caveat worth stating plainly:** since I could not trigger #1 on demand, this
+is a well-supported inference, not a verified reproduction. If it recurs after
+this fix ships, the next thing to capture is `window.location.href` at the
+moment of the click — that single value distinguishes "the window was already on
+a bad origin" from "something else builds this URL".
+
+Also worth flagging, though it did not produce the reported symptom: the
+packaged `index.html` references assets absolutely (`/assets/index-*.js`,
+`/favicon.svg`) while `window-manager.js` and `main.js` load it via
+`loadFile()`. Absolute paths do not resolve under `file://`. That tension is
+what the current branch name (`fix/vite-base-absolute-deep-routes`) is about and
+is adjacent to this area; it is left alone here to keep the diff to the bug.
+
+---
+
+## Bug 3 — remote sign-in loading state
+
+The report was "nothing appears to happen". A pending state *did* exist
+(`OAuthButton` already accepted `loading`), so the real defect is subtler than
+"it is missing":
+
+`AuthScreen` passed the **same shared `loading` flag to every provider button**.
+Clicking Google put *both* Google and GitHub into "Connecting…", so the UI
+claimed to be signing in with a provider the user never chose.
+`UpgradeAccount` had the identical problem with its `submitting` flag.
+
+Fixed by tracking *which* provider is pending:
+
+- the clicked provider shows the spinner, names itself
+  (`Connecting to Google...`), and sets `aria-busy`;
+- the others are disabled but visually idle, so a stray second click cannot
+  start a competing sign-in.
+
+`OAuthButton` was also brought onto the repo's styling contract: `cn()` instead
+of a template-literal `className`, and the shared `Loader2` spinner instead of a
+hand-rolled bordered `div`. Colors and layout are unchanged.
+
+---
+
+## Tests
+
+Every test below was confirmed to **fail before** the corresponding fix and
+**pass after**.
+
+`web/src/store/__tests__/authStore.redirect-origin.test.ts` — reproduces the bug
+exactly. Pre-fix it produced the reported URL:
+
+```
+Expected: "https://app.reliantlabs.io/auth/callback"
+Received: "http://127.0.0.1:61655/auth/callback"
+```
+
+`web/src/lib/__tests__/appUrl.test.ts` — 7 cases for `getAppURL`, including the
+one that matters most: a browser on `localhost:3000` keeps its origin, while
+Electron on the same origin does not.
+
+`web/src/components/__tests__/AuthScreen.oauth-pending.test.tsx` — the clicked
+provider goes busy, the other one does not, and a second click while one is in
+flight is refused.
+
+Full web suite on both branches: **256 files / 1908 tests passing**, plus
+`tsc --noEmit` clean.
+
+---
+
+## What was ruled out
+
+- **`reliant auth serve` (port 19284)** — documented localhost receiver;
+  neither observed port matches, and it is not running in the desktop app.
+- **The daemon** — allocates from the fixed range 9190–9290
+  (`backend-manager.js`), not ephemeral high ports.
+- **`internal/auth/oauthcallback`** — binds an OS-assigned port and builds
+  `http://localhost:<port>/auth/callback`, which *looks* like a match, but it is
+  the Claude/Codex provider-login receiver reached via `auth.start_oauth`. It is
+  a legitimate loopback receiver: the local server is the intended recipient, and
+  the URL never leaves the machine.
+- **`internal/auth/oauth.go`** — `LoginWithOAuthProvider` also binds
+  `127.0.0.1:0` and builds `http://127.0.0.1:<port>/auth/callback`, the closest
+  textual match in the codebase. It is reached from `StartOAuthSignIn` and is
+  correct by design for the CLI/daemon flow, where the local server is genuinely
+  the endpoint. It is not what the renderer sent to Google.
+
+The distinction that matters: a loopback callback is *correct* when the local
+process is the intended receiver, and *wrong* when it is published to a
+third-party provider as the app's public address. Only the renderer's redirect
+did the latter.

--- a/ONBOARDING_FINDINGS.md
+++ b/ONBOARDING_FINDINGS.md
@@ -1,0 +1,252 @@
+# Onboarding investigation — new user, mobile, production
+
+Scope: the **client** onboarding flow (screen order, duplication, state). The
+server-side billing bypass in `internal/svcdaemon` is owned by another agent and
+is deliberately untouched here.
+
+## TL;DR
+
+**Screens 2, 3 and 4 were not onboarding.** Every string the user quoted after
+the first screen belongs to `web/src/components/Projects/ProjectPicker.tsx` —
+the *post*-onboarding project picker. The user was **ejected out of onboarding**
+partway through, and everything they saw afterwards was the picker's own
+daemon-connect UI doing exactly what it is designed to do for a user who has no
+running machine.
+
+So the answer to "do we have duplicate screens?" is **no, not really** — there
+is one onboarding flow, plus a second daemon-connect surface that the user was
+dropped into by mistake. The answer to "how did these even pop up?" is a
+one-line ordering bug in `finalizeOnboardingSideEffects`.
+
+Two PRs are open. **Neither is merged.**
+
+| PR | What |
+|----|------|
+| [#169](https://github.com/reliant-labs/reliant/pull/169) | Stop leaving `/onboarding` while the cloud daemon is still provisioning (the ejection). |
+| [#172](https://github.com/reliant-labs/reliant/pull/172) | Gate ProjectPicker's "provision a cloud daemon" on compute eligibility (the client half of the money bug). |
+
+---
+
+## 1. Is there more than one onboarding implementation?
+
+**Yes, two trees — but they are two different systems, not two copies of one.**
+Both are live. Neither is dead code. **Nothing should be deleted.**
+
+### `web/src/components/OnboardingFlow/` — the SETUP flow (this is the one that routes)
+
+Mounted at `/onboarding` (`routes.tsx:411`, via `OnboardingRoute`). Five steps in
+`stepConfig.ts`: `compute → model → project-choice → github-connect →
+project-picker`. This is what a new user is sent through.
+
+Notably, the current step is **derived from plan state**, not stored:
+`deriveStep(plan)` in `stepConfig.ts`. There is no `step` URL param and no state
+machine that can "skip ahead" — the derivation is a pure function of the plan,
+and the plan lives in the URL. **This design is sound and is not the bug.**
+
+### `web/src/components/Onboarding/` — the guided TOUR + achievement checklist
+
+`OnboardingWizard`, spotlights, `ContextualTipsLayer`, the checklist store.
+Mounted globally on the root route (`routes.tsx:162`). It is the post-setup
+walkthrough that spotlights desktop chrome by DOM selector.
+
+### Can they both mount at once?
+
+They can both be *mounted*, but the wizard **suppresses itself** on the setup
+route — `OnboardingWizard.tsx:340` computes `isOnboardingRoute` and gates on it
+at line 519. It also returns `null` on any non-desktop surface (line ~420). So on
+mobile at `/onboarding`, the tour is doubly suppressed. **This is not the source
+of the duplicate-feeling screens.**
+
+**Recommendation: do not delete either tree.** The naming is genuinely
+confusing, and renaming `Onboarding/` → `Tour/` would make the split obvious —
+but that is a separate, purely-cosmetic change and is the user's call, not mine.
+
+---
+
+## 2. What decides the first screen — and why did the user get ejected?
+
+### The ejection (root cause, fixed in #169)
+
+All three terminal steps do this:
+
+```ts
+await finalizeOnboardingSideEffects(...)
+if (isCloud) setShowDaemonGate(true);
+```
+
+…but `finalizeOnboardingSideEffects` (`useOnboardingComplete.ts`) ended with an
+**unconditional** `router.navigate({ to: "/" })`.
+
+For a cloud user the router therefore left `/onboarding` **before** the gate
+could render. `DaemonConnectingGate` — the screen whose entire job is to say
+*"your machine is still starting"* — was never seen.
+
+The user lands on `/` with `onboarding_completed = true` and **no ACTIVE
+daemon**. That is precisely the state `ModernApp` answers by rendering
+`ProjectPicker` (`!currentProject`), whose `NoActiveDaemonState` renders:
+
+- `"Connect a daemon"` — `ProjectPicker.tsx:315 / 500 / 510`
+- `"Cloud daemon requested — It may take a few minutes to provision…"` — `:395–400`
+- `"Resume a daemon"` / `"Pick a daemon to wake up…"` — `:526 / :530`
+
+**The clincher:** the user saw `Resume workspace-daemon`. The string
+`"workspace-daemon"` appears in **exactly one place in the entire codebase** —
+`ProjectPicker.tsx:299`. Onboarding's own cloud path names its daemon
+`"onboarding-daemon"` (`ComputeStep.tsx:214`). The daemon name alone proves the
+user was in the picker, not in onboarding.
+
+Screens 2→3→4 are therefore one coherent sequence in a **single** component,
+which is why they felt like a broken onboarding: they were a *correct* picker
+flow shown to someone who should still have been in onboarding.
+
+### The "set your API key" first screen — NOT fully confirmed
+
+I could not reproduce this one from a production trace, so I am flagging it
+rather than guessing. What I established:
+
+- The modal is `ApiKeySetupModal`, titled **"Add an API key"**, rendered by
+  `ModalLayer`, which is mounted on the **root route** and has **no route
+  awareness** — it does not suppress itself on `/onboarding`. `Modal` is
+  `z-50`; `OnboardingPage` is `z-40`. **So an API-key modal can render on top of
+  the onboarding card.** That is a real ordering hazard.
+- It is normally gated by `checklistState.welcomeShown` in `apiKeySetupStore`
+  (lines 192, 259), and `welcomeShown` is only set by `markTourCompleted`. For a
+  brand-new user it should be `false`, which should defer the modal.
+- **The uncertainty:** `loadState()` reads `welcomeShown` from a backend setting
+  *unioned with a localStorage mirror*. I could not confirm which value a fresh
+  production mobile user gets, and I did not want to assert a mechanism I had
+  not proven.
+
+**Recommendation (not in either PR):** make `ModalLayer` suppress
+`api-key-setup` while `pathname.startsWith("/onboarding")`. Onboarding's
+`ModelStep` already owns provider setup, so the modal is redundant there
+regardless of how it was triggered. I did not include this because I could not
+build a failing test that proved the trigger, and I would rather hand you a
+confirmed diagnosis than a speculative patch.
+
+### On the documented "loading is not the negative of success" anti-pattern
+
+I checked specifically. The onboarding gates are **mostly careful** about this —
+`OnboardingRoute` waits on `isUserLoading` *and* `daemonsLoading` before acting,
+with a comment explaining why, and `ComputeStep` blocks behind `daemonLoading`
+for the same reason.
+
+The one genuine instance I found was in `ProjectPicker`'s cloud button, which
+treated *not-yet-known* eligibility as *permitted*. That is fixed in #172, with a
+regression test for the still-loading case.
+
+---
+
+## 3. Mobile: is this mobile-only?
+
+**No — this is general.** Mobile shares the setup flow rather than forking it.
+
+- `mobileRedirect.ts:66` lists `/onboarding` as a **preserved** path — phones are
+  never redirected away from it.
+- `MobileShell.tsx:71` bounces an un-onboarded user to `/onboarding`, the same
+  gate `ModernApp` applies.
+- Both `MobileShell` and `ModernApp` correctly wait for `isUserLoading` first.
+
+The bug is in `finalizeOnboardingSideEffects`, which is surface-agnostic. A
+desktop user on the cloud path hits it identically. Mobile is likely just where
+it was noticed — and mobile makes it *worse*, because the picker the user is
+dumped into is a dense desktop table.
+
+---
+
+## 4. Is "Resume a daemon" the intended flow?
+
+**No.** It is the symptom.
+
+The intended flow after requesting a cloud daemon is `DaemonConnectingGate`: poll
+for up to 60s, then show connected / failed with Retry, View logs, and Skip. That
+screen exists, is tested, and is good. The user never reached it.
+
+Instead they were bounced to the picker, which independently discovered "this
+account has a daemon that is not ACTIVE" and offered to resume it — showing
+`Starting`, because the machine really was still provisioning. **Onboarding lost
+its state; the picker was doing its job correctly with the wrong user in front of
+it.**
+
+---
+
+## 5. Eligibility: does the UI check before offering a cloud daemon?
+
+**Onboarding does. The picker did not.** This is a real finding and worth having.
+
+- `ComputeStep` gates on `useCloudEligibility()`, keeps a second guard inside the
+  click handler, and shows the reason + coupon form + plans link when ineligible.
+- `ProjectPicker`'s `ConnectDaemonModal` gated **only** on
+  `capabilities.cloudDaemons` — a *deployment* flag, not an *entitlement*.
+  `useCloudEligibility` was not referenced anywhere in that file.
+
+So the button the user actually clicked was the **unguarded** one. That is the
+client-side half of the P0.
+
+I verified this is not theoretical by reverting the gate in #172: with it
+removed, an ineligible user's click reaches `CreateDaemon`. With it in place, it
+does not.
+
+**This does not excuse the server.** A client gate is defense-in-depth and a UX
+fix; `internal/svcdaemon.CreateDaemon` is the authority and its fix should land
+regardless of #172.
+
+---
+
+## Corroborating production-shaped data
+
+From the control-plane dev database (read-only):
+
+- **29 of 43 users** have `onboarding_completed_at IS NULL`.
+- **8 distinct users** have `onboarding_completed_at IS NULL` **and** at least
+  one daemon — i.e. they paid the provisioning cost but never reached the step
+  that records completion. All 8 of those daemon rows are named
+  `onboarding-daemon` at `status = 3` (SUSPENDED).
+
+This is the exact population the ejection bug produces, and it is why
+`OnboardingRoute` already carries a self-heal path for "has a working daemon but
+is flagged incomplete".
+
+---
+
+## A hazard I did not fix (flagging, not touching)
+
+There are **two colliding `DaemonStatus` enums**, and the numbers disagree:
+
+| value | control-plane | reliant registry |
+|-------|---------------|------------------|
+| 1 | `PENDING` | `ACTIVE` |
+| 2 | `ACTIVE` | `IDLE` |
+| 3 | `SUSPENDED` | `DISCONNECTED` |
+
+The codebase is *aware* of this — `hasUsableControlPlaneDaemonForOnboarding` and
+`cloudDaemonStatusLabel` both exist specifically to avoid it, with good comments.
+
+But note what `OnboardingRoute`'s self-heal treats as proof of completion:
+control-plane `ACTIVE` **or `PENDING`**. `PENDING` means *still provisioning*. So
+a user whose daemon is merely pending can be marked onboarding-complete and sent
+to `/` — where, having no ACTIVE daemon, they meet the project picker. That is a
+second, independent route to the same bad screen.
+
+I left this alone: it is a deliberate design decision with a written rationale
+(avoiding a worse trap where users get permanently stuck), and changing it needs
+a product judgement about which failure is preferable. Worth a conversation.
+
+---
+
+## Verification performed
+
+- New test in #169 **confirmed failing before the fix** (navigate fired with
+  `to: "/"` while the caller still had to show the gate) and passing after.
+- New tests in #172 **confirmed failing** with the gate reverted (`CreateDaemon`
+  fires for an ineligible user) and passing with it.
+- Full web suite on both branches: **1903 passed / 255 files**, no regressions.
+- `tsc --noEmit` clean on both; `eslint` clean on changed files.
+
+## What I did NOT do
+
+- Did not merge anything.
+- Did not touch `internal/svcdaemon` (owned).
+- Did not delete either onboarding tree.
+- Did not patch the API-key modal ordering, because I could not prove the
+  trigger. Recommendation is above.


### PR DESCRIPTION
Two findings docs written while diagnosing the v1.6.3 release issues.

Kept because each records evidence the fix commits do not: what was **reproduced** versus **inferred**, what was checked against a pristine `main`, and the open questions handed back rather than guessed at.

- `OAUTH_REDIRECT_FINDINGS.md` — the loopback redirect (`getOAuthRedirectUrl` declared in `electron.d.ts`, never implemented in `preload.js`), and why the back-to-project variant is an inference rather than a reproduction.
- `ONBOARDING_FINDINGS.md` — the ejection out of `/onboarding`, the two live `Onboarding` trees that are **not** duplicates, and the `PENDING`-means-complete self-heal deliberately left alone as a product judgement.

Docs only, no code.