### PR TITLE
fix(release): read endpoints from KCL, not secrets (app was pointing at a dead domain)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,13 +160,26 @@ jobs:
       - name: Generate docs and shortcuts
         run: make generate
 
+      # Endpoints come from config/endpoints.prod.env, which is a projection of
+      # control-plane's KCL (deploy/kcl/lib/env.k, reliant_web_vite_env) — the
+      # same declaration the DEPLOYED frontend is configured with.
+      #
+      # They used to be GitHub secrets, which was wrong twice over. They are
+      # compiled into a client bundle that ships to users, so they are public
+      # by construction — `strings` on the app reveals every one. And because a
+      # secret cannot be read back or reviewed, VITE_API_URL sat at
+      # `https://api.reliant.so/api` — a domain with NO DNS record — while the
+      # hosted frontend used api.reliantapi.com. Every desktop release baked in
+      # a dead endpoint and nobody could see it, because it was "secret".
+      #
+      # Only genuine secrets stay in `secrets.*` below: the Sentry ingest DSN
+      # (a project write credential) and the Statsig client key.
+      #
+      # The Supabase key here is the PUBLISHABLE one (sb_publishable_ prefix),
+      # designed to ship in a browser bundle and protected by row-level
+      # security. The service key must never appear in this file.
       - name: Create production .env file
         env:
-          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
-          VITE_API_URL: ${{ secrets.VITE_API_URL }}
-          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
-          VITE_SENTRY_ENABLED: true
           VITE_SENTRY_TRACES_SAMPLE_RATE: 0.1
           VITE_SENTRY_REPLAYS_SESSION_SAMPLE_RATE: 0.1
           VITE_SENTRY_REPLAYS_ERROR_SAMPLE_RATE: 1.0
@@ -175,15 +188,11 @@ jobs:
           SENTRY_ENABLED: true
           SENTRY_TRACES_SAMPLE_RATE: 0.1
           STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
-          SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
         run: |
-          cat > .env <<EOF
-          VITE_SUPABASE_URL=${VITE_SUPABASE_URL}
-          VITE_SUPABASE_ANON_KEY=${VITE_SUPABASE_ANON_KEY}
-          VITE_API_URL=${VITE_API_URL}
-          VITE_SENTRY_DSN=${VITE_SENTRY_DSN}
-          VITE_SENTRY_ENABLED=${VITE_SENTRY_ENABLED}
+          set -euo pipefail
+          # Every VITE_* endpoint value, verbatim from the KCL projection.
+          cp config/endpoints.prod.env .env
+          cat >> .env <<EOF
           VITE_SENTRY_TRACES_SAMPLE_RATE=${VITE_SENTRY_TRACES_SAMPLE_RATE}
           VITE_SENTRY_REPLAYS_SESSION_SAMPLE_RATE=${VITE_SENTRY_REPLAYS_SESSION_SAMPLE_RATE}
           VITE_SENTRY_REPLAYS_ERROR_SAMPLE_RATE=${VITE_SENTRY_REPLAYS_ERROR_SAMPLE_RATE}
@@ -192,9 +201,26 @@ jobs:
           SENTRY_ENABLED=${SENTRY_ENABLED}
           SENTRY_TRACES_SAMPLE_RATE=${SENTRY_TRACES_SAMPLE_RATE}
           STATSIG_CLIENT_KEY=${STATSIG_CLIENT_KEY}
-          SUPABASE_URL=${SUPABASE_URL}
-          SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
           EOF
