### PR TITLE
ci: stop the E2E Frontend job timing out, and surface the real test failures

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -222,7 +222,28 @@ jobs:
   e2e-frontend:
     name: E2E Frontend (Playwright)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Measured, not guessed: this job was cancelled at 15m in every one of
+    # the last 50 runs that reached the test step (the other 8/50 died in
+    # <3s on an unrelated `goose install` flake, now pinned — see below).
+    # It was never a slow-but-passing job; the Playwright suite itself was
+    # genuinely failing and playwright.config.ts's `retries: 2` (single
+    # worker in CI) was tripling the cost of every failure.
+    #
+    # After this change (make generate scoped to generate-shortcuts, goose
+    # pinned, browser cache added, one stale assertion fixed, two
+    # non-test manual-QA scripts excluded from the run):
+    #   - setup (checkout -> build -> browser install) measures ~2-3 min
+    #   - the suite itself, run locally with CI's exact config (single
+    #     worker, 2 retries, `CI=true`), takes 15.3 minutes wall clock —
+    #     because 26 onboarding.spec.ts tests are genuinely failing against
+    #     a refactored onboarding step model (see commit message) and each
+    #     failure still costs 3 attempts.
+    # 15+3 leaves no margin for CI-runner variance, so this is set to 20,
+    # not bumped arbitrarily. It should come back down once onboarding.spec.ts
+    # is rewritten against the current step model (tracked separately, not
+    # in scope for this CI-infra fix) — at that point the real number is
+    # close to 3-4 minutes.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 
@@ -254,10 +275,29 @@ jobs:
         run: buf generate --template buf.gen.yaml
 
       - name: Install goose
-        run: go install github.com/pressly/goose/v3/cmd/goose@latest
+        # Pinned to match the version in go.mod. This step was an unpinned
+        # `@latest` install; every one of this job's non-timeout failures in
+        # the last 50 runs (8/50) died here in <3s on a transient resolution
+        # flake, not because the version drifted. Pinning removes the flake
+        # source; it doesn't change behavior otherwise.
+        run: go install github.com/pressly/goose/v3/cmd/goose@v3.25.0
 
-      - name: Generate docs and shortcuts
-        run: make generate
+      - name: Generate shortcuts
+        # Only `make generate-shortcuts` output is a build input for web/ —
+        # web/src/store/shortcutsData.generated.ts, imported by
+        # shortcutsStore.ts (confirmed: deleting it breaks `vite build` with
+        # "Could not resolve ./shortcutsData.generated"). The full `make
+        # generate` also builds 14 unrelated Go-side doc/reference targets
+        # (CLI reference, tools reference, Mintlify pages, etc.) that this
+        # job doesn't consume; that cost ~2.5-3 minutes of this job's budget
+        # for no effect on the build or the tests.
+        run: make generate-shortcuts
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}
 
       - name: Build (alpha)
         working-directory: web

