### PR TITLE
fix(prod): derive the real gateway host, and validate release endpoints against DNS

### DIFF
--- a/.github/actions/generate-build-config/action.yml
+++ b/.github/actions/generate-build-config/action.yml
@@ -1,0 +1,44 @@
+name: Generate Electron runtime build config
+description: >-
+  Writes electron/src/build-config.js from env vars and validates the
+  compiled-in server/gateway URLs. Shared by the macOS, Linux, and Windows
+  release jobs so the generation logic exists exactly once.
+
+inputs:
+  statsig-client-key:
+    required: false
+    default: ""
+  sentry-dsn:
+    required: false
+    default: ""
+  supabase-url:
+    required: false
+    default: ""
+  supabase-anon-key:
+    required: false
+    default: ""
+  reliant-server-url:
+    required: false
+    default: ""
+  reliant-api-url:
+    required: false
+    default: ""
+  reliant-gateway-url:
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Generate runtime build config
+      working-directory: electron
+      shell: bash
+      env:
+        STATSIG_CLIENT_KEY: ${{ inputs.statsig-client-key }}
+        SENTRY_DSN: ${{ inputs.sentry-dsn }}
+        SUPABASE_URL: ${{ inputs.supabase-url }}
+        SUPABASE_ANON_KEY: ${{ inputs.supabase-anon-key }}
+        RELIANT_SERVER_URL: ${{ inputs.reliant-server-url }}
+        RELIANT_API_URL: ${{ inputs.reliant-api-url }}
+        RELIANT_GATEWAY_URL: ${{ inputs.reliant-gateway-url }}
+      run: node ../.github/scripts/generate-build-config.mjs

--- a/.github/release-config.env
+++ b/.github/release-config.env
@@ -1,0 +1,22 @@
+# Non-sensitive release endpoints for the Electron release pipeline.
+#
+# These are hostnames, not secrets — the API base URL and the daemon gateway
+# URL are public facts a packaged binary ships with and a `curl` reveals in
+# seconds. Committing them means a hostname change is a reviewable PR diff,
+# not an invisible secret-version edit. Real secrets (Supabase keys, code
+# signing, Sentry DSN, etc.) stay in GCP Secret Manager / GitHub Actions
+# secrets. See ELECTRON_PROD_CONFIG_BRIEFING.md and FORGE_SECRETS_DESIGN.md
+# for the incident this replaced (api.reliant.so, a dead domain, baked in
+# because a hostname value was hidden inside secrets.VITE_API_URL).
+#
+# RELIANT_SERVER_URL / RELIANT_API_URL: the api-server. No trailing /api —
+# verified against the live server (see release.yml validation step).
+# RELIANT_GATEWAY_URL: the daemon gateway. Must be set explicitly — the
+# gateway host cannot be derived from the api host for the prod domain (see
+# cmd/reliant/commands/connection.go's deriveGatewayURL; prod's `api.` prefix
+# derives `gateway-api.<domain>`, which does not exist. The derivation works
+# for other envs, e.g. preprod: `preprod.` -> `gateway-preprod.` is correct.
+# Prod is the exception because its host is `api.` rather than an env name.)
+RELIANT_SERVER_URL=https://api.reliantapi.com
+RELIANT_API_URL=https://api.reliantapi.com
+RELIANT_GATEWAY_URL=https://gateway.reliantapi.com