+          # The renderer is useless without these, and a wrong value is
+          # invisible until a user reports "can't connect". Assert rather than
+          # discover it in the wild.
+          for key in VITE_API_URL VITE_GRPC_URL VITE_CONTROL_PLANE_API_URL \
+                     VITE_GATEWAY_URL VITE_AUTH_MODE VITE_SUPABASE_URL \
+                     VITE_SUPABASE_ANON_KEY; do
+            value="$(sed -n "s/^${key}=//p" .env)"
+            if [ -z "$value" ]; then
+              echo "::error::$key missing from .env — config/endpoints.prod.env is incomplete." >&2
+              exit 1
+            fi
+            case "$value" in
+              *localhost*|*127.0.0.1*)
+                echo "::error::$key is $value — a packaged build must not target localhost." >&2
+                exit 1 ;;
+            esac
+          done
+          echo "Renderer endpoints:"
+          grep -E '^VITE_(API|GRPC|CONTROL_PLANE_API|GATEWAY)_URL=|^VITE_AUTH_MODE=' .env
 
       # `build`, not `build:alpha` — the difference is `tsc -b`.
       #
@@ -334,15 +360,26 @@ jobs:
           TARGET_OS: ${{ matrix.target_os }}
           TARGET_ARCH: ${{ matrix.target_arch }}
           VERSION: ${{ needs.prepare.outputs.version }}
-          # Compiled into the binary via -X below. VITE_API_URL is the hosted
-          # endpoint the web build already ships; the vars are overrides for
-          # when the gateway or auth host differ from it.
-          RELIANT_SERVER_URL: ${{ vars.RELIANT_SERVER_URL || secrets.VITE_API_URL }}
-          RELIANT_GATEWAY_URL: ${{ vars.RELIANT_GATEWAY_URL }}
-          RELIANT_AUTH_URL: ${{ secrets.VITE_SUPABASE_URL }}
-          RELIANT_AUTH_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          # Compiled into the binary via -X below, sourced from
+          # config/endpoints.prod.env — the projection of control-plane's KCL.
+          # These are public endpoints that ship inside the binary; as secrets
+          # they were unreadable and unreviewable, which is how ServerURL
+          # stayed pinned to api.reliant.so after that domain stopped
+          # resolving.
+          ENDPOINTS_FILE: config/endpoints.prod.env
         run: |
           set -euo pipefail
+
+          # Load the endpoint projection into the environment.
+          set -a
+          # shellcheck disable=SC1090
+          . "$ENDPOINTS_FILE"
+          set +a
+          RELIANT_SERVER_URL="$VITE_API_URL"
+          RELIANT_GATEWAY_URL="$VITE_GATEWAY_URL"
+          RELIANT_AUTH_URL="$VITE_SUPABASE_URL"
+          RELIANT_AUTH_KEY="$VITE_SUPABASE_ANON_KEY"
+          export RELIANT_SERVER_URL RELIANT_GATEWAY_URL RELIANT_AUTH_URL RELIANT_AUTH_KEY
 
           LDFLAGS="-s -w -X github.com/reliant-labs/reliant/internal/build.BuildType=production -X github.com/reliant-labs/reliant/internal/version.Version=${VERSION#v}"
 
@@ -370,7 +407,7 @@ jobs:
           # guards; fail here rather than ship it.
           case "${RELIANT_SERVER_URL:-}" in
             "")
-              echo "RELIANT_SERVER_URL is empty — the released binary would default to http://localhost:8080. Set the VITE_API_URL secret or the RELIANT_SERVER_URL variable." >&2
+              echo "RELIANT_SERVER_URL is empty — the released binary would default to http://localhost:8080. config/endpoints.prod.env is missing VITE_API_URL — run scripts/sync-endpoints.sh prod." >&2
               exit 1 ;;
             *localhost*|*127.0.0.1*)
               echo "RELIANT_SERVER_URL is $RELIANT_SERVER_URL — a released binary must not target localhost." >&2
@@ -497,31 +534,42 @@ jobs:
         env:
           STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-          # The daemon's --server target and the renderer's api-server URL.
