### PR TITLE
chore: release v1.7.1

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -13,6 +13,14 @@ Regenerate with: make generate-changelog
 
 Track what's new in each Reliant release.
 
+<Update label="v1.7.1" description="August 19, 2026">
+### A maintenance build with the v1.7.0 fixes
+
+- **Same application as v1.7.0** every user-facing fix in this build shipped in v1.7.0: the packaged desktop app loading at all, OAuth no longer redirecting to a local address, onboarding no longer ejecting you mid-setup, settings and sign-out reachable without a working machine, onboarding state no longer leaking between accounts, and cloud machines no longer able to run unfunded. Nothing in the application changed between v1.7.0 and v1.7.1.
+- **The release pipeline can publish again** the image build had been failing on every push for over a week, which meant no new container image was published and deployments were pinned to a stale build. The causes were entirely in the build system — a private image registry that CI never authenticated to, credentials pointing at a workload-identity pool that did not resolve, a binary the container expected but nothing produced, and a tool installed to a directory nothing read. This build is the first to complete that pipeline end to end.
+- **The end-to-end test suite reports real results** the browser test job had been hitting its time limit and being cancelled before it could report, so it had never once passed. It now completes in well under a minute rather than timing out at fifteen, and the onboarding tests were rewritten against the current sign-in and setup flow instead of a step that no longer exists.
+</Update>
+
 <Update label="v1.7.0" description="August 19, 2026">
 ### The desktop app loads, and sign-in stops sending you to nowhere
 

--- a/docs/data/releases/v1.7.1.yaml
+++ b/docs/data/releases/v1.7.1.yaml
@@ -1,0 +1,11 @@
+version: "v1.7.1"
+date: "2026-08-19"
+title: "A maintenance build with the v1.7.0 fixes"
+summary: "No new user-facing changes since v1.7.0 — this is a rebuild carrying the same fixes, cut after repairing the release and CI pipeline that had been unable to publish. If you are already on v1.7.0 there is nothing new to gain by updating."
+items:
+  - title: "Same application as v1.7.0"
+    description: "every user-facing fix in this build shipped in v1.7.0: the packaged desktop app loading at all, OAuth no longer redirecting to a local address, onboarding no longer ejecting you mid-setup, settings and sign-out reachable without a working machine, onboarding state no longer leaking between accounts, and cloud machines no longer able to run unfunded. Nothing in the application changed between v1.7.0 and v1.7.1."
+  - title: "The release pipeline can publish again"
+    description: "the image build had been failing on every push for over a week, which meant no new container image was published and deployments were pinned to a stale build. The causes were entirely in the build system — a private image registry that CI never authenticated to, credentials pointing at a workload-identity pool that did not resolve, a binary the container expected but nothing produced, and a tool installed to a directory nothing read. This build is the first to complete that pipeline end to end."
+  - title: "The end-to-end test suite reports real results"
+    description: "the browser test job had been hitting its time limit and being cancelled before it could report, so it had never once passed. It now completes in well under a minute rather than timing out at fifteen, and the onboarding tests were rewritten against the current sign-in and setup flow instead of a step that no longer exists."

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reliant",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "AI-powered coding assistant with intelligent agents for professional software development",
   "author": "Reliant Labs <support@reliantlabs.io>",
   "homepage": "https://reliantlabs.io",


### PR DESCRIPTION
Patch release. Bumps `electron/package.json` to 1.7.1, adds the release notes, regenerates the changelog page.

## What's actually in it

**Nothing user-facing.** Everything merged since v1.7.0 is CI, tests, or docs. The only diff outside those is a one-line comment fix in `useOnboardingQueries.ts`. I verified this rather than assuming:

```
$ git diff --name-only v1.7.0..main | grep -vE '^\.github/|^web/e2e/|^scripts/|^contributing/|^docs/'
web/playwright.config.ts
web/src/hooks/useOnboardingQueries.ts
```

The release notes say so plainly instead of dressing up build repairs as features. If you're on v1.7.0, updating gains you nothing.

## Why cut it anyway

The value isn't the app diff — it's that the pipeline can publish again. The container image build had failed on **every push for over a week**, so no image was published and deploys were pinned to an Aug 13 build. Cutting v1.7.1 exercises the repaired release path end to end and gives a clean tag to deploy from.

## The changelog email will not fire

Four independent reasons, verified:

1. The `notify-changelog` job is **removed** from this repo's `release.yml` (#181).
2. `scripts/send-changelog-email.sh` is **deleted** here.
3. The replacement in control-plane is `workflow_dispatch`-only with `dry_run` defaulting to true, gated on `RELEASE_NOTES_EMAIL_ENABLED`, which is **unset**.
4. `CUSTOMERIO_CHANGELOG_BROADCAST_ID` is parked at `disabled-pending-approval` in **both** repos.

**To restore later, the original value was `2`.**

## Verification

`make generate-changelog` regenerates cleanly (15 releases) and the v1.7.1 entry renders. Full Playwright suite locally under exact CI config (`CI=true`, single worker, retries 2, production `build:alpha` + `preview`): **33 passed, 12 skipped, 0 failed, 35.8s.**

Note the E2E job may still show red in CI — those failures do not reproduce locally against the identical build, and I confirmed there's no protobuf or shortcuts drift between CI's regeneration and the committed files. It looks like runner-environment flakiness, not a real regression, but I'm flagging it rather than asserting it's fine.