--- a/.github/scripts/generate-build-config.mjs
+++ b/.github/scripts/generate-build-config.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Single generator for electron/src/build-config.js, shared by the macOS,
+// Linux, and Windows release jobs. Previously this was three copy-pasted
+// bash blocks (release.yml lines 510, 709, 894) that could and did drift —
+// one is enough, invoked identically from every platform job.
+//
+// Reads its values from process.env (populated by the calling workflow step
+// from .github/release-config.env + GitHub secrets), JSON-encodes them, and
+// writes a CommonJS module. Fails the build if RELIANT_SERVER_URL is unset
+// or targets localhost — see validate-endpoint.mjs for the stronger
+// resolvable/reachable check run separately in CI.
+
+import { writeFileSync } from "node:fs";
+
+const config = {
+  STATSIG_CLIENT_KEY: process.env.STATSIG_CLIENT_KEY || "",
+  SENTRY_DSN: process.env.SENTRY_DSN || "",
+  SENTRY_ENABLED: "true",
+  SENTRY_TRACES_SAMPLE_RATE: "0.1",
+  SUPABASE_URL: process.env.SUPABASE_URL || "",
+  SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY || "",
+  RELIANT_SERVER_URL: process.env.RELIANT_SERVER_URL || "",
+  RELIANT_API_URL: process.env.RELIANT_API_URL || "",
+  RELIANT_GATEWAY_URL: process.env.RELIANT_GATEWAY_URL || "",
+};
+
+const lines = Object.entries(config)
+  .map(([k, v]) => "  " + JSON.stringify(k) + ": " + JSON.stringify(v) + ",")
+  .join("\n");
+
+writeFileSync("src/build-config.js", `module.exports = {\n${lines}\n};\n`);
+
+// Fail the build rather than ship an app that points at nothing.
+// backend-manager.js falls back to http://localhost:8080 when
+// RELIANT_SERVER_URL is unset — correct for an OSS build run from source,
+// useless in a packaged app on a user's machine, and silent either way.
+const url = config.RELIANT_SERVER_URL;
+if (!url) {
+  console.error(
+    "build-config.js has no RELIANT_SERVER_URL — the packaged app would aim the daemon at localhost:8080. " +
+      "Set RELIANT_SERVER_URL in .github/release-config.env.",
+  );
+  process.exit(1);
+}
+if (/localhost|127\.0\.0\.1/.test(url)) {
+  console.error(`build-config.js RELIANT_SERVER_URL is ${url} — a packaged build must not target localhost.`);
+  process.exit(1);
+}
+if (!config.RELIANT_GATEWAY_URL) {
+  console.error(
+    "build-config.js has no RELIANT_GATEWAY_URL. The daemon gateway host cannot be safely derived from " +
+      "RELIANT_SERVER_URL for every environment (prod's `api.` host derives `gateway-api.<domain>`, which " +
+      "does not exist — see cmd/reliant/commands/connection.go deriveGatewayURL and " +
+      "ELECTRON_PROD_CONFIG_BRIEFING.md). Set RELIANT_GATEWAY_URL explicitly in .github/release-config.env.",
+  );
+  process.exit(1);
+}
+
+console.log(`build-config.js RELIANT_SERVER_URL = ${url}`);
+console.log(`build-config.js RELIANT_GATEWAY_URL = ${config.RELIANT_GATEWAY_URL}`);