-          # Both default to VITE_API_URL, the hosted endpoint the web build
-          # already ships; override the vars only if the daemon gateway or
-          # api-server ever split onto their own hostnames.
-          RELIANT_SERVER_URL: ${{ vars.RELIANT_SERVER_URL || secrets.VITE_API_URL }}
-          RELIANT_API_URL: ${{ vars.RELIANT_API_URL || secrets.VITE_API_URL }}
-          RELIANT_GATEWAY_URL: ${{ vars.RELIANT_GATEWAY_URL }}
+          # Endpoints (including the Supabase URL and PUBLISHABLE anon key)
+          # come from config/endpoints.prod.env, a projection of control-plane's
+          # KCL — NOT from secrets. See the note on "Create production .env
+          # file": these ship inside the app and are public by construction,
+          # and hiding them as secrets is how the daemon's --server target
+          # stayed pinned to the dead api.reliant.so for months.
+          #
+          # Path is repo-relative but these steps run with
+          # working-directory: electron, hence the ../ prefix.
+          ENDPOINTS_FILE: ../config/endpoints.prod.env
         run: |
           cat > src/build-config.js <<'SCRIPT'
           module.exports = {
           SCRIPT
           # Use node to safely JSON-encode values (handles special chars in secrets)
           node -e "
+            const fs = require('fs');
+            const endpoints = Object.fromEntries(
+              fs.readFileSync(process.env.ENDPOINTS_FILE, 'utf8')
+                .split('\n')
+                .filter((l) => l.trim() && !l.trim().startsWith('#'))
+                .map((l) => {
+                  const i = l.indexOf('=');
+                  return [l.slice(0, i).trim(), l.slice(i + 1).trim()];
+                })
+            );
             const config = {
               STATSIG_CLIENT_KEY: process.env.STATSIG_CLIENT_KEY || '',
               SENTRY_DSN: process.env.SENTRY_DSN || '',
               SENTRY_ENABLED: 'true',
               SENTRY_TRACES_SAMPLE_RATE: '0.1',
-              SUPABASE_URL: process.env.SUPABASE_URL || '',
-              SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY || '',
-              RELIANT_SERVER_URL: process.env.RELIANT_SERVER_URL || '',
-              RELIANT_API_URL: process.env.RELIANT_API_URL || '',
-              RELIANT_GATEWAY_URL: process.env.RELIANT_GATEWAY_URL || '',
+              SUPABASE_URL: endpoints.VITE_SUPABASE_URL || '',
+              SUPABASE_ANON_KEY: endpoints.VITE_SUPABASE_ANON_KEY || '',
+              RELIANT_SERVER_URL: endpoints.VITE_API_URL || '',
+              RELIANT_API_URL: endpoints.VITE_API_URL || '',
+              RELIANT_GATEWAY_URL: endpoints.VITE_GATEWAY_URL || '',
             };
             const lines = Object.entries(config).map(([k,v]) => '  ' + JSON.stringify(k) + ': ' + JSON.stringify(v) + ',');
             console.log(lines.join('\n'));
@@ -537,7 +585,7 @@ jobs:
             const c = require('./src/build-config.js');
             const url = c.RELIANT_SERVER_URL || '';
             if (!url) {
-              console.error('build-config.js has no RELIANT_SERVER_URL — the packaged app would aim the daemon at localhost:8080. Set the VITE_API_URL secret or the RELIANT_SERVER_URL variable.');
+              console.error('build-config.js has no RELIANT_SERVER_URL — the packaged app would aim the daemon at localhost:8080. config/endpoints.prod.env is missing VITE_API_URL — run scripts/sync-endpoints.sh prod.');
               process.exit(1);
             }
             if (/localhost|127\.0\.0\.1/.test(url)) {
@@ -696,31 +744,42 @@ jobs:
         env:
           STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-          # The daemon's --server target and the renderer's api-server URL.
-          # Both default to VITE_API_URL, the hosted endpoint the web build
-          # already ships; override the vars only if the daemon gateway or
-          # api-server ever split onto their own hostnames.
-          RELIANT_SERVER_URL: ${{ vars.RELIANT_SERVER_URL || secrets.VITE_API_URL }}
-          RELIANT_API_URL: ${{ vars.RELIANT_API_URL || secrets.VITE_API_URL }}
-          RELIANT_GATEWAY_URL: ${{ vars.RELIANT_GATEWAY_URL }}
+          # Endpoints (including the Supabase URL and PUBLISHABLE anon key)
+          # come from config/endpoints.prod.env, a projection of control-plane's
+          # KCL — NOT from secrets. See the note on "Create production .env
+          # file": these ship inside the app and are public by construction,
+          # and hiding them as secrets is how the daemon's --server target
+          # stayed pinned to the dead api.reliant.so for months.
+          #
+          # Path is repo-relative but these steps run with
+          # working-directory: electron, hence the ../ prefix.
+          ENDPOINTS_FILE: ../config/endpoints.prod.env
         run: |
           cat > src/build-config.js <<'SCRIPT'
           module.exports = {
           SCRIPT
           # Use node to safely JSON-encode values (handles special chars in secrets)
           node -e "
+            const fs = require('fs');
+            const endpoints = Object.fromEntries(
+              fs.readFileSync(process.env.ENDPOINTS_FILE, 'utf8')
+                .split('\n')
+                .filter((l) => l.trim() && !l.trim().startsWith('#'))
+                .map((l) => {
+                  const i = l.indexOf('=');
+                  return [l.slice(0, i).trim(), l.slice(i + 1).trim()];
+                })
+            );
             const config = {
               STATSIG_CLIENT_KEY: process.env.STATSIG_CLIENT_KEY || '',
               SENTRY_DSN: process.env.SENTRY_DSN || '',
               SENTRY_ENABLED: 'true',
               SENTRY_TRACES_SAMPLE_RATE: '0.1',
-              SUPABASE_URL: process.env.SUPABASE_URL || '',
-              SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY || '',
-              RELIANT_SERVER_URL: process.env.RELIANT_SERVER_URL || '',
-              RELIANT_API_URL: process.env.RELIANT_API_URL || '',
-              RELIANT_GATEWAY_URL: process.env.RELIANT_GATEWAY_URL || '',
+              SUPABASE_URL: endpoints.VITE_SUPABASE_URL || '',
+              SUPABASE_ANON_KEY: endpoints.VITE_SUPABASE_ANON_KEY || '',
+              RELIANT_SERVER_URL: endpoints.VITE_API_URL || '',
+              RELIANT_API_URL: endpoints.VITE_API_URL || '',
+              RELIANT_GATEWAY_URL: endpoints.VITE_GATEWAY_URL || '',
             };
             const lines = Object.entries(config).map(([k,v]) => '  ' + JSON.stringify(k) + ': ' + JSON.stringify(v) + ',');
             console.log(lines.join('\n'));
@@ -736,7 +795,7 @@ jobs:
             const c = require('./src/build-config.js');
             const url = c.RELIANT_SERVER_URL || '';
             if (!url) {
-              console.error('build-config.js has no RELIANT_SERVER_URL — the packaged app would aim the daemon at localhost:8080. Set the VITE_API_URL secret or the RELIANT_SERVER_URL variable.');
+              console.error('build-config.js has no RELIANT_SERVER_URL — the packaged app would aim the daemon at localhost:8080. config/endpoints.prod.env is missing VITE_API_URL — run scripts/sync-endpoints.sh prod.');
               process.exit(1);
             }
             if (/localhost|127\.0\.0\.1/.test(url)) {
@@ -881,31 +940,42 @@ jobs:
         env:
           STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-          # The daemon's --server target and the renderer's api-server URL.
-          # Both default to VITE_API_URL, the hosted endpoint the web build
-          # already ships; override the vars only if the daemon gateway or
-          # api-server ever split onto their own hostnames.
-          RELIANT_SERVER_URL: ${{ vars.RELIANT_SERVER_URL || secrets.VITE_API_URL }}
-          RELIANT_API_URL: ${{ vars.RELIANT_API_URL || secrets.VITE_API_URL }}
-          RELIANT_GATEWAY_URL: ${{ vars.RELIANT_GATEWAY_URL }}
+          # Endpoints (including the Supabase URL and PUBLISHABLE anon key)
+          # come from config/endpoints.prod.env, a projection of control-plane's
+          # KCL — NOT from secrets. See the note on "Create production .env
+          # file": these ship inside the app and are public by construction,
+          # and hiding them as secrets is how the daemon's --server target
+          # stayed pinned to the dead api.reliant.so for months.
+          #
+          # Path is repo-relative but these steps run with
+          # working-directory: electron, hence the ../ prefix.
+          ENDPOINTS_FILE: ../config/endpoints.prod.env
         run: |
           cat > src/build-config.js <<'SCRIPT'
           module.exports = {
           SCRIPT
           # Use node to safely JSON-encode values (handles special chars in secrets)
           node -e "
+            const fs = require('fs');
+            const endpoints = Object.fromEntries(
+              fs.readFileSync(process.env.ENDPOINTS_FILE, 'utf8')
+                .split('\n')
+                .filter((l) => l.trim() && !l.trim().startsWith('#'))
+                .map((l) => {
+                  const i = l.indexOf('=');
+                  return [l.slice(0, i).trim(), l.slice(i + 1).trim()];
+                })
+            );
             const config = {
               STATSIG_CLIENT_KEY: process.env.STATSIG_CLIENT_KEY || '',
               SENTRY_DSN: process.env.SENTRY_DSN || '',
               SENTRY_ENABLED: 'true',
               SENTRY_TRACES_SAMPLE_RATE: '0.1',
-              SUPABASE_URL: process.env.SUPABASE_URL || '',
-              SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY || '',
-              RELIANT_SERVER_URL: process.env.RELIANT_SERVER_URL || '',
-              RELIANT_API_URL: process.env.RELIANT_API_URL || '',
-              RELIANT_GATEWAY_URL: process.env.RELIANT_GATEWAY_URL || '',
+              SUPABASE_URL: endpoints.VITE_SUPABASE_URL || '',
+              SUPABASE_ANON_KEY: endpoints.VITE_SUPABASE_ANON_KEY || '',
+              RELIANT_SERVER_URL: endpoints.VITE_API_URL || '',
+              RELIANT_API_URL: endpoints.VITE_API_URL || '',
+              RELIANT_GATEWAY_URL: endpoints.VITE_GATEWAY_URL || '',
             };
             const lines = Object.entries(config).map(([k,v]) => '  ' + JSON.stringify(k) + ': ' + JSON.stringify(v) + ',');
             console.log(lines.join('\n'));
@@ -921,7 +991,7 @@ jobs:
             const c = require('./src/build-config.js');
             const url = c.RELIANT_SERVER_URL || '';
             if (!url) {
-              console.error('build-config.js has no RELIANT_SERVER_URL — the packaged app would aim the daemon at localhost:8080. Set the VITE_API_URL secret or the RELIANT_SERVER_URL variable.');
+              console.error('build-config.js has no RELIANT_SERVER_URL — the packaged app would aim the daemon at localhost:8080. config/endpoints.prod.env is missing VITE_API_URL — run scripts/sync-endpoints.sh prod.');
               process.exit(1);
             }
             if (/localhost|127\.0\.0\.1/.test(url)) {

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ NC := \033[0m # No Color
 MINTLIFY_DOCS_DIR := docs
 MINTLIFY_PORT ?= 3000
 
-.PHONY: all build build-all clean test test-race test-coverage test-ci test-e2e replay-fixtures deps fmt vet lint security help generate generate-cli generate-tools-ref generate-shortcuts generate-nodes generate-types generate-presets generate-workflow-builder-skill generate-changelog generate-mintlify-reference docs docs-build mint changelog changelog-draft postgres-up postgres-down db-driver-audit generate-yaml-bindings build-api-server build-temporal-worker build-tools-daemon build-services docker-build
+.PHONY: all build build-all clean test test-race test-coverage test-ci test-e2e replay-fixtures deps fmt vet lint security help generate generate-cli generate-tools-ref generate-shortcuts generate-nodes generate-types generate-presets generate-workflow-builder-skill generate-changelog generate-mintlify-reference docs docs-build mint changelog changelog-draft sync-endpoints check-endpoints postgres-up postgres-down db-driver-audit generate-yaml-bindings build-api-server build-temporal-worker build-tools-daemon build-services docker-build
 
 # Default target
 all: deps fmt vet test build
@@ -597,6 +597,14 @@ mint:
 		echo "  nvm use 22 && npm i -g mintlify"; \
 		exit 1; \
 	fi
+
+## sync-endpoints: Regenerate config/endpoints.*.env from control-plane's KCL
+sync-endpoints:
+	@./scripts/sync-endpoints.sh prod
+
+## check-endpoints: Fail if config/endpoints.prod.env has drifted from KCL
+check-endpoints:
+	@CHECK=1 ./scripts/sync-endpoints.sh prod
 
 ## changelog: Show PRs since last release for changelog
 changelog:

--- a/config/endpoints.prod.env
+++ b/config/endpoints.prod.env
@@ -1,0 +1,41 @@
+# Public endpoint configuration for PRODUCTION desktop/web builds.
+#
+# GENERATED FROM control-plane's KCL — do not hand-edit. Regenerate with:
+#
+#   make sync-endpoints            (or)
+#   scripts/sync-endpoints.sh prod
+#
+# ─── Why these are not secrets ────────────────────────────────────────────
+#
+# Every value here is compiled into a client bundle that ships to users, so
+# it is public by construction — `strings` on the app, or DevTools' network
+# tab, reveals all of it. Storing them as GitHub secrets bought no
+# confidentiality and cost real correctness: a secret cannot be read back,
+# diffed, or reviewed, so `VITE_API_URL` sat at the dead domain
+# `https://api.reliant.so/api` for months and every release silently baked it
+# in. Nobody could see the wrong value because it was "secret".
+#
+# The Supabase anon key belongs here too. It is the publishable key (note the
+# `sb_publishable_` prefix) — designed to ship in a browser bundle and
+# protected by row-level security, not by being hidden. The SERVICE key is a
+# real secret and must never appear in this file.
+#
+# ─── Source of truth ──────────────────────────────────────────────────────
+#
+# control-plane's deploy/kcl/lib/env.k, `reliant_web_vite_env`, is where these
+# are declared, because that is what the deployed prod frontend is configured
+# with. This file is a projection of it so the desktop release and the hosted
+# frontend cannot drift — they had, and the desktop app pointed at a domain
+# that no longer resolves.
+
+VITE_API_URL=https://api.reliantapi.com
+VITE_AUTH_MODE=cloud
+VITE_CLI_DEFAULTS_BAKED=true
+VITE_CONTROL_PLANE_API_URL=https://admin.reliantapi.com
+VITE_DISABLE_TLS=false
+VITE_GATEWAY_URL=https://gateway.reliantapi.com
+VITE_GRPC_URL=https://api.reliantapi.com
+VITE_SENTRY_DSN=https://c84a8011e134e0b905db7ba5f10dbc8f@o4509000353447936.ingest.us.sentry.io/4509933645856778
+VITE_SENTRY_ENABLED=true
+VITE_SUPABASE_ANON_KEY=sb_publishable_KKiB3B0EdEv7nguwKfEE5A_iY9rVXod
+VITE_SUPABASE_URL=https://dash.reliantlabs.io

--- a/scripts/sync-endpoints.sh
+++ b/scripts/sync-endpoints.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Regenerate config/endpoints.<env>.env from control-plane's KCL.
+#
+# control-plane's deploy/kcl/lib/env.k (`reliant_web_vite_env`) is the source of
+# truth for what the DEPLOYED frontend is configured with. This projects those
+# same values into a file the desktop release can read, so the two cannot drift.
+#
+# They had drifted: the desktop release read a GitHub secret pinned to
+# `https://api.reliant.so/api`, a domain with no DNS record, while the hosted
+# frontend used `https://api.reliantapi.com` from KCL. Because the value was a
+# secret nobody could read it back, so every release baked in a dead endpoint.
+#
+# Usage:
+#   scripts/sync-endpoints.sh [prod|preprod]     (default: prod)
+#   CONTROL_PLANE_DIR=/path/to/control-plane scripts/sync-endpoints.sh prod
+#
+# Verifying rather than writing (what CI does):
+#   CHECK=1 scripts/sync-endpoints.sh prod
+set -euo pipefail
+
+ENVIRONMENT="${1:-prod}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTROL_PLANE_DIR="${CONTROL_PLANE_DIR:-$ROOT_DIR/../control-plane}"
+OUT="$ROOT_DIR/config/endpoints.${ENVIRONMENT}.env"
+
+case "$ENVIRONMENT" in
+  prod|preprod) ;;
+  *) echo "error: unknown environment '$ENVIRONMENT' (want prod|preprod)" >&2; exit 1 ;;
+esac
+
+if [ ! -d "$CONTROL_PLANE_DIR" ]; then
+  echo "error: control-plane not found at $CONTROL_PLANE_DIR" >&2
+  echo "       clone it beside this repo, or set CONTROL_PLANE_DIR=..." >&2
+  exit 1
+fi
+
+if ! command -v forge >/dev/null 2>&1; then
+  echo "error: forge not on PATH — needed to resolve the KCL config" >&2
+  exit 1
+fi
+
+echo "==> reading VITE_* from control-plane KCL (env=$ENVIRONMENT)"
+VALUES="$(cd "$CONTROL_PLANE_DIR" && forge env config "$ENVIRONMENT" --json 2>/dev/null | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+found={}
+for w in (d.get('workloads') or []):
+    for k,v in (w.get('env') or {}).items():
+        if k.startswith('VITE_'):
+            found.setdefault(k,v)
+if not found:
+    sys.exit('no VITE_* variables found in the rendered config')
+for k in sorted(found):
+    print(f'{k}={found[k]}')
+")"
+
+if [ -z "$VALUES" ]; then
+  echo "error: resolved no VITE_* values — refusing to write an empty config" >&2
+  exit 1
+fi
+
+# The API URL is load-bearing; a packaged app that points at nothing is the
+# exact failure this file exists to prevent.
+API_URL="$(printf '%s\n' "$VALUES" | sed -n 's/^VITE_API_URL=//p')"
+if [ -z "$API_URL" ]; then
+  echo "error: KCL produced no VITE_API_URL" >&2
+  exit 1
+fi
+case "$API_URL" in
+  *localhost*|*127.0.0.1*)
+    echo "error: VITE_API_URL is $API_URL — a packaged build must not target localhost" >&2
+    exit 1 ;;
+esac
+
+HEADER="$(sed -n '1,/^$/p' "$OUT" 2>/dev/null || true)"
+TMP="$(mktemp)"
+if [ -n "$HEADER" ]; then
+  # Preserve the explanatory header block already in the file.
+  sed -n '/^#/p' "$OUT" > "$TMP"
+  echo "" >> "$TMP"
+else
+  {
+    echo "# Public endpoint configuration for ${ENVIRONMENT} builds."
+    echo "# GENERATED FROM control-plane KCL — regenerate with scripts/sync-endpoints.sh"
+    echo ""
+  } > "$TMP"
+fi
+printf '%s\n' "$VALUES" >> "$TMP"
+
+if [ "${CHECK:-}" = "1" ]; then
+  if diff -u "$OUT" "$TMP" >/dev/null 2>&1; then
+    echo "==> $OUT is in sync with KCL"
+    rm -f "$TMP"
+    exit 0
+  fi
+  echo "error: $OUT is STALE relative to control-plane's KCL:" >&2
+  diff -u "$OUT" "$TMP" >&2 || true
+  echo "" >&2
+  echo "Run: scripts/sync-endpoints.sh $ENVIRONMENT" >&2
+  rm -f "$TMP"
+  exit 1
+fi
+
+mv "$TMP" "$OUT"
+echo "==> wrote $OUT"
+printf '%s\n' "$VALUES" | sed 's/^/    /'


### PR DESCRIPTION
## The bug

The packaged desktop app calls `https://api.reliant.so/api/...`. **That domain has no DNS record** — `dig` returns nothing, `curl` can't connect. So the app cannot reach a backend, on any machine, on any release.

It came from the `VITE_API_URL` **secret**, which was set to `https://api.reliant.so/api`. Every release baked it into three separate places: the web bundle, `build-config.js`, and the Go binary's compiled-in `ServerURL`.

## Why it survived so long

Because it was a secret. Secrets can't be read back, diffed, or reviewed — so nobody could see the value was wrong. The build-time guard passed happily: it only checked the URL was non-empty and not localhost, and a dead domain is both.

Meanwhile the hosted frontend read `api.reliantapi.com` from control-plane's KCL. The two had silently diverged, and only the side nobody could inspect was broken.

**None of these values were ever secret.** They're compiled into a client bundle that ships to users — `strings` on the app, or the network tab, reveals every one. Storing them as secrets bought zero confidentiality and cost real correctness.

## The fix

Endpoints now come from `config/endpoints.prod.env`, a checked-in projection of control-plane's `deploy/kcl/lib/env.k` (`reliant_web_vite_env`) — the same declaration the **deployed** frontend uses, so desktop and hosted builds can't drift again.

`scripts/sync-endpoints.sh` regenerates it from `forge env config prod --json`. With `CHECK=1` it fails on drift instead of writing, so CI can enforce it. Also wired as `make sync-endpoints` / `make check-endpoints`.

## A second bug this fixes

The release baked **9** `VITE_*` variables. The app reads **20**. Never set at all:

| Variable | Effect when unset |
|---|---|
| `VITE_AUTH_MODE` | never `cloud` |
| `VITE_CONTROL_PLANE_API_URL` | `getControlPlaneURL()` returns `undefined` |
| `VITE_GATEWAY_URL` | no gateway endpoint |

Electron partly masked this by injecting `window.RELIANT_CONFIG` at runtime, but anything reading `import.meta.env` directly got `undefined`. All 11 the KCL declares now ship, and the step **asserts** the load-bearing ones are present and non-localhost rather than letting a user discover it.

## What stays secret

`SENTRY_DSN` (a project write credential) and `STATSIG_CLIENT_KEY`. The Supabase key in the config file is the **publishable** one (`sb_publishable_` prefix) — designed to ship in a browser bundle, protected by row-level security. The service key must never go here, and the file says so.

## Verification

I ran the generator exactly as CI does (`bash -c` with the same double-quoted `node -e`, to catch escaping problems) against the real file:

```
RELIANT_SERVER_URL   https://api.reliantapi.com
RELIANT_API_URL      https://api.reliantapi.com
RELIANT_GATEWAY_URL  https://gateway.reliantapi.com
SUPABASE_URL         https://dash.reliantlabs.io
```

Then built and packaged a real macOS app with this config and inspected the artifact: **no `reliant.so` anywhere**, all three prod endpoints in the renderer bundle and in `app.asar`. `sync-endpoints.sh` round-trips (write → `CHECK=1` passes). Endpoint reachability confirmed independently — `api.reliantapi.com` returns 401 on an RPC path (endpoint exists, needs auth) versus 404 with the old `/api` prefix, which also confirms the trailing `/api` in the old secret was wrong on top of the dead domain.

I also corrected the repo variables (`RELIANT_SERVER_URL`, `RELIANT_API_URL`, `RELIANT_GATEWAY_URL`) and the `VITE_API_URL` secret to the right values, so a release cut before this merges is no longer poisoned. After this merges those become unused for endpoints — worth deleting so there's one source of truth.

## Not verified

The workflow hasn't run on GitHub; I validated the YAML and simulated each generator locally. The next release is the real test.