--- a/web/e2e/branding.spec.ts
+++ b/web/e2e/branding.spec.ts
@@ -9,13 +9,17 @@ test.describe('Branding - Favicon', () => {
   });
 
   test('uses app favicon instead of Vite default', async ({ page }) => {
-    const favicon = page.locator('head link[rel="icon"]');
-    await expect(favicon).toHaveCount(1);
+    // index.html declares two rel="icon" links: an SVG primary and a PNG
+    // fallback for browsers without SVG favicon support. Both are expected.
+    const favicons = page.locator('head link[rel="icon"]');
+    const hrefs = await favicons.evaluateAll((links) => links.map((l) => l.getAttribute('href')));
 
-    const href = await favicon.getAttribute('href');
-    expect(href).toBeTruthy();
-    expect(href).not.toContain('vite.svg');
-    // Preferred convention
-    expect(href).toContain('favicon');
+    expect(hrefs.length).toBeGreaterThan(0);
+    for (const href of hrefs) {
+      expect(href).toBeTruthy();
+      expect(href).not.toContain('vite.svg');
+      // Preferred convention
+      expect(href).toContain('favicon');
+    }
   });
 });

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -7,6 +7,14 @@ const baseURL = process.env.BASE_URL || (isCI ? 'http://localhost:4173' : 'http:
 
 export default defineConfig({
   testDir: './e2e',
+  // Manual QA scripts, not automated tests — excluded from the default run:
+  //  - debug-canvas.spec.ts: zero `expect()` calls, pure console.log
+  //    diagnostics against onboarding-gated app state.
+  //  - workflow-builder-validation.spec.ts: hardcodes `localhost:3046`,
+  //    unrelated to this config's managed webServer (localhost:4173), so it
+  //    can never pass here. Run either manually with `playwright test
+  //    e2e/<file>` against a dev server when needed.
+  testIgnore: ['**/debug-canvas.spec.ts', '**/workflow-builder-validation.spec.ts'],
   fullyParallel: true,
   forbidOnly: isCI,
   retries: isCI ? 2 : 0,


### PR DESCRIPTION
`E2E Frontend (Playwright)` fails on every PR. It is **not** a failing assertion — the job hits `timeout-minutes: 15` and GitHub cancels it, which is why the annotation reads `The job has exceeded the maximum execution time of 15m0s` and no test report is ever produced.

## What was actually measured

Not estimated — pulled from real run data:

- Across the **50 most recent `pr-ci.yml` runs, `e2e-frontend` has never once passed.** 42 were cancelled at the 15-minute wall; the other 8 died in under 3 seconds on an unrelated `go install goose@latest` resolution flake.
- Setup (checkout → build → browser install) consistently burned ~5-6 minutes before a single test ran, dominated by `make generate` (~2.5-3 min).
- Run locally under CI's exact configuration (`CI=true`, single worker, `retries: 2`): **24.6 minutes, with 30 of 51 tests genuinely failing.** The suite could never have fit in 15 minutes.

So this job was concealing two separate problems: a budget too small for its setup, and a suite that was already broken.

## Changes

**Reclaimed setup time (~3 min):**
- `make generate` → `make generate-shortcuts`. Only the shortcuts output is a build input for `web/` (verified: deleting it breaks `vite build`). The full target also builds 14 unrelated Go-side doc targets this job never consumes.
- Pinned `goose` to `v3.25.0` to match `go.mod`, removing the flake that killed 8 runs.
- Added a Playwright browser cache keyed on `web/package-lock.json`.

**Test corrections:**
- `branding.spec.ts` asserted exactly one `rel="icon"` link. `index.html` legitimately declares two (SVG primary, PNG fallback). The assertion now checks **every** favicon href — coverage is preserved, not weakened.
- `debug-canvas.spec.ts` (zero `expect()` calls, pure `console.log` diagnostics) and `workflow-builder-validation.spec.ts` (hardcodes `localhost:3046`, unreachable from this config's `localhost:4173` webServer, so it can never pass here) are excluded via `testIgnore`. **Not deleted** — still runnable manually.

**Timeout 15 → 20**, justified by a re-measured 15.3-minute local run plus ~3 minutes of setup. It should return to ~4 minutes once the failures below are fixed.

## What this PR deliberately does NOT fix

**26 tests in `onboarding.spec.ts` genuinely fail**, and I left them failing rather than skip or delete them.

They drive the onboarding flow through `?step=goal`. That step no longer exists: `ONBOARDING_STEPS` in `web/src/components/OnboardingFlow/stepConfig.ts` is now `[compute, model, project-choice, github-connect, project-picker]`, and the only surviving mention of `goal` in `web/src` is a stale comment. The app also now renders an `AuthGuard`/`AuthScreen` gate these tests' mocks don't satisfy. That is real product/test drift needing a rewrite against the current step model — a separate piece of work from this CI-infrastructure fix, and not something to paper over.

**Consequence worth stating plainly:** this job goes from *red because it was cancelled* to *red because 26 tests fail*. That is strictly more informative — it now produces an actual Playwright report — but it does not turn green. `main` is unprotected, so it blocks nothing mechanically. If you'd rather this PR land green, say so and I'll rewrite `onboarding.spec.ts` against the current model as part of it.

## Verification

Full suite re-run locally after the changes: 15.3 min, 10 passed, 26 failed (all `onboarding.spec.ts`), 12 skipped. `pr-ci.yml` YAML validated.