--- a/.github/scripts/validate-endpoint.mjs
+++ b/.github/scripts/validate-endpoint.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// Fails a release build rather than shipping it pointed at nothing, at
+// localhost, or at a dead host — the api.reliant.so incident was a hostname
+// that was never resolvable, baked in silently. Checks, in order:
+//   1. required + non-empty
+//   2. not localhost/127.0.0.1
+//   3. DNS resolves
+//   4. reachable over HTTPS (any HTTP status counts; network/timeout does not)
+//
+// Usage: node validate-endpoint.mjs <ENV_VAR_NAME> <url> [--required]
+
+import dns from "node:dns/promises";
+
+const [name, url, ...rest] = process.argv.slice(2);
+const required = rest.includes("--required");
+
+if (!name) {
+  console.error("usage: validate-endpoint.mjs <NAME> <url> [--required]");
+  process.exit(1);
+}
+
+if (!url) {
+  if (required) {
+    console.error(
+      `${name} is empty — a released build must not ship without it. ` +
+        `Set it in .github/release-config.env.`,
+    );
+    process.exit(1);
+  }
+  console.log(`${name} is empty (not required) — skipping.`);
+  process.exit(0);
+}
+
+if (/localhost|127\.0\.0\.1/.test(url)) {
+  console.error(`${name} is ${url} — a released build must not target localhost.`);
+  process.exit(1);
+}
+
+let host;
+try {
+  host = new URL(url).hostname;
+} catch (e) {
+  console.error(`${name} is ${url} — not a valid URL: ${e.message}`);
+  process.exit(1);
+}
+
+try {
+  await dns.lookup(host);
+} catch (e) {
+  console.error(
+    `${name} host "${host}" does not resolve (${e.code || e.message}). ` +
+      `This is exactly the api.reliant.so dead-domain bug this check exists to catch.`,
+  );
+  process.exit(1);
+}
+
+try {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8000);
+  const res = await fetch(url, { method: "GET", signal: controller.signal });
+  clearTimeout(timeout);
+  console.log(`${name} = ${url} — resolves and is reachable (HTTP ${res.status}).`);
+} catch (e) {
+  console.error(
+    `${name} host "${host}" resolved but is not reachable over HTTPS (${e.message}). ` +
+      `Refusing to ship a build that targets a dead endpoint.`,
+  );
+  process.exit(1);
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,20 @@ jobs:
         id: timing-start
         run: echo "ts=$(date +%s)" >> "$GITHUB_OUTPUT"
 
+      - name: Load release endpoint config
+        # Non-sensitive hostnames, version-controlled and reviewable — see
+        # .github/release-config.env for why these aren't secrets.
+        run: grep -v '^#' .github/release-config.env | grep -v '^$' >> "$GITHUB_ENV"
+
+      - name: Validate release endpoints
+        # Fails fast, once, before any platform build spends minutes on a
+        # release that would ship a dead or unreachable hostname — this is
+        # the check that would have caught api.reliant.so being NXDOMAIN.
+        run: |
+          node .github/scripts/validate-endpoint.mjs RELIANT_SERVER_URL "$RELIANT_SERVER_URL" --required
+          node .github/scripts/validate-endpoint.mjs RELIANT_API_URL "$RELIANT_API_URL" --required
+          node .github/scripts/validate-endpoint.mjs RELIANT_GATEWAY_URL "$RELIANT_GATEWAY_URL" --required
+
       - name: Extract version
         id: version
         run: |
@@ -164,7 +178,9 @@ jobs:
         env:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
-          VITE_API_URL: ${{ secrets.VITE_API_URL }}
+          # Non-sensitive hostname, loaded from .github/release-config.env
+          # above (RELIANT_API_URL), not a secret.
+          VITE_API_URL: ${{ env.RELIANT_API_URL }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           VITE_SENTRY_ENABLED: true
           VITE_SENTRY_TRACES_SAMPLE_RATE: 0.1
@@ -304,6 +320,9 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Load release endpoint config
+        run: grep -v '^#' .github/release-config.env | grep -v '^$' >> "$GITHUB_ENV"
+
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
@@ -329,16 +348,19 @@ jobs:
           df -h
           du -sh "$RUNNER_TEMP" "$HOME/.cache/go-build" "$HOME/go/pkg/mod" 2>/dev/null || true
 
+      - name: Validate release endpoints
+        run: |
+          node .github/scripts/validate-endpoint.mjs RELIANT_SERVER_URL "$RELIANT_SERVER_URL" --required
+          node .github/scripts/validate-endpoint.mjs RELIANT_GATEWAY_URL "$RELIANT_GATEWAY_URL" --required
+
       - name: Build backend binaries
         env:
           TARGET_OS: ${{ matrix.target_os }}
           TARGET_ARCH: ${{ matrix.target_arch }}
           VERSION: ${{ needs.prepare.outputs.version }}
-          # Compiled into the binary via -X below. VITE_API_URL is the hosted
-          # endpoint the web build already ships; the vars are overrides for
-          # when the gateway or auth host differ from it.
-          RELIANT_SERVER_URL: ${{ vars.RELIANT_SERVER_URL || secrets.VITE_API_URL }}
-          RELIANT_GATEWAY_URL: ${{ vars.RELIANT_GATEWAY_URL }}
+          # RELIANT_SERVER_URL / RELIANT_GATEWAY_URL come from
+          # .github/release-config.env, loaded into $GITHUB_ENV above —
+          # non-sensitive hostnames, not secrets.
           RELIANT_AUTH_URL: ${{ secrets.VITE_SUPABASE_URL }}
           RELIANT_AUTH_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
         run: |
@@ -366,17 +388,8 @@ jobs:
             LDFLAGS="$LDFLAGS -X $BD.AuthKey=$RELIANT_AUTH_KEY"
           fi
 
-          # A released binary that still points at localhost is the bug this
-          # guards; fail here rather than ship it.
-          case "${RELIANT_SERVER_URL:-}" in
-            "")
-              echo "RELIANT_SERVER_URL is empty — the released binary would default to http://localhost:8080. Set the VITE_API_URL secret or the RELIANT_SERVER_URL variable." >&2
-              exit 1 ;;
-            *localhost*|*127.0.0.1*)
-              echo "RELIANT_SERVER_URL is $RELIANT_SERVER_URL — a released binary must not target localhost." >&2
-              exit 1 ;;
-          esac
           echo "Compiled-in ServerURL = $RELIANT_SERVER_URL"
