### PR TITLE
chore: bump forge to v0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,8 +28,8 @@ require (
 	github.com/pdfcpu/pdfcpu v0.13.0
 	github.com/pressly/goose/v3 v3.25.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/reliant-labs/forge v0.1.0
-	github.com/reliant-labs/forge/pkg v0.1.0
+	github.com/reliant-labs/forge v0.1.1
+	github.com/reliant-labs/forge/pkg v0.1.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/sqlc-dev/pqtype v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -535,8 +535,12 @@ github.com/redis/go-redis/v9 v9.1.0 h1:137FnGdk+EQdCbye1FW+qOEcY5S+SpY9T0Niuqvtf
 github.com/redis/go-redis/v9 v9.1.0/go.mod h1:urWj3He21Dj5k4TK1y59xH8Uj6ATueP8AH1cY3lZl4c=
 github.com/reliant-labs/forge v0.1.0 h1:sW+jWbHAtGiyE4OGXcylLNi3O/pI6ytMpwdw/AO7czU=
 github.com/reliant-labs/forge v0.1.0/go.mod h1:ObCxWQjRccCJaRSDhyZhRT4J1YNOM8RCzIYjxg2L+aw=
+github.com/reliant-labs/forge v0.1.1 h1:rDyNKpSaipiUI/69YtheKlxt+GcCYD1oHblS1cAnYY8=
+github.com/reliant-labs/forge v0.1.1/go.mod h1:HP6Ih0OpUgKFIN4PV6EHmldG+Ef49oRLJNgMjbyZHDQ=
 github.com/reliant-labs/forge/pkg v0.1.0 h1:07GKMAixDSrN4vtQJ8pze1mP/hR1G8xSxrRV0n909Ow=
 github.com/reliant-labs/forge/pkg v0.1.0/go.mod h1:yVuNEMU2atdN1obN85YE/Qgv9lBY4m4l8JiCwtNxCRM=
+github.com/reliant-labs/forge/pkg v0.1.1 h1:RkGZKBdplhGfqvFhmVzexUP+ZnEboepoZTyRAk3Ojs0=
+github.com/reliant-labs/forge/pkg v0.1.1/go.mod h1:yVuNEMU2atdN1obN85YE/Qgv9lBY4m4l8JiCwtNxCRM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
Picks up the three forge fixes released in v0.1.1:

- **forge#107** — pinned cross-repo git sources for frontends (`forge.GitSource`)
- **forge#108** — `forge doctor` reports a KCL-declared frontend missing from `forge.yaml`
- **forge#109** — duplicate config field names are now a hard error instead of silently shadowing each other in generated KCL

`go build ./...` clean; tests pass across every package that imports forge (`internal/grpc`, `internal/skills`, `cmd/reliant`).