+          echo "Compiled-in GatewayURL = $RELIANT_GATEWAY_URL"
 
           if [[ "$TARGET_OS" == "windows" ]]; then
             BACKEND_BIN_NAME="reliant-backend.exe"
@@ -443,6 +456,9 @@ jobs:
         id: timing-start
         run: echo "ts=$(date +%s)" >> "$GITHUB_OUTPUT"
 
+      - name: Load release endpoint config
+        run: grep -v '^#' .github/release-config.env | grep -v '^$' >> "$GITHUB_ENV"
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -493,59 +509,15 @@ jobs:
         run: npm ci --legacy-peer-deps --prefer-offline
 
       - name: Generate runtime build config
-        working-directory: electron
-        env:
-          STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-          # The daemon's --server target and the renderer's api-server URL.
-          # Both default to VITE_API_URL, the hosted endpoint the web build
-          # already ships; override the vars only if the daemon gateway or
-          # api-server ever split onto their own hostnames.
-          RELIANT_SERVER_URL: ${{ vars.RELIANT_SERVER_URL || secrets.VITE_API_URL }}
-          RELIANT_API_URL: ${{ vars.RELIANT_API_URL || secrets.VITE_API_URL }}
-          RELIANT_GATEWAY_URL: ${{ vars.RELIANT_GATEWAY_URL }}
-        run: |
-          cat > src/build-config.js <<'SCRIPT'
-          module.exports = {
-          SCRIPT
-          # Use node to safely JSON-encode values (handles special chars in secrets)
-          node -e "
-            const config = {
-              STATSIG_CLIENT_KEY: process.env.STATSIG_CLIENT_KEY || '',
-              SENTRY_DSN: process.env.SENTRY_DSN || '',
-              SENTRY_ENABLED: 'true',
-              SENTRY_TRACES_SAMPLE_RATE: '0.1',
-              SUPABASE_URL: process.env.SUPABASE_URL || '',
-              SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY || '',
-              RELIANT_SERVER_URL: process.env.RELIANT_SERVER_URL || '',
-              RELIANT_API_URL: process.env.RELIANT_API_URL || '',
-              RELIANT_GATEWAY_URL: process.env.RELIANT_GATEWAY_URL || '',
-            };
-            const lines = Object.entries(config).map(([k,v]) => '  ' + JSON.stringify(k) + ': ' + JSON.stringify(v) + ',');
-            console.log(lines.join('\n'));
-          " >> src/build-config.js
-          echo '};' >> src/build-config.js
-          # Fail the build rather than ship an app that points at nothing.
-          # backend-manager.js falls back to http://localhost:8080 when
-          # RELIANT_SERVER_URL is unset — correct for an OSS build run from
-          # source, useless in a packaged app on a user's machine, and silent
-          # either way. This is the check that was missing when the key was
-          # absent from the generator entirely.
-          node -e "
-            const c = require('./src/build-config.js');
-            const url = c.RELIANT_SERVER_URL || '';
-            if (!url) {
-              console.error('build-config.js has no RELIANT_SERVER_URL — the packaged app would aim the daemon at localhost:8080. Set the VITE_API_URL secret or the RELIANT_SERVER_URL variable.');
-              process.exit(1);
-            }
-            if (/localhost|127\.0\.0\.1/.test(url)) {
-              console.error('build-config.js RELIANT_SERVER_URL is ' + url + ' — a packaged build must not target localhost.');
-              process.exit(1);
-            }
-            console.log('build-config.js RELIANT_SERVER_URL = ' + url);
-          "
+        uses: ./.github/actions/generate-build-config
+        with:
+          statsig-client-key: ${{ secrets.STATSIG_CLIENT_KEY }}
+          sentry-dsn: ${{ secrets.SENTRY_DSN }}
+          supabase-url: ${{ secrets.VITE_SUPABASE_URL }}
+          supabase-anon-key: ${{ secrets.SUPABASE_ANON_KEY }}
+          reliant-server-url: ${{ env.RELIANT_SERVER_URL }}
+          reliant-api-url: ${{ env.RELIANT_API_URL }}
+          reliant-gateway-url: ${{ env.RELIANT_GATEWAY_URL }}
 
       - name: Build and Publish macOS apps (Signed & Notarized)
         working-directory: electron
@@ -642,6 +614,9 @@ jobs:
         id: timing-start
         run: echo "ts=$(date +%s)" >> "$GITHUB_OUTPUT"
 
+      - name: Load release endpoint config
+        run: grep -v '^#' .github/release-config.env | grep -v '^$' >> "$GITHUB_ENV"
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -692,59 +667,15 @@ jobs:
         run: npm ci --legacy-peer-deps --prefer-offline
 
       - name: Generate runtime build config
-        working-directory: electron
-        env:
-          STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-          # The daemon's --server target and the renderer's api-server URL.
-          # Both default to VITE_API_URL, the hosted endpoint the web build
-          # already ships; override the vars only if the daemon gateway or
-          # api-server ever split onto their own hostnames.
-          RELIANT_SERVER_URL: ${{ vars.RELIANT_SERVER_URL || secrets.VITE_API_URL }}
-          RELIANT_API_URL: ${{ vars.RELIANT_API_URL || secrets.VITE_API_URL }}
-          RELIANT_GATEWAY_URL: ${{ vars.RELIANT_GATEWAY_URL }}
-        run: |
-          cat > src/build-config.js <<'SCRIPT'
-          module.exports = {
-          SCRIPT
-          # Use node to safely JSON-encode values (handles special chars in secrets)
-          node -e "
-            const config = {
-              STATSIG_CLIENT_KEY: process.env.STATSIG_CLIENT_KEY || '',
-              SENTRY_DSN: process.env.SENTRY_DSN || '',
-              SENTRY_ENABLED: 'true',
-              SENTRY_TRACES_SAMPLE_RATE: '0.1',
-              SUPABASE_URL: process.env.SUPABASE_URL || '',
-              SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY || '',
-              RELIANT_SERVER_URL: process.env.RELIANT_SERVER_URL || '',
-              RELIANT_API_URL: process.env.RELIANT_API_URL || '',
-              RELIANT_GATEWAY_URL: process.env.RELIANT_GATEWAY_URL || '',
-            };
-            const lines = Object.entries(config).map(([k,v]) => '  ' + JSON.stringify(k) + ': ' + JSON.stringify(v) + ',');
-            console.log(lines.join('\n'));
-          " >> src/build-config.js
-          echo '};' >> src/build-config.js
-          # Fail the build rather than ship an app that points at nothing.
-          # backend-manager.js falls back to http://localhost:8080 when
-          # RELIANT_SERVER_URL is unset — correct for an OSS build run from
-          # source, useless in a packaged app on a user's machine, and silent
-          # either way. This is the check that was missing when the key was
-          # absent from the generator entirely.
-          node -e "
-            const c = require('./src/build-config.js');
-            const url = c.RELIANT_SERVER_URL || '';
-            if (!url) {
-              console.error('build-config.js has no RELIANT_SERVER_URL — the packaged app would aim the daemon at localhost:8080. Set the VITE_API_URL secret or the RELIANT_SERVER_URL variable.');
-              process.exit(1);
-            }
-            if (/localhost|127\.0\.0\.1/.test(url)) {
-              console.error('build-config.js RELIANT_SERVER_URL is ' + url + ' — a packaged build must not target localhost.');
-              process.exit(1);
-            }
-            console.log('build-config.js RELIANT_SERVER_URL = ' + url);
-          "
+        uses: ./.github/actions/generate-build-config
+        with:
+          statsig-client-key: ${{ secrets.STATSIG_CLIENT_KEY }}
+          sentry-dsn: ${{ secrets.SENTRY_DSN }}
+          supabase-url: ${{ secrets.VITE_SUPABASE_URL }}
+          supabase-anon-key: ${{ secrets.SUPABASE_ANON_KEY }}
+          reliant-server-url: ${{ env.RELIANT_SERVER_URL }}
+          reliant-api-url: ${{ env.RELIANT_API_URL }}
+          reliant-gateway-url: ${{ env.RELIANT_GATEWAY_URL }}
 
       - name: Build and Publish Linux apps
         working-directory: electron
@@ -827,6 +758,9 @@ jobs:
         shell: bash
         run: echo "ts=$(date +%s)" >> "$GITHUB_OUTPUT"
 
+      - name: Load release endpoint config
+        run: grep -v '^#' .github/release-config.env | grep -v '^$' >> "$GITHUB_ENV"
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -876,60 +810,15 @@ jobs:
         run: npm ci --legacy-peer-deps --prefer-offline
 
       - name: Generate runtime build config
-        working-directory: electron
-        shell: bash
-        env:
-          STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-          # The daemon's --server target and the renderer's api-server URL.
-          # Both default to VITE_API_URL, the hosted endpoint the web build
-          # already ships; override the vars only if the daemon gateway or
-          # api-server ever split onto their own hostnames.
-          RELIANT_SERVER_URL: ${{ vars.RELIANT_SERVER_URL || secrets.VITE_API_URL }}
-          RELIANT_API_URL: ${{ vars.RELIANT_API_URL || secrets.VITE_API_URL }}
-          RELIANT_GATEWAY_URL: ${{ vars.RELIANT_GATEWAY_URL }}
-        run: |
-          cat > src/build-config.js <<'SCRIPT'
-          module.exports = {
-          SCRIPT
-          # Use node to safely JSON-encode values (handles special chars in secrets)
-          node -e "
-            const config = {
-              STATSIG_CLIENT_KEY: process.env.STATSIG_CLIENT_KEY || '',
-              SENTRY_DSN: process.env.SENTRY_DSN || '',
-              SENTRY_ENABLED: 'true',
-              SENTRY_TRACES_SAMPLE_RATE: '0.1',
-              SUPABASE_URL: process.env.SUPABASE_URL || '',
-              SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY || '',
-              RELIANT_SERVER_URL: process.env.RELIANT_SERVER_URL || '',
-              RELIANT_API_URL: process.env.RELIANT_API_URL || '',
-              RELIANT_GATEWAY_URL: process.env.RELIANT_GATEWAY_URL || '',
-            };
-            const lines = Object.entries(config).map(([k,v]) => '  ' + JSON.stringify(k) + ': ' + JSON.stringify(v) + ',');
-            console.log(lines.join('\n'));
-          " >> src/build-config.js
-          echo '};' >> src/build-config.js
-          # Fail the build rather than ship an app that points at nothing.
-          # backend-manager.js falls back to http://localhost:8080 when
-          # RELIANT_SERVER_URL is unset — correct for an OSS build run from
-          # source, useless in a packaged app on a user's machine, and silent
-          # either way. This is the check that was missing when the key was
-          # absent from the generator entirely.
-          node -e "
-            const c = require('./src/build-config.js');
-            const url = c.RELIANT_SERVER_URL || '';
-            if (!url) {
-              console.error('build-config.js has no RELIANT_SERVER_URL — the packaged app would aim the daemon at localhost:8080. Set the VITE_API_URL secret or the RELIANT_SERVER_URL variable.');
-              process.exit(1);
-            }
-            if (/localhost|127\.0\.0\.1/.test(url)) {
-              console.error('build-config.js RELIANT_SERVER_URL is ' + url + ' — a packaged build must not target localhost.');
-              process.exit(1);
-            }
-            console.log('build-config.js RELIANT_SERVER_URL = ' + url);
-          "
+        uses: ./.github/actions/generate-build-config
+        with:
+          statsig-client-key: ${{ secrets.STATSIG_CLIENT_KEY }}
+          sentry-dsn: ${{ secrets.SENTRY_DSN }}
+          supabase-url: ${{ secrets.VITE_SUPABASE_URL }}
+          supabase-anon-key: ${{ secrets.SUPABASE_ANON_KEY }}
+          reliant-server-url: ${{ env.RELIANT_SERVER_URL }}
+          reliant-api-url: ${{ env.RELIANT_API_URL }}
+          reliant-gateway-url: ${{ env.RELIANT_GATEWAY_URL }}
 
       - name: Build and Publish Windows apps
         working-directory: electron

--- a/cmd/reliant/commands/connection.go
+++ b/cmd/reliant/commands/connection.go
@@ -238,7 +238,19 @@ func deriveGatewayURL(server string) string {
 	// "reliantapi.com" (1 dot) -> gateway.reliantapi.com
 	if strings.Count(host, ".") >= 2 {
 		parts := strings.SplitN(host, ".", 2)
-		host = "gateway-" + parts[0] + "." + parts[1]
+		// The leading label is an ENVIRONMENT name (staging, preprod), so the
+		// gateway for it is that same environment's gateway: gateway-staging.
+		// But when the leading label is the SERVICE name `api`, the gateway is
+		// its SIBLING service — gateway.<domain> — not a prefixed form of the
+		// api host. Prefixing there invents gateway-api.<domain>, which does
+		// not exist; that shipped, and the packaged daemon could never reach a
+		// gateway. prod is the only env whose host is named for the service
+		// rather than the environment, which is why it is the exception.
+		if parts[0] == "api" {
+			host = "gateway." + parts[1]
+		} else {
+			host = "gateway-" + parts[0] + "." + parts[1]
+		}
 	} else {
 		host = "gateway." + host
 	}

--- a/cmd/reliant/commands/connection_test.go
+++ b/cmd/reliant/commands/connection_test.go
@@ -281,6 +281,55 @@ func TestResolveGatewayPrecedence(t *testing.T) {
 			t.Errorf("gateway = %q, want the localhost server as-is", conn.GatewayURL)
 		}
 	})
+
+	// prod's api-server is api.reliantapi.com, whose gateway is
+	// gateway.reliantapi.com — NOT gateway-api.reliantapi.com, which does not
+	// resolve. The `api` label names the SERVICE, not an environment, so
+	// prefixing it the way an env label is prefixed invents a dead host. This
+	// shipped: the packaged app derived gateway-api.<domain> and the daemon
+	// could never reach a gateway.
+	t.Run("an api. server derives the sibling gateway. host", func(t *testing.T) {
+		writeContexts(t, cfg)
+		conn, err := resolveWithArgs(t, "--server", "https://api.reliantapi.com")
+		if err != nil {
+			t.Fatalf("resolveServer: %v", err)
+		}
+		const want = "https://gateway.reliantapi.com"
+		if conn.GatewayURL != want {
+			t.Errorf("gateway = %q, want %q (gateway-api.reliantapi.com does not exist)", conn.GatewayURL, want)
+		}
+	})
+}
+
+// TestDeriveGatewayURL pins the host-rewriting rule directly, including the
+// env-label cases that must keep working alongside the `api.` fix.
+func TestDeriveGatewayURL(t *testing.T) {
+	cases := []struct {
+		name   string
+		server string
+		want   string
+	}{
+		// `api` names the service, so the gateway is its SIBLING, not a
+		// prefixed form of it. Verified live: gateway.reliantapi.com resolves,
+		// gateway-api.reliantapi.com is NXDOMAIN.
+		{"prod api host", "https://api.reliantapi.com", "https://gateway.reliantapi.com"},
+		// An environment label keeps the prefix form. Verified live:
+		// gateway-preprod.reliantapi.com resolves.
+		{"preprod env label", "https://preprod.reliantapi.com", "https://gateway-preprod.reliantapi.com"},
+		{"staging env label", "https://staging.reliantapi.com", "https://gateway-staging.reliantapi.com"},
+		{"apex", "https://reliantapi.com", "https://gateway.reliantapi.com"},
+		{"localhost untouched", "http://localhost:3091", "http://localhost:3091"},
+		{"loopback untouched", "http://127.0.0.1:8080", "http://127.0.0.1:8080"},
+		{"port preserved", "https://api.reliantapi.com:8443", "https://gateway.reliantapi.com:8443"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := deriveGatewayURL(tc.server); got != tc.want {
+				t.Errorf("deriveGatewayURL(%q) = %q, want %q", tc.server, got, tc.want)
+			}
+		})
+	}
 }
 
 func TestDescribeServerNamesTheSource(t *testing.T) {


### PR DESCRIPTION
Two defects that together made the packaged desktop app unable to reach a backend. Both are verified against live DNS, not reasoned about.

## 1. The derived gateway host does not exist

`deriveGatewayURL` turned `api.reliantapi.com` into `gateway-api.reliantapi.com`:

```
dig +short gateway-api.reliantapi.com   → (nothing — NXDOMAIN)
dig +short gateway.reliantapi.com       → 34.31.112.130
```

The rule assumed the leading label is an **environment** name, which is true for preprod (`preprod.` → `gateway-preprod.`) and staging. Prod is the exception: its host is named for the **service** (`api.`), so the gateway is its sibling `gateway.<domain>`, not a prefixed form of the api host.

So prod was the single environment the derivation got wrong, and prod is what ships to users. Even with a correct API URL, the packaged daemon derived a gateway that has no DNS record.

## 2. Endpoints were secrets, so nobody could see they were wrong

`VITE_API_URL` contained `https://api.reliant.so/api` — a domain with **no DNS record at all**. Every release baked it into the web bundle, `build-config.js`, and the Go binary's compiled-in `ServerURL`.

It survived because it was a secret: secrets cannot be read back, diffed, or reviewed. The existing guard only checked non-empty and non-localhost, and a dead domain passes both.

These are public hostnames that ship inside the binary — `curl` or `strings` reveals them in seconds. Hiding them bought no confidentiality and cost real correctness. They now live in `.github/release-config.env`, so a hostname change is a reviewable diff.

## The check that would have caught it

`.github/scripts/validate-endpoint.mjs` runs once, before any platform build:

1. required and non-empty
2. not localhost / 127.0.0.1
3. **DNS resolves**
4. **reachable over HTTPS** (any status counts; only network failure/timeout fails)

Steps 3 and 4 are the ones that matter here — they are what turns "shipped a dead domain to users" into "release fails in ten seconds". It also fails fast, before the multi-platform builds spend minutes producing artifacts that were never going to work.

## Verification

`go build ./...` clean. `go test ./cmd/reliant/commands/` passes, including the derivation cases:

```
--- PASS: TestDeriveGatewayURL
    prod_api_host          preprod_env_label     staging_env_label
    apex                   localhost_untouched   loopback_untouched
    port_preserved
--- PASS: TestResolveGatewayPrecedence
    an_api._server_derives_the_sibling_gateway._host
    RELIANT_GATEWAY_URL_wins_over_derivation   ...
```

The explicit `RELIANT_GATEWAY_URL` override still wins over derivation, so the config file and the derivation agree rather than fight.

## Relationship to #184

#184 solved the dead-domain half differently, by projecting endpoints from control-plane's KCL. **This PR supersedes it** — same fix, plus the live DNS/reachability gate, plus the gateway-derivation bug that #184 does not address. I'll close #184 in favour of this.

The one idea worth carrying over from #184 is keeping these values in sync with control-plane's KCL, which is where the deployed frontend gets the same hostnames. Worth a follow-up so the two can't drift again; not required for this fix to be correct.
