### PR TITLE
fix(daemon): non-interactive auth, credential waiting, and event delivery

### DIFF
--- a/cmd/reliant/commands/daemon.go
+++ b/cmd/reliant/commands/daemon.go
@@ -71,7 +71,14 @@ the Reliant cloud platform via a bidirectional gRPC stream.`,
 // The daemon PAT is minted by, and scoped to, conn's server — the one the
 // resolved context names — so registering never silently targets a different
 // server than the rest of the CLI.
-func registerDaemon(ctx context.Context, cmd *cobra.Command, conn *connection) error {
+//
+// nonInteractive, when true, forbids the OAuth login step from opening a
+// browser or starting the local login-page HTTP server: it is passed straight
+// through to auth.Login, which returns auth.ErrNonInteractiveLoginRequired
+// instead of running the interactive flow. Callers that must idle rather than
+// fail outright (see waitForCredentialsNonInteractive) detect that sentinel
+// with errors.Is.
+func registerDaemon(ctx context.Context, cmd *cobra.Command, conn *connection, nonInteractive bool) error {
 	apiURL, gwURL := conn.ServerURL, conn.GatewayURL
 
 	accessToken, err := auth.ReadAccessTokenFromAuthFile()
@@ -79,8 +86,10 @@ func registerDaemon(ctx context.Context, cmd *cobra.Command, conn *connection) e
 		return fmt.Errorf("reading auth file: %w", err)
 	}
 	if accessToken == "" {
-		fmt.Fprintln(cmd.OutOrStdout(), "Not logged in. Starting authentication...")
-		result, err := auth.Login(ctx, auth.LoginOptions{})
+		if !nonInteractive {
+			fmt.Fprintln(cmd.OutOrStdout(), "Not logged in. Starting authentication...")
+		}
+		result, err := auth.Login(ctx, auth.LoginOptions{NonInteractive: nonInteractive})
 		if err != nil {
 			return fmt.Errorf("login failed: %w", err)
 		}
@@ -156,10 +165,11 @@ func daemonCredsExpiringSoon(creds *auth.DaemonCredentials, now time.Time) bool 
 // ensureDaemonCredentials returns existing daemon credentials or creates new ones.
 // This is the shared credential resolution logic used by both `open` and `daemon start`.
 //
-// If no credentials exist, runs the interactive registration flow: prompts
-// for sign-in (if not already), then mints a PAT via CreateDaemonToken.
-// Most users will instead use `--token` to paste a PAT minted from the web UI.
-func ensureDaemonCredentials(ctx context.Context, cmd *cobra.Command, conn *connection) (*auth.DaemonCredentials, error) {
+// If no credentials exist, runs the registration flow: prompts for sign-in
+// (if not already, and unless nonInteractive is set — see registerDaemon),
+// then mints a PAT via CreateDaemonToken. Most users will instead use
+// `--token` to paste a PAT minted from the web UI.
+func ensureDaemonCredentials(ctx context.Context, cmd *cobra.Command, conn *connection, nonInteractive bool) (*auth.DaemonCredentials, error) {
 	apiURL, gwURL := conn.ServerURL, conn.GatewayURL
 
 	creds, err := auth.ReadDaemonCredentials(apiURL)
@@ -176,7 +186,9 @@ func ensureDaemonCredentials(ctx context.Context, cmd *cobra.Command, conn *conn
 		if daemonCredsExpiringSoon(creds, time.Now()) {
 			logging.Warn("stored daemon PAT is expired or near expiry — re-minting",
 				"expiresAt", creds.ExpiresAt.Format(time.RFC3339))
-			fmt.Fprintln(cmd.OutOrStdout(), "Daemon credentials expired. Re-registering...")
+			if !nonInteractive {
+				fmt.Fprintln(cmd.OutOrStdout(), "Daemon credentials expired. Re-registering...")
+			}
 			_ = auth.DeleteDaemonCredentials(apiURL)
 			creds = nil
 		} else {
@@ -190,11 +202,11 @@ func ensureDaemonCredentials(ctx context.Context, cmd *cobra.Command, conn *conn
 			}
 			return creds, nil
 		}
-	} else {
+	} else if !nonInteractive {
 		fmt.Fprintln(cmd.OutOrStdout(), "No daemon credentials found. Registering...")
 	}
 
-	if err := registerDaemon(ctx, cmd, conn); err != nil {
+	if err := registerDaemon(ctx, cmd, conn, nonInteractive); err != nil {
 		return nil, fmt.Errorf("daemon registration failed: %w", err)
 	}
 
@@ -204,6 +216,115 @@ func ensureDaemonCredentials(ctx context.Context, cmd *cobra.Command, conn *conn
 		return nil, fmt.Errorf("failed to read daemon credentials after registration")
 	}
 	return creds, nil
+}
+
+// daemonCredentialPollInterval is how often a non-interactive daemon with no
+// usable credentials re-checks disk for one appearing there. In practice this
+// is Electron's own pre-mint path (electron/src/daemon-creds.js) writing
+// ~/.reliant/daemon.json after the user signs in through Electron's login
+// page and respawns the daemon — but polling also covers the case where the
+// daemon is left running and the file simply appears underneath it. A stat
+// plus small JSON read is cheap enough to afford every few seconds.
+//
+// A var, not a const, so tests can shrink it rather than spending real wall
+// clock time waiting out the production interval.
+var daemonCredentialPollInterval = 3 * time.Second
+
+// waitForCredentialsNonInteractive is what a non-interactive daemon does
+// instead of running the OAuth login flow: it stays resident and idle,
+// publishing daemonstate.StreamAwaitingCredentials so `daemon status` and
+// Electron's own health check can report "waiting for sign-in" honestly
+// instead of as a crash, and re-checks the credentials file on disk until one
+// appears or ctx is cancelled (SIGINT/SIGTERM are wired to ctx cancellation by
+// watchShutdownSignals, so this loop stays responsive to graceful shutdown).
+func waitForCredentialsNonInteractive(ctx context.Context, cmd *cobra.Command, conn *connection, dataDir string) (*auth.DaemonCredentials, error) {
+	fmt.Fprintln(cmd.OutOrStdout(), "No daemon credentials found and running non-interactively — waiting for sign-in...")
+	if err := daemonstate.SetStream(dataDir, daemonstate.StreamAwaitingCredentials, "waiting for credentials to appear on disk"); err != nil {
+		logging.Warn("failed to publish awaiting-credentials daemon state", "error", err)
+	}
+
+	// Check immediately before the first tick: a credential can already be on
+	// disk (e.g. a slow registerDaemon call lost a race with Electron's own
+	// pre-mint), and there is no reason to make that case wait a full poll
+	// interval.
+	if creds := pollDaemonCredentials(cmd, conn); creds != nil {
+		return creds, nil
+	}
+
+	ticker := time.NewTicker(daemonCredentialPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			if creds := pollDaemonCredentials(cmd, conn); creds != nil {
+				return creds, nil
+			}
+		}
+	}
+}
+
+// pollDaemonCredentials is one credential-check attempt shared by the
+// immediate check and every subsequent tick in
+// waitForCredentialsNonInteractive. Returns nil (never an error) when there is
+// nothing usable yet — a bad read or a not-yet-valid credential is exactly the
+// same as "nothing yet" to the caller, which just waits for the next tick.
+func pollDaemonCredentials(cmd *cobra.Command, conn *connection) *auth.DaemonCredentials {
+	creds, err := auth.ReadDaemonCredentials(conn.ServerURL)
+	if err != nil {
+		logging.Warn("error re-checking daemon credentials while awaiting sign-in", "error", err)
+		return nil
+	}
+	if creds == nil {
+		return nil
+	}
+	// A credential can appear on disk already past its expiry (a stale mount,
+	// a slow write racing a clock) — keep waiting for a good one rather than
+	// handing the caller something that will fail the very first gateway
+	// reach-out.
+	if daemonCredsExpiringSoon(creds, time.Now()) {
+		return nil
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "Daemon credentials found — resuming startup")
+	return creds
+}
+
+// resolveOrAwaitCredentials calls ensureDaemonCredentials and, when running
+// non-interactively with no usable credentials, falls into
+// waitForCredentialsNonInteractive instead of surfacing
+// auth.ErrNonInteractiveLoginRequired as a fatal error. This is the seam used
+// by both the initial credential resolution and the auth-failure retry path
+// in `daemon start`, so neither can regress into popping a browser.
+func resolveOrAwaitCredentials(ctx context.Context, cmd *cobra.Command, conn *connection, dataDir string, nonInteractive bool) (*auth.DaemonCredentials, error) {
+	creds, err := ensureDaemonCredentials(ctx, cmd, conn, nonInteractive)
+	if err == nil {
+		return creds, nil
+	}
+	if nonInteractive && errors.Is(err, auth.ErrNonInteractiveLoginRequired) {
+		return waitForCredentialsNonInteractive(ctx, cmd, conn, dataDir)
+	}
+	return nil, err
+}
+
+// registerOrAwaitCredentials is resolveOrAwaitCredentials's counterpart for
+// the auth-failure retry path: the caller has already deleted stale
+// credentials and needs a fresh registration, but a non-interactive daemon
+// must idle rather than fail when that requires a login it cannot run.
+func registerOrAwaitCredentials(ctx context.Context, cmd *cobra.Command, conn *connection, dataDir string, nonInteractive bool) (*auth.DaemonCredentials, error) {
+	regErr := registerDaemon(ctx, cmd, conn, nonInteractive)
+	if regErr == nil {
+		newCreds, readErr := auth.ReadDaemonCredentials(conn.ServerURL)
+		if readErr != nil || newCreds == nil {
+			return nil, fmt.Errorf("failed to read credentials after re-registration")
+		}
+		return newCreds, nil
+	}
+	if nonInteractive && errors.Is(regErr, auth.ErrNonInteractiveLoginRequired) {
+		return waitForCredentialsNonInteractive(ctx, cmd, conn, dataDir)
+	}
+	return nil, fmt.Errorf("re-registration failed: %w", regErr)
 }
 
 // persistDaemonCredentials best-effort writes daemon credentials to disk.
@@ -352,7 +473,10 @@ After registering, run 'reliant daemon start' to connect.`,
 				return nil
 			}
 
-			return registerDaemon(cmd.Context(), cmd, conn)
+			// `daemon register` is always an explicit, interactive CLI
+			// invocation — never spawned by Electron — so it never passes
+			// nonInteractive.
+			return registerDaemon(cmd.Context(), cmd, conn, false)
 		},
 	}
 
@@ -395,17 +519,18 @@ func watchShutdownSignals(sigCh <-chan os.Signal, w io.Writer, cancel context.Ca
 
 func newDaemonStartCmd() *cobra.Command {
 	var (
-		port       string
-		grpcURL    string
-		dataDir    string
-		background bool
-		tlsCert    string
-		tlsKey     string
-		tlsMode    string
-		useToken   bool
-		daemonName string
-		serverMode bool
-		listenPort int
+		port           string
+		grpcURL        string
+		dataDir        string
+		background     bool
+		tlsCert        string
+		tlsKey         string
+		tlsMode        string
+		useToken       bool
+		daemonName     string
+		serverMode     bool
+		listenPort     int
+		nonInteractive bool
 	)
 
 	cmd := &cobra.Command{
@@ -419,7 +544,14 @@ execution capabilities.
 Credential resolution order:
   1. Daemon credentials file (created by 'reliant daemon register')
   2. If logged in but not registered, auto-registers and creates credentials
-  3. If not logged in, prompts for login and then auto-registers`,
+  3. If not logged in, prompts for login and then auto-registers — unless
+     --non-interactive (or RELIANT_DAEMON_NON_INTERACTIVE) is set, in which
+     case the daemon never opens a browser or runs the login flow itself. It
+     instead stays resident and idle, publishing "awaiting_credentials" in its
+     runtime state, and polls for a credentials file to appear on disk (see
+     'reliant daemon status' and internal/toolexec/daemonstate). This is the
+     mode Electron spawns in: its own login page owns interactive sign-in, and
+     the daemon must never pop a second one.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if background {
 				// TODO: implement background fork/detach
@@ -487,7 +619,7 @@ Credential resolution order:
 					return err
 				}
 			} else {
-				creds, err = ensureDaemonCredentials(ctx, cmd, conn)
+				creds, err = resolveOrAwaitCredentials(ctx, cmd, conn, dataDir, nonInteractive)
 				if err != nil {
 					return err
 				}
@@ -564,14 +696,12 @@ Credential resolution order:
 						"error", err, "code", code.String(), "gateway_url", daemonGRPCURL)
 					_ = auth.DeleteDaemonCredentials(conn.ServerURL)
 
-					fmt.Fprintln(cmd.OutOrStdout(), "Credentials expired or revoked. Re-registering...")
-					if regErr := registerDaemon(ctx, cmd, conn); regErr != nil {
-						return fmt.Errorf("re-registration failed: %w (original: %v)", regErr, err)
+					if !nonInteractive {
+						fmt.Fprintln(cmd.OutOrStdout(), "Credentials expired or revoked. Re-registering...")
 					}
-
-					newCreds, readErr := auth.ReadDaemonCredentials(conn.ServerURL)
-					if readErr != nil || newCreds == nil {
-						return fmt.Errorf("failed to read credentials after re-registration")
+					newCreds, regErr := registerOrAwaitCredentials(ctx, cmd, conn, dataDir, nonInteractive)
+					if regErr != nil {
+						return fmt.Errorf("re-registration failed: %w (original: %v)", regErr, err)
 					}
 
 					logging.Info("Re-registered successfully, retrying connection...")
@@ -602,6 +732,14 @@ Credential resolution order:
 	cmd.Flags().StringVar(&daemonName, "name", "", "Human-friendly daemon name (default: <instance-id>@<hostname>)")
 	cmd.Flags().BoolVar(&serverMode, "server-mode", envOrDefault("DAEMON_SERVER_MODE", "") == "true", "Listen for incoming gateway connections instead of dialing out")
 	cmd.Flags().IntVar(&listenPort, "listen-port", envOrDefaultInt("DAEMON_LISTEN_PORT", 9190), "Port to listen on in server mode")
+	// Precedence: explicit --non-interactive on the command line always wins
+	// (cobra only applies this default when the flag is absent); otherwise
+	// RELIANT_DAEMON_NON_INTERACTIVE; otherwise false (interactive, the
+	// existing CLI behavior). Electron spawns the daemon with this flag set
+	// so it never opens a browser — Electron's own login page owns
+	// interactive sign-in. See registerDaemon / waitForCredentialsNonInteractive.
+	cmd.Flags().BoolVar(&nonInteractive, "non-interactive", envOrDefaultBool("RELIANT_DAEMON_NON_INTERACTIVE", false),
+		"Never open a browser or run interactive login; idle and wait for credentials to appear on disk instead")
 
 	return cmd
 }
@@ -740,6 +878,8 @@ stream is not established.`,
 				fmt.Fprintln(out, "Daemon is running and its gateway stream is established")
 			case state.Stream == daemonstate.StreamUnknown:
 				fmt.Fprintln(out, "Daemon process exists but its gateway stream state is unknown")
+			case state.Stream == daemonstate.StreamAwaitingCredentials:
+				fmt.Fprintln(out, "Daemon is running but has no usable credentials — waiting for sign-in")
 			default:
 				fmt.Fprintf(out, "Daemon process exists but its gateway stream is NOT established (%s)\n", state.Stream)
 			}

--- a/cmd/reliant/commands/daemon_creds_test.go
+++ b/cmd/reliant/commands/daemon_creds_test.go
@@ -70,7 +70,7 @@ func TestEnsureDaemonCredentials_ReadOnlyFileTolerated(t *testing.T) {
 	// Pass a different gateway URL to force the drift-rewrite (persist) path.
 	const driftedGateway = "https://gateway-staging.reliantapi.com:8443"
 	target := &connection{ServerURL: serverURL, GatewayURL: driftedGateway}
-	creds, err := ensureDaemonCredentials(context.Background(), cmd, target)
+	creds, err := ensureDaemonCredentials(context.Background(), cmd, target, false)
 	if err != nil {
 		t.Fatalf("ensureDaemonCredentials returned error on read-only creds file: %v", err)
 	}

--- a/cmd/reliant/commands/daemon_nonint_test.go
+++ b/cmd/reliant/commands/daemon_nonint_test.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2025 Reliant Labs
+package commands
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/reliant-labs/reliant/internal/auth"
+	"github.com/reliant-labs/reliant/internal/toolexec/daemonstate"
+)
+
+// withTempReliantHome redirects ~/.reliant (where daemon credentials and the
+// auth session live) to a fresh temp dir, isolating the test from any real
+// credentials on the machine running it.
+func withTempReliantHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+}
+
+// TestRegisterDaemonNonInteractiveNeverOpensBrowser is the reproduction for
+// the daemon side of the prod bug: with no auth session on disk and
+// nonInteractive=true, registerDaemon must return
+// auth.ErrNonInteractiveLoginRequired instead of falling into auth.Login's
+// interactive flow, which would open a browser and start a local HTTP server.
+func TestRegisterDaemonNonInteractiveNeverOpensBrowser(t *testing.T) {
+	withTempReliantHome(t)
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(os.Stderr)
+	conn := &connection{ServerURL: "https://staging.reliantapi.com"}
+
+	err := registerDaemon(context.Background(), cmd, conn, true)
+	if err == nil {
+		t.Fatal("registerDaemon(nonInteractive=true) returned nil error, want ErrNonInteractiveLoginRequired wrapped")
+	}
+	if !errors.Is(err, auth.ErrNonInteractiveLoginRequired) {
+		t.Fatalf("registerDaemon(nonInteractive=true) error = %v, want it to wrap ErrNonInteractiveLoginRequired", err)
+	}
+}
+
+// TestResolveOrAwaitCredentials_IdlesAndPicksUpCredentials exercises the crux
+// of the daemon-side fix: with no credentials on disk and nonInteractive=true,
+// resolveOrAwaitCredentials must NOT return an error or exit — it must publish
+// daemonstate.StreamAwaitingCredentials and then keep polling disk until a
+// credential appears (simulating Electron's pre-mint path writing
+// ~/.reliant/daemon.json), at which point it returns that credential.
+func TestResolveOrAwaitCredentials_IdlesAndPicksUpCredentials(t *testing.T) {
+	withTempReliantHome(t)
+	t.Setenv("RELIANT_AUTH_URL", "") // ensure ReadAccessTokenFromAuthFile sees no session
+
+	oldInterval := daemonCredentialPollInterval
+	daemonCredentialPollInterval = 20 * time.Millisecond
+	t.Cleanup(func() { daemonCredentialPollInterval = oldInterval })
+
+	dataDir := t.TempDir()
+	cmd := &cobra.Command{}
+	cmd.SetOut(os.Stderr)
+	const serverURL = "https://staging.reliantapi.com"
+	conn := &connection{ServerURL: serverURL}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resultCh := make(chan struct {
+		creds *auth.DaemonCredentials
+		err   error
+	}, 1)
+	go func() {
+		creds, err := resolveOrAwaitCredentials(ctx, cmd, conn, dataDir, true)
+		resultCh <- struct {
+			creds *auth.DaemonCredentials
+			err   error
+		}{creds, err}
+	}()
+
+	// Give the goroutine a moment to reach the idle loop and publish state.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		state, err := daemonstate.Read(dataDir)
+		if err == nil && state.Stream == daemonstate.StreamAwaitingCredentials {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("daemon never published StreamAwaitingCredentials in %s (last state=%+v err=%v)", dataDir, state, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Now simulate Electron's pre-mint path: write a usable daemon credential
+	// for this origin.
+	seeded := &auth.DaemonCredentials{
+		PAT:       "rlnt_pat_electron-preminted",
+		ServerURL: serverURL,
+	}
+	if err := auth.WriteDaemonCredentials(seeded); err != nil {
+		t.Fatalf("seeding daemon credentials: %v", err)
+	}
+
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			t.Fatalf("resolveOrAwaitCredentials returned error: %v", result.err)
+		}
+		if result.creds == nil || result.creds.PAT != seeded.PAT {
+			t.Fatalf("resolveOrAwaitCredentials returned %+v, want PAT %q", result.creds, seeded.PAT)
+		}
+	case <-ctx.Done():
+		t.Fatal("resolveOrAwaitCredentials did not pick up the seeded credential before the test deadline")
+	}
+}
+
+// TestWaitForCredentialsNonInteractive_RespectsCancellation ensures the idle
+// loop actually returns (rather than blocking forever) when ctx is cancelled
+// — the daemon must stay responsive to SIGINT/SIGTERM while idling.
+func TestWaitForCredentialsNonInteractive_RespectsCancellation(t *testing.T) {
+	withTempReliantHome(t)
+
+	oldInterval := daemonCredentialPollInterval
+	daemonCredentialPollInterval = 20 * time.Millisecond
+	t.Cleanup(func() { daemonCredentialPollInterval = oldInterval })
+
+	dataDir := t.TempDir()
+	cmd := &cobra.Command{}
+	cmd.SetOut(os.Stderr)
+	conn := &connection{ServerURL: "https://staging.reliantapi.com"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := waitForCredentialsNonInteractive(ctx, cmd, conn, dataDir)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("waitForCredentialsNonInteractive returned %v, want context.Canceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("waitForCredentialsNonInteractive did not return after ctx cancellation")
+	}
+
+	if p := filepath.Join(dataDir, daemonstate.FileName); true {
+		state, err := daemonstate.Read(dataDir)
+		if err != nil {
+			t.Fatalf("reading daemon state at %s: %v", p, err)
+		}
+		if state.Stream != daemonstate.StreamAwaitingCredentials {
+			t.Fatalf("daemon state stream = %q, want %q", state.Stream, daemonstate.StreamAwaitingCredentials)
+		}
+	}
+}

--- a/cmd/reliant/commands/open.go
+++ b/cmd/reliant/commands/open.go
@@ -87,7 +87,7 @@ This is the "reliant ." command.`,
 
 			if !noDaemon {
 				// Ensure we have a PAT for daemon auth (reuse existing or create new)
-				creds, credErr := ensureDaemonCredentials(ctx, cmd, target)
+				creds, credErr := ensureDaemonCredentials(ctx, cmd, target, false)
 				if credErr != nil {
 					return fmt.Errorf("daemon credential setup failed: %w", credErr)
 				}

--- a/cmd/reliant/commands/root.go
+++ b/cmd/reliant/commands/root.go
@@ -74,3 +74,17 @@ func envOrDefaultInt(key string, defaultVal int) int {
 	}
 	return defaultVal
 }
+
+// envOrDefaultBool returns the environment variable parsed as a bool, or the
+// default. Used as a flag's default value so an explicit CLI flag still wins
+// over the env var — cobra only applies the default when the flag is not
+// passed on the command line, so the precedence is: explicit flag > env var >
+// this default.
+func envOrDefaultBool(key string, defaultVal bool) bool {
+	if v := os.Getenv(key); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			return b
+		}
+	}
+	return defaultVal
+}

--- a/electron/package.json
+++ b/electron/package.json
@@ -19,7 +19,7 @@
     "build:backend": "cd .. && go build -buildvcs=false -o dist/reliant.tmp ./cmd/reliant/ && mv dist/reliant.tmp dist/reliant",
     "dev:vite": "npm --prefix ../web run dev",
     "dev:electron": "node scripts/wait-and-start.js",
-    "test": "node --test test/backend-auth.test.js test/daemon-creds.test.js test/backend-manager-readiness.test.js test/backend-manager-orphan-cleanup.test.js test/menu-accelerators.test.js test/navigation-policy.test.js test/child-signals.test.js test/app-protocol.test.js test/renderer-health.test.js test/diagnostics.test.js",
+    "test": "node --test test/backend-auth.test.js test/daemon-creds.test.js test/backend-manager-readiness.test.js test/backend-manager-awaiting-credentials.test.js test/backend-manager-orphan-cleanup.test.js test/menu-accelerators.test.js test/navigation-policy.test.js test/child-signals.test.js test/app-protocol.test.js test/renderer-health.test.js test/diagnostics.test.js",
     "build:web": "cd ../web && npm run build:alpha",
     "build:web:alpha": "cd ../web && npm run build:alpha",
     "build": "npm run build:web && ../scripts/build-electron.sh mac && electron-builder",

--- a/electron/src/backend-manager.js
+++ b/electron/src/backend-manager.js
@@ -5,6 +5,11 @@ const { app } = require('electron');
 const log = require('./logger');
 const dotenv = require('dotenv');
 const daemonCreds = require('./daemon-creds');
+const {
+  DAEMON_NON_INTERACTIVE_FLAG,
+  DAEMON_STATE_STREAM_FIELD,
+  DAEMON_STREAM_AWAITING_CREDENTIALS,
+} = require('./daemon-contract');
 
 // Default API URL — NEUTRAL (localhost) for the OSS build.
 //
@@ -158,6 +163,14 @@ class BackendManager {
    */
   buildDaemonArgs() {
     const args = ['daemon', 'start'];
+
+    // Electron owns the whole sign-in flow (login page, ensureDaemonCreds
+    // pre-mint, restart-on-sign-in). The daemon's own interactive
+    // registration — opening a localhost browser tab — is broken under
+    // headless Electron (no TTY) and must never run; this flag tells it to
+    // idle and publish stream: "awaiting_credentials" instead. See
+    // daemon-contract.js.
+    args.push(DAEMON_NON_INTERACTIVE_FLAG);
 
     // Pass hosted API URL
     args.push('--server', this.apiUrl);
@@ -805,6 +818,26 @@ class BackendManager {
     }
   }
 
+  /**
+   * Wait for the daemon to become ready. Resolves `true` once the gateway
+   * stream is connected. Resolves `false` (does NOT reject) as soon as the
+   * daemon reports it is idling under --non-interactive with no
+   * credentials (isAwaitingCredentials()) — that is the expected steady
+   * state until the user signs in, not a failure, and the Go daemon sits in
+   * it indefinitely rather than exiting. Rejecting on a timeout here would
+   * misclassify "waiting for sign-in" as "crashed": every caller of this
+   * method either shows an error dialog or (in the child-process exit
+   * handler's case) feeds handleCrash's 5-attempt restart loop, respawning
+   * — and, pre-fix, browser-tab-opening — every attempt. Resolving `false`
+   * promptly instead lets callers hand the port to the renderer (which
+   * already shows the login page independent of daemon readiness) and stay
+   * quiet, with no dialog and no restart loop, until sign-in triggers
+   * restartBackendForAuthPrincipalChange.
+   *
+   * A genuine startup failure (never wrote a record, disconnected, wrong
+   * pid — anything NOT "awaiting credentials") still rejects on timeout,
+   * preserving the existing crash-detection contract callers rely on.
+   */
   async waitForReady(timeout = null) {
     const actualTimeout = timeout || this.startupTimeout;
 
@@ -812,14 +845,6 @@ class BackendManager {
       const startTime = Date.now();
 
       const checkReady = async () => {
-        // Check if we've exceeded timeout
-        if (Date.now() - startTime > actualTimeout) {
-          reject(new Error(
-            `Daemon failed to become ready within ${actualTimeout}ms — ${this.describeDaemonState()}`
-          ));
-          return;
-        }
-
         // The daemon doesn't expose a local HTTP health endpoint; readiness is
         // read out of the runtime record it publishes. See checkHealth().
         try {
@@ -831,6 +856,23 @@ class BackendManager {
           }
         } catch (error) {
           // Daemon not ready yet, continue polling
+        }
+
+        // Waiting for the user to sign in is not a timeout condition —
+        // settle immediately rather than either rejecting or blocking the
+        // caller for the full startup timeout.
+        if (this.isAwaitingCredentials()) {
+          log.info('[BackendManager] Daemon awaiting credentials — not ready, but not a crash');
+          resolve(false);
+          return;
+        }
+
+        // Check if we've exceeded timeout
+        if (Date.now() - startTime > actualTimeout) {
+          reject(new Error(
+            `Daemon failed to become ready within ${actualTimeout}ms — ${this.describeDaemonState()}`
+          ));
+          return;
         }
 
         // Schedule next check - poll faster for quicker startup
@@ -888,6 +930,32 @@ class BackendManager {
           : state.stream === 'connected'
       );
     });
+  }
+
+  /**
+   * Is the running daemon idling under --non-interactive with no
+   * credentials, per its own runtime record?
+   *
+   * This is the distinction the whole "make Electron patient" fix hinges
+   * on: a daemon in this state is NOT crashed and NOT stuck — it is doing
+   * exactly what --non-interactive tells it to do, and will sit here
+   * indefinitely until Electron mints a PAT and respawns it after sign-in.
+   * Callers (waitForReady, the whenReady startup path, handleCrash) must
+   * treat it as distinct from every other non-ready state, which is exactly
+   * "still starting up" or "actually broken".
+   *
+   * Reads the record fresh (like checkHealth) rather than reusing
+   * lastDaemonState, since callers poll this independently of checkHealth.
+   */
+  isAwaitingCredentials() {
+    if (!this.process || this.process.killed) {
+      return false;
+    }
+    const state = this.readDaemonState();
+    if (!state || state.pid !== this.process.pid) {
+      return false;
+    }
+    return state[DAEMON_STATE_STREAM_FIELD] === DAEMON_STREAM_AWAITING_CREDENTIALS;
   }
 
   /**
@@ -1179,10 +1247,19 @@ class BackendManager {
         }
       });
 
-      // Wait for daemon to be ready
+      // Wait for daemon to be ready. Resolves `false` (does not throw) when
+      // the daemon is legitimately idling under --non-interactive with no
+      // credentials — the process is alive and spawned successfully, it is
+      // just not yet able to serve tool calls. isRunning tracks "the daemon
+      // process exists and did not crash"; isReady()/checkHealth() is the
+      // separate, correct place to ask "can it serve a tool call right now".
       const readyStart = Date.now();
-      await this.waitForReady();
-      log.info(`[BackendManager] ✓ Daemon ready in ${Date.now() - readyStart}ms`);
+      const ready = await this.waitForReady();
+      if (ready) {
+        log.info(`[BackendManager] ✓ Daemon ready in ${Date.now() - readyStart}ms`);
+      } else {
+        log.info(`[BackendManager] Daemon spawned but awaiting credentials (not yet ready) after ${Date.now() - readyStart}ms`);
+      }
 
       this.isRunning = true;
 

--- a/electron/src/daemon-contract.js
+++ b/electron/src/daemon-contract.js
@@ -1,0 +1,46 @@
+/**
+ * Contract between Electron and the Go daemon for the "wait for sign-in,
+ * don't open a browser" startup path.
+ *
+ * CONFIRMED against the Go source (not a placeholder):
+ *   - CLI flag:     cmd/reliant/commands/daemon.go:741
+ *   - Stream value: internal/toolexec/daemonstate/state.go:58
+ *
+ * With --non-interactive, a daemon that has no credentials for its --server
+ * origin does NOT exit and does NOT open a browser — it idles as a
+ * long-lived process, publishing stream: "awaiting_credentials" in
+ * daemon-state.json, and re-checks for credentials appearing on disk. It
+ * only proceeds once Electron mints a PAT (ensureDaemonCreds) and respawns
+ * it (restartBackendForAuthPrincipalChange in main.js, triggered by
+ * sign-in). Real crashes are unaffected — a daemon that dies still exits
+ * and still drives the existing handleCrash restart-loop path.
+ */
+
+// CLI flag Electron passes at every daemon spawn (buildDaemonArgs). Always
+// on: Electron drives auth itself (ensureDaemonCreds pre-mint, then the
+// sign-in-triggered respawn), so the daemon's own interactive flow — which
+// opens a localhost browser tab and is broken under headless Electron (no
+// TTY) — must never run.
+const DAEMON_NON_INTERACTIVE_FLAG = '--non-interactive';
+
+// Env-var fallback for the same flag (RELIANT_DAEMON_NON_INTERACTIVE, not
+// RELIANT_NON_INTERACTIVE). Electron always passes the CLI flag directly, so
+// this constant exists only for anything that spawns the daemon by env
+// instead of argv.
+const DAEMON_NON_INTERACTIVE_ENV_VAR = 'RELIANT_DAEMON_NON_INTERACTIVE';
+
+// daemon-state.json's `stream` field name (see internal/toolexec/daemonstate
+// State.Stream / json tag "stream").
+const DAEMON_STATE_STREAM_FIELD = 'stream';
+
+// The Stream value published while the daemon has no credentials for its
+// --server origin and is idling under --non-interactive rather than
+// attempting interactive registration.
+const DAEMON_STREAM_AWAITING_CREDENTIALS = 'awaiting_credentials';
+
+module.exports = {
+  DAEMON_NON_INTERACTIVE_FLAG,
+  DAEMON_NON_INTERACTIVE_ENV_VAR,
+  DAEMON_STATE_STREAM_FIELD,
+  DAEMON_STREAM_AWAITING_CREDENTIALS,
+};

--- a/electron/src/main.js
+++ b/electron/src/main.js
@@ -1310,9 +1310,15 @@ async function createWindow(options = {}) {
     } else if (!isReady) {
       log.info("Backend not ready yet, waiting...");
       try {
-        await backendManager.waitForReady();
+        // waitForReady() resolves `false` (does not throw) when the daemon
+        // is idling under --non-interactive awaiting sign-in — that is not
+        // an error, so the catch below is reserved for a genuine failure.
+        const becameReady = await backendManager.waitForReady();
         const finalPort = backendManager.getPort();
-        log.info("Backend now ready, sending port to frontend:", finalPort);
+        log.info(
+          becameReady ? "Backend now ready, sending port to frontend:" : "Backend still awaiting credentials, sending port anyway:",
+          finalPort
+        );
         mainWindow.webContents.send("backend-port", finalPort);
       } catch (error) {
         log.error("Backend failed to become ready:", error);
@@ -1659,11 +1665,13 @@ ipcMain.handle("get-backend-port", async () => {
   if (port && !isReady) {
     log.info("[IPC] Backend has port but not ready, waiting...");
     try {
-      // Optionally, you could use a shorter timeout for reloads if needed
-      await backendManager.waitForReady();
+      // waitForReady() resolves `false` (does not throw) when the daemon is
+      // idling under --non-interactive awaiting sign-in — expected, not an
+      // error. The catch below only fires for a genuine startup failure.
+      const becameReady = await backendManager.waitForReady();
       const finalPort = backendManager.getPort();
       log.info(
-        "[IPC] Backend now ready, returning port:",
+        becameReady ? "[IPC] Backend now ready, returning port:" : "[IPC] Backend still awaiting credentials, returning port anyway:",
         finalPort,
         "type:",
         typeof finalPort
@@ -3989,13 +3997,24 @@ app.whenReady().then(async () => {
   log.info(`[Backend] ✓ BackendManager created in ${Date.now() - backendCreateStart}ms`);
 
   // Start backend in background (don't await yet)
+  //
+  // backendManager.start() resolves with the daemon's port once the process
+  // is spawned successfully — including the "spawned, but idling under
+  // --non-interactive with no credentials yet" case (BackendManager.
+  // waitForReady() resolves `false` rather than throwing for that state; see
+  // its doc comment). Only a genuine startup failure — bad binary, spawn
+  // error, a real timeout that is NOT "awaiting credentials" — rejects here.
+  // So this .catch is reserved for real failures: never signing in is not
+  // one, and must not show "Backend Error".
   const backendStartTime = Date.now();
   log.info("[Backend] Starting backend service in background...");
   const backendStartPromise = backendManager.start().then((port) => {
     log.info(`[Backend] ✓ Backend service started in ${Date.now() - backendStartTime}ms`);
-    log.debug(`[Backend] Backend running and ready on port ${port}`);
+    log.debug(`[Backend] Backend process running on port ${port} (may still be awaiting sign-in)`);
 
-    // Send port to all windows
+    // Send port to all windows regardless of daemon readiness — the
+    // renderer's login page does not depend on the daemon being ready, and
+    // the config-ready handshake only needs a port number to unblock.
     BrowserWindow.getAllWindows().forEach((window) => {
       log.debug("Sending backend port to window:", port);
       window.webContents.send("backend-port", port);

--- a/electron/test/backend-manager-awaiting-credentials.test.js
+++ b/electron/test/backend-manager-awaiting-credentials.test.js
@@ -1,0 +1,118 @@
+// A daemon spawned under --non-interactive with no credentials on disk does
+// NOT open a browser and does NOT exit — it idles, publishing
+// stream: "awaiting_credentials" in daemon-state.json, until Electron mints
+// a PAT and respawns it after sign-in (see daemon-contract.js).
+//
+// Before this fix, BackendManager had no notion of that state: waitForReady()
+// only knew "connected" (ready) or "not connected yet" (keep polling until
+// startupTimeout, then reject). A credential-less daemon idling in
+// "awaiting_credentials" looked identical to one stuck mid-crash, so it got
+// the full 30s timeout, a rejected promise, an app.whenReady "Backend Error"
+// dialog / IPC "Backend Connection Error" dialog, and — for the
+// process-exit-driven path — handleCrash's 5-attempt browser-tab-opening
+// restart loop. These tests fail on that pre-fix behavior and pass after it.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const BackendManager = require('../src/backend-manager');
+const {
+  DAEMON_NON_INTERACTIVE_FLAG,
+  DAEMON_STREAM_AWAITING_CREDENTIALS,
+} = require('../src/daemon-contract');
+
+const DAEMON_PID = 4242;
+
+function harness() {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'daemon-state-'));
+  const manager = new BackendManager();
+
+  manager.daemonDataDir = () => dataDir;
+  manager.process = { pid: DAEMON_PID, killed: false };
+  // Keep these tests fast — the timeout path is exercised explicitly below
+  // with its own short value, not the production 30s default.
+  manager.startupTimeout = 300;
+
+  return {
+    manager,
+    writeState: (state) =>
+      fs.writeFileSync(path.join(dataDir, 'daemon-state.json'), JSON.stringify(state)),
+  };
+}
+
+test('every daemon spawn passes the non-interactive flag', () => {
+  const manager = new BackendManager();
+  const args = manager.buildDaemonArgs();
+  assert.ok(
+    args.includes(DAEMON_NON_INTERACTIVE_FLAG),
+    `expected ${DAEMON_NON_INTERACTIVE_FLAG} in daemon args, got: ${args.join(' ')}`
+  );
+});
+
+test('isAwaitingCredentials is true only for our own pid publishing the awaiting-credentials stream', async () => {
+  const { manager, writeState } = harness();
+
+  writeState({ pid: DAEMON_PID, stream: DAEMON_STREAM_AWAITING_CREDENTIALS });
+  assert.equal(manager.isAwaitingCredentials(), true);
+
+  // A record from a different (earlier) daemon must not count.
+  writeState({ pid: DAEMON_PID + 1, stream: DAEMON_STREAM_AWAITING_CREDENTIALS });
+  assert.equal(manager.isAwaitingCredentials(), false);
+
+  // Any other stream value is not "awaiting credentials".
+  writeState({ pid: DAEMON_PID, stream: 'connecting' });
+  assert.equal(manager.isAwaitingCredentials(), false);
+
+  writeState({ pid: DAEMON_PID, stream: 'connected' });
+  assert.equal(manager.isAwaitingCredentials(), false);
+
+  // No live process — never awaiting credentials, whatever the file says.
+  writeState({ pid: DAEMON_PID, stream: DAEMON_STREAM_AWAITING_CREDENTIALS });
+  manager.process = null;
+  assert.equal(manager.isAwaitingCredentials(), false);
+});
+
+test('waitForReady resolves false promptly when awaiting credentials — it does not reject or hang for the full startup timeout', async () => {
+  const { manager, writeState } = harness();
+  writeState({ pid: DAEMON_PID, stream: DAEMON_STREAM_AWAITING_CREDENTIALS });
+
+  const start = Date.now();
+  const ready = await manager.waitForReady();
+  const elapsed = Date.now() - start;
+
+  assert.equal(ready, false, 'awaiting-credentials must resolve false, not throw');
+  assert.ok(
+    elapsed < manager.startupTimeout,
+    `expected an early settle well under the ${manager.startupTimeout}ms startup timeout, took ${elapsed}ms`
+  );
+});
+
+test('waitForReady still rejects on timeout for a daemon that is NOT awaiting credentials (real crash/stall path preserved)', async () => {
+  const { manager, writeState } = harness();
+  // Stuck "connecting" forever is the genuine stall/crash case this promise
+  // must still catch — distinct from "awaiting_credentials".
+  writeState({ pid: DAEMON_PID, stream: 'connecting' });
+
+  await assert.rejects(() => manager.waitForReady(), /failed to become ready/);
+});
+
+test('waitForReady resolves true once the daemon moves from awaiting_credentials to connected', async () => {
+  const { manager, writeState } = harness();
+  writeState({ pid: DAEMON_PID, stream: DAEMON_STREAM_AWAITING_CREDENTIALS });
+
+  // Flip to connected shortly after the wait starts (simulating the
+  // post-sign-in respawn reaching the gateway).
+  setTimeout(() => writeState({ pid: DAEMON_PID, stream: 'connected' }), 20);
+
+  // Poll manually since resolving false is instantaneous in the harness above;
+  // here we want the *eventual* ready path, so call again after the flip.
+  const firstPass = await manager.waitForReady();
+  assert.equal(firstPass, false);
+
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  const secondPass = await manager.waitForReady();
+  assert.equal(secondPass, true);
+});

--- a/go.sum
+++ b/go.sum
@@ -533,12 +533,8 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.1.0 h1:137FnGdk+EQdCbye1FW+qOEcY5S+SpY9T0NiuqvtfMY=
 github.com/redis/go-redis/v9 v9.1.0/go.mod h1:urWj3He21Dj5k4TK1y59xH8Uj6ATueP8AH1cY3lZl4c=
-github.com/reliant-labs/forge v0.1.0 h1:sW+jWbHAtGiyE4OGXcylLNi3O/pI6ytMpwdw/AO7czU=
-github.com/reliant-labs/forge v0.1.0/go.mod h1:ObCxWQjRccCJaRSDhyZhRT4J1YNOM8RCzIYjxg2L+aw=
 github.com/reliant-labs/forge v0.1.1 h1:rDyNKpSaipiUI/69YtheKlxt+GcCYD1oHblS1cAnYY8=
 github.com/reliant-labs/forge v0.1.1/go.mod h1:HP6Ih0OpUgKFIN4PV6EHmldG+Ef49oRLJNgMjbyZHDQ=
-github.com/reliant-labs/forge/pkg v0.1.0 h1:07GKMAixDSrN4vtQJ8pze1mP/hR1G8xSxrRV0n909Ow=
-github.com/reliant-labs/forge/pkg v0.1.0/go.mod h1:yVuNEMU2atdN1obN85YE/Qgv9lBY4m4l8JiCwtNxCRM=
 github.com/reliant-labs/forge/pkg v0.1.1 h1:RkGZKBdplhGfqvFhmVzexUP+ZnEboepoZTyRAk3Ojs0=
 github.com/reliant-labs/forge/pkg v0.1.1/go.mod h1:yVuNEMU2atdN1obN85YE/Qgv9lBY4m4l8JiCwtNxCRM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -23,6 +23,13 @@ import (
 // ErrAuthNotConfigured is returned when OAuth is attempted without required env vars.
 var ErrAuthNotConfigured = fmt.Errorf("auth provider not configured")
 
+// ErrNonInteractiveLoginRequired is returned by Login when LoginOptions.NonInteractive
+// is set and no session is already available. The PKCE flow this function runs
+// has no non-interactive form — it always needs a browser and a human — so a
+// caller that must never pop a browser (the tools daemon) gets this error
+// instead of one.
+var ErrNonInteractiveLoginRequired = fmt.Errorf("interactive login required but running non-interactively")
+
 func getAuthURL() string {
 	return builddefaults.Value("RELIANT_AUTH_URL", builddefaults.AuthURL, "")
 }
@@ -45,7 +52,14 @@ func requireAuthConfig() (serverURL string, anonKey string, err error) {
 }
 
 // LoginOptions configures the OAuth PKCE login flow.
-type LoginOptions struct{}
+type LoginOptions struct {
+	// NonInteractive, when true, makes Login refuse to open a browser or
+	// start the local login-page HTTP server, returning
+	// ErrNonInteractiveLoginRequired immediately instead. Set this for any
+	// caller that must never surface interactive login UX itself — the tools
+	// daemon in particular, which Electron drives through its own login page.
+	NonInteractive bool
+}
 
 // LoginResult holds the tokens and user info returned after a successful login.
 type LoginResult struct {
@@ -146,6 +160,10 @@ func LoginWithOAuthProvider(ctx context.Context, provider string, opts LoginOpti
 
 // Login performs login via a local web page that supports email/password and OAuth providers.
 func Login(ctx context.Context, opts LoginOptions) (*LoginResult, error) {
+	if opts.NonInteractive {
+		return nil, ErrNonInteractiveLoginRequired
+	}
+
 	serverURL, anonKey, err := requireAuthConfig()
 	if err != nil {
 		return nil, err
@@ -326,7 +344,12 @@ func buildAuthURL(serverURL, redirectURI, challenge, provider string) (string, e
 
 // --- Browser opener ---
 
-func openBrowser(url string) error {
+// openBrowser is a var, not a plain func, so tests can substitute a fake and
+// assert it is never called — the same seam internal/auth/oauthcallback uses
+// for the same reason (see its openBrowser var).
+var openBrowser = defaultOpenBrowser
+
+func defaultOpenBrowser(url string) error {
 	switch runtime.GOOS {
 	case "darwin":
 		return exec.Command("open", url).Start()

--- a/internal/auth/oauth_nonint_test.go
+++ b/internal/auth/oauth_nonint_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2025 Reliant Labs
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestLoginNonInteractiveNeverOpensBrowser is the reproduction for the prod
+// bug: the daemon must never open a browser or start the local login-page
+// HTTP server when it has no credentials and cannot run an interactive login.
+// Before the fix, Login had no way to refuse the interactive flow at all —
+// this test fails against that code (it opens a browser and hangs waiting for
+// a callback that never comes) and passes once LoginOptions.NonInteractive
+// short-circuits before any of that setup runs.
+func TestLoginNonInteractiveNeverOpensBrowser(t *testing.T) {
+	withCompiledAuthDefaults(t, "http://auth.localhost", "test-key")
+
+	browserOpened := false
+	original := openBrowser
+	openBrowser = func(string) error {
+		browserOpened = true
+		return nil
+	}
+	defer func() { openBrowser = original }()
+
+	_, err := Login(context.Background(), LoginOptions{NonInteractive: true})
+	if err == nil {
+		t.Fatal("Login(NonInteractive) returned nil error, want ErrNonInteractiveLoginRequired")
+	}
+	if !errors.Is(err, ErrNonInteractiveLoginRequired) {
+		t.Fatalf("Login(NonInteractive) error = %v, want ErrNonInteractiveLoginRequired", err)
+	}
+	if browserOpened {
+		t.Fatal("Login(NonInteractive) opened a browser — it must never do so")
+	}
+}
+
+// TestLoginInteractiveStillOpensBrowser guards the other direction: the
+// existing interactive behavior (used by `reliant daemon register` and `auth
+// login`) must be unchanged by the new option defaulting to false.
+func TestLoginInteractiveStillOpensBrowser(t *testing.T) {
+	withCompiledAuthDefaults(t, "http://auth.localhost", "test-key")
+
+	browserOpened := make(chan string, 1)
+	original := openBrowser
+	openBrowser = func(url string) error {
+		browserOpened <- url
+		return nil
+	}
+	defer func() { openBrowser = original }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = Login(ctx, LoginOptions{})
+	}()
+
+	select {
+	case <-browserOpened:
+		// Expected: Login opened the browser. Cancel to unblock the
+		// goroutine waiting on the callback that will never arrive in a test.
+		cancel()
+	case <-done:
+		t.Fatal("Login returned before opening the browser")
+	}
+	<-done
+}

--- a/internal/daemonevents/publisher.go
+++ b/internal/daemonevents/publisher.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -66,11 +67,25 @@ const (
 // Event is the wire format for a daemon lifecycle event.
 //
 // Versioned so consumers can detect and reject unsupported newer payloads
-// without crashing.
+// without crashing. Schema must match the consumer's DaemonEvent struct in
+// `control-plane/internal/natsio/messages.go`.
 //
 // Reason is set on disconnected / connect_failed events and surfaced to the
 // frontend on the daemon record so users see e.g. "Couldn't connect — dial
 // tcp: i/o timeout" instead of a generic "Disconnected" badge.
+//
+// Name/Hostname/Platform are set on connected events only, carrying the
+// identity the daemon asserted at registration (see
+// ToolsDaemonService.notifyConnected) so a control-plane consumer upserting
+// an external daemon has something better than the daemon id to show as its
+// name. All three are additive optional fields (added without bumping
+// Version): an older consumer's encoding/json.Unmarshal silently drops
+// unknown fields, so it keeps working unchanged, and a consumer built
+// against this version treats missing fields as "" — the same as an old
+// publisher — so the two schemas can evolve independently as long as new
+// fields stay optional. A bump would only be warranted for a change a
+// pre-upgrade consumer could misinterpret (e.g. a field whose meaning
+// changes, or a field going from optional to load-bearing).
 type Event struct {
 	Version   int       `json:"version"`
 	Type      EventType `json:"type"`
@@ -78,6 +93,9 @@ type Event struct {
 	DaemonID  string    `json:"daemonId"`
 	Timestamp time.Time `json:"timestamp"`
 	Reason    string    `json:"reason,omitempty"`
+	Name      string    `json:"name,omitempty"`
+	Hostname  string    `json:"hostname,omitempty"`
+	Platform  string    `json:"platform,omitempty"`
 }
 
 // Publisher implements toolexec.DaemonConnectionListener and writes events
@@ -115,30 +133,61 @@ func NewPublisher(nc *nats.Conn) (*Publisher, error) {
 	return &Publisher{js: js}, nil
 }
 
-// OnDaemonConnected satisfies toolexec.DaemonConnectionListener.
+// OnDaemonConnected satisfies toolexec.DaemonConnectionListener. Callers that
+// have the daemon's registered identity available should call
+// OnDaemonConnectedWithInfo instead so the control plane gets a usable name.
 func (p *Publisher) OnDaemonConnected(userID, daemonID string) {
-	p.publish(EventTypeConnected, SubjectConnected, userID, daemonID, "")
+	p.publishConnected(userID, daemonID, "", "", "")
+}
+
+// OnDaemonConnectedWithInfo satisfies toolexec.DaemonConnectionInfoListener.
+// name/hostname/platform are whatever the daemon asserted in its
+// DaemonRegister message (internal/grpc/services/tools_daemon.go); any of
+// them may be empty. ToolsDaemonService.notifyConnected calls this instead
+// of OnDaemonConnected when the listener implements the interface, so this
+// is the path actually used in production; OnDaemonConnected above only
+// exists to satisfy the base interface and covers callers/tests with no
+// identity to give.
+func (p *Publisher) OnDaemonConnectedWithInfo(userID, daemonID, name, hostname, platform string) {
+	p.publishConnected(userID, daemonID, name, hostname, platform)
 }
 
 // OnDaemonDisconnected satisfies toolexec.DaemonConnectionListener.
 func (p *Publisher) OnDaemonDisconnected(userID, daemonID string) {
-	p.publish(EventTypeDisconnected, SubjectDisconnected, userID, daemonID, "")
+	p.publish(EventTypeDisconnected, SubjectDisconnected, userID, daemonID, "", "", "", "")
 }
 
 // OnDaemonDisconnectedWithReason is like OnDaemonDisconnected but carries a
 // human-readable reason that the control plane persists on the daemon row.
 func (p *Publisher) OnDaemonDisconnectedWithReason(userID, daemonID, reason string) {
-	p.publish(EventTypeDisconnected, SubjectDisconnected, userID, daemonID, reason)
+	p.publish(EventTypeDisconnected, SubjectDisconnected, userID, daemonID, reason, "", "", "")
 }
 
 // OnDaemonConnectFailed is called by the connector loop whenever an outbound
 // dial / registration attempt fails. The reason is the wrapped error returned
 // by connectOnce.
 func (p *Publisher) OnDaemonConnectFailed(userID, daemonID, reason string) {
-	p.publish(EventTypeConnectFailed, SubjectConnectFailed, userID, daemonID, reason)
+	p.publish(EventTypeConnectFailed, SubjectConnectFailed, userID, daemonID, reason, "", "", "")
 }
 
-func (p *Publisher) publish(t EventType, subject, userID, daemonID, reason string) {
+// publishConnected resolves the display name and publishes a connected
+// event. This is the ONE place that decides name precedence — name, then
+// hostname, then the daemon id itself — so Event.Name is never empty on the
+// wire and every consumer, present or future, can use it as-is without
+// re-deriving the rule. Hostname/Platform still travel unresolved alongside
+// it for consumers (like the control plane) that want the raw value too.
+func (p *Publisher) publishConnected(userID, daemonID, name, hostname, platform string) {
+	resolvedName := strings.TrimSpace(name)
+	if resolvedName == "" {
+		resolvedName = strings.TrimSpace(hostname)
+	}
+	if resolvedName == "" {
+		resolvedName = daemonID
+	}
+	p.publish(EventTypeConnected, SubjectConnected, userID, daemonID, "", resolvedName, hostname, platform)
+}
+
+func (p *Publisher) publish(t EventType, subject, userID, daemonID, reason, name, hostname, platform string) {
 	if p == nil || p.js == nil {
 		return
 	}
@@ -149,6 +198,9 @@ func (p *Publisher) publish(t EventType, subject, userID, daemonID, reason strin
 		DaemonID:  daemonID,
 		Timestamp: time.Now().UTC(),
 		Reason:    reason,
+		Name:      name,
+		Hostname:  hostname,
+		Platform:  platform,
 	}
 	data, err := json.Marshal(evt)
 	if err != nil {

--- a/internal/daemonevents/publisher_test.go
+++ b/internal/daemonevents/publisher_test.go
@@ -1,0 +1,143 @@
+package daemonevents
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeJetStream implements jetstream.JetStream by embedding the interface
+// (nil) and overriding only Publish, the single method Publisher.publish
+// calls. Any other method would panic on the nil embedded value, which is
+// fine — these tests never exercise them.
+type fakeJetStream struct {
+	jetstream.JetStream
+	published []publishedMsg
+}
+
+type publishedMsg struct {
+	subject string
+	data    []byte
+}
+
+func (f *fakeJetStream) Publish(_ context.Context, subject string, payload []byte, _ ...jetstream.PublishOpt) (*jetstream.PubAck, error) {
+	f.published = append(f.published, publishedMsg{subject: subject, data: payload})
+	return &jetstream.PubAck{}, nil
+}
+
+// control-plane's mirror of Event, hand-copied here so the test can prove
+// the JSON one side emits actually decodes into the shape the other side
+// expects. The two structs are hand-synced across repos with nothing else
+// enforcing that; this is the property that matters.
+type controlPlaneDaemonEvent struct {
+	Version   int       `json:"version"`
+	Type      string    `json:"type"`
+	UserID    string    `json:"userId"`
+	DaemonID  string    `json:"daemonId"`
+	Timestamp time.Time `json:"timestamp"`
+	Reason    string    `json:"reason,omitempty"`
+	Name      string    `json:"name,omitempty"`
+	Hostname  string    `json:"hostname,omitempty"`
+	Platform  string    `json:"platform,omitempty"`
+}
+
+func TestPublisher_OnDaemonConnectedWithInfo_MarshalsNameHostnamePlatform(t *testing.T) {
+	js := &fakeJetStream{}
+	p := &Publisher{js: js}
+
+	p.OnDaemonConnectedWithInfo("user-1", "daemon-1", "my-laptop", "my-laptop.local", "darwin")
+
+	require.Len(t, js.published, 1)
+	require.Equal(t, SubjectConnected, js.published[0].subject)
+
+	var evt Event
+	require.NoError(t, json.Unmarshal(js.published[0].data, &evt))
+	require.Equal(t, CurrentEventVersion, evt.Version)
+	require.Equal(t, EventTypeConnected, evt.Type)
+	require.Equal(t, "user-1", evt.UserID)
+	require.Equal(t, "daemon-1", evt.DaemonID)
+	require.Equal(t, "my-laptop", evt.Name)
+	require.Equal(t, "my-laptop.local", evt.Hostname)
+	require.Equal(t, "darwin", evt.Platform)
+
+	// Round-trip against control-plane's independently-maintained struct:
+	// this is the property that actually matters, since nothing but this
+	// test enforces the two stay in sync.
+	var cpEvt controlPlaneDaemonEvent
+	require.NoError(t, json.Unmarshal(js.published[0].data, &cpEvt))
+	require.Equal(t, evt.Name, cpEvt.Name)
+	require.Equal(t, evt.Hostname, cpEvt.Hostname)
+	require.Equal(t, evt.Platform, cpEvt.Platform)
+}
+
+func TestPublisher_NamePrecedence(t *testing.T) {
+	tests := []struct {
+		name         string
+		daemonName   string
+		hostname     string
+		daemonID     string
+		wantResolved string
+	}{
+		{
+			name:         "name wins when present",
+			daemonName:   "my-laptop",
+			hostname:     "my-laptop.local",
+			daemonID:     "daemon-1",
+			wantResolved: "my-laptop",
+		},
+		{
+			name:         "falls back to hostname when name empty",
+			daemonName:   "",
+			hostname:     "my-laptop.local",
+			daemonID:     "daemon-1",
+			wantResolved: "my-laptop.local",
+		},
+		{
+			name:         "falls back to daemon id when both empty",
+			daemonName:   "",
+			hostname:     "",
+			daemonID:     "daemon-1",
+			wantResolved: "daemon-1",
+		},
+		{
+			name:         "whitespace-only name treated as empty",
+			daemonName:   "   ",
+			hostname:     "my-laptop.local",
+			daemonID:     "daemon-1",
+			wantResolved: "my-laptop.local",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			js := &fakeJetStream{}
+			p := &Publisher{js: js}
+
+			p.OnDaemonConnectedWithInfo("user-1", tt.daemonID, tt.daemonName, tt.hostname, "darwin")
+
+			require.Len(t, js.published, 1)
+			var evt Event
+			require.NoError(t, json.Unmarshal(js.published[0].data, &evt))
+			require.Equal(t, tt.wantResolved, evt.Name)
+		})
+	}
+}
+
+func TestPublisher_OnDaemonConnected_NoInfoStillPublishes(t *testing.T) {
+	js := &fakeJetStream{}
+	p := &Publisher{js: js}
+
+	p.OnDaemonConnected("user-1", "daemon-1")
+
+	require.Len(t, js.published, 1)
+	var evt Event
+	require.NoError(t, json.Unmarshal(js.published[0].data, &evt))
+	// No name/hostname available on this path, so the resolved name falls
+	// all the way back to the daemon id.
+	require.Equal(t, "daemon-1", evt.Name)
+	require.Empty(t, evt.Hostname)
+}

--- a/internal/grpc/services/tools_daemon.go
+++ b/internal/grpc/services/tools_daemon.go
@@ -106,6 +106,8 @@ type daemonConnection struct {
 	userID       string
 	daemonID     string
 	name         string
+	hostname     string
+	platform     string
 	labels       map[string]string
 	daemonType   string // "local" or "cloud"
 	connectedAt  time.Time
@@ -255,12 +257,20 @@ func (s *ToolsDaemonService) AddConnectionListener(l toolexec.DaemonConnectionLi
 	s.listenersMu.Unlock()
 }
 
-// notifyConnected calls OnDaemonConnected on all registered listeners.
+// notifyConnected calls OnDaemonConnectedWithInfo on any listener that
+// implements toolexec.DaemonConnectionInfoListener (currently just
+// daemonevents.Publisher), falling back to plain OnDaemonConnected for
+// listeners that only care about identity (NATSToolBridge,
+// daemonquery.Responder/UserResponder). Each listener gets exactly one call.
 // Must be called OUTSIDE s.mu to avoid deadlocks.
-func (s *ToolsDaemonService) notifyConnected(userID, daemonID string) {
+func (s *ToolsDaemonService) notifyConnected(userID, daemonID, name, hostname, platform string) {
 	s.listenersMu.RLock()
 	defer s.listenersMu.RUnlock()
 	for _, l := range s.listeners {
+		if infoListener, ok := l.(toolexec.DaemonConnectionInfoListener); ok {
+			infoListener.OnDaemonConnectedWithInfo(userID, daemonID, name, hostname, platform)
+			continue
+		}
 		l.OnDaemonConnected(userID, daemonID)
 	}
 }
@@ -637,6 +647,8 @@ func (s *ToolsDaemonService) ConnectDaemon(
 		userID:              userID,
 		daemonID:            daemonID,
 		name:                reg.GetName(),
+		hostname:            reg.GetHostname(),
+		platform:            reg.GetPlatform(),
 		labels:              reg.GetLabels(),
 		daemonType:          reg.GetDaemonType(),
 		connectedAt:         now2,
@@ -664,7 +676,7 @@ func (s *ToolsDaemonService) ConnectDaemon(
 	s.supersedeIncumbent(oldConn)
 
 	// Notify listeners outside the mutex.
-	s.notifyConnected(userID, daemonID)
+	s.notifyConnected(userID, daemonID, conn.name, conn.hostname, conn.platform)
 	s.statePublisher.Connected(daemonID, userID, conn.daemonType)
 
 	// Publish an immediate heartbeat so the frontend knows the daemon is
@@ -775,6 +787,8 @@ func (s *ToolsDaemonService) RegisterOutboundConnection(
 		userID:              userID,
 		daemonID:            daemonID,
 		name:                reg.GetName(),
+		hostname:            reg.GetHostname(),
+		platform:            reg.GetPlatform(),
 		labels:              reg.GetLabels(),
 		daemonType:          reg.GetDaemonType(),
 		connectedAt:         now,
@@ -802,7 +816,7 @@ func (s *ToolsDaemonService) RegisterOutboundConnection(
 		logging.Info(LOG_PREFIX_TOOLS_DAEMON+" Replaced old daemon connection (outbound)", "userID", userID, "daemonID", daemonID)
 	}
 
-	s.notifyConnected(userID, daemonID)
+	s.notifyConnected(userID, daemonID, conn.name, conn.hostname, conn.platform)
 	s.statePublisher.Connected(daemonID, userID, conn.daemonType)
 	s.publishDaemonHeartbeat(context.Background(), userID, daemonID, time.Now().UTC(), nil)
 

--- a/internal/toolexec/daemon_router.go
+++ b/internal/toolexec/daemon_router.go
@@ -182,6 +182,20 @@ type DaemonConnectionListener interface {
 	OnDaemonDisconnected(userID, daemonID string)
 }
 
+// DaemonConnectionInfoListener is an optional extension of
+// DaemonConnectionListener for listeners that need the identity the daemon
+// asserted at registration time (name/hostname/platform), not just the ids.
+// ToolsDaemonService type-asserts each registered listener against this
+// interface and calls it alongside OnDaemonConnected when satisfied, so
+// existing listeners (NATSToolBridge, daemonquery.Responder/UserResponder)
+// that only care about ids need no change. daemonevents.Publisher is the
+// only current implementor — it needs this to carry a usable machine name
+// through to the control plane, which OnDaemonConnected's two bare ids
+// cannot express.
+type DaemonConnectionInfoListener interface {
+	OnDaemonConnectedWithInfo(userID, daemonID, name, hostname, platform string)
+}
+
 // DaemonConnectionManager is the subset of ToolsDaemonService needed by NATSToolBridge.
 // This avoids importing the services package from toolexec.
 //

--- a/internal/toolexec/daemonstate/state.go
+++ b/internal/toolexec/daemonstate/state.go
@@ -48,6 +48,14 @@ const (
 	// StreamListening is the server-mode analogue of connecting: the daemon is
 	// accepting gateway dial-ins but none is attached.
 	StreamListening Stream = "listening"
+	// StreamAwaitingCredentials means the daemon has no usable credentials and
+	// (running non-interactively, e.g. spawned by Electron) is idling rather
+	// than exiting or opening an interactive login flow. It is waiting for a
+	// credential to appear on disk — normally because Electron's own login UI
+	// signed the user in and minted one. Electron reads this exact string from
+	// `stream` in daemon-state.json to distinguish "waiting for sign-in" from
+	// a crash, instead of reporting a timeout after waitForReady's 30s.
+	StreamAwaitingCredentials Stream = "awaiting_credentials"
 )
 
 // Established reports whether the daemon can currently serve tool calls.


### PR DESCRIPTION
Daemon and OAuth paths assumed a terminal to prompt at. In the packaged desktop app there isn't one, so flows needing input stalled instead of failing usefully. The non-interactive paths now have explicit handling and tests.

- `electron/src/daemon-contract.js` — one description of what the main process and the daemon agree on, instead of the shape being implied in several places.
- A readiness path that **waits for credentials** rather than racing them, covered by `backend-manager-awaiting-credentials.test.js`.
- Tighter daemon event publishing and tool-daemon routing so state transitions are not dropped.

## Verification

`go build ./...` clean. Go tests pass for every touched package: `cmd/reliant/commands`, `internal/auth`, `internal/daemonevents`, `internal/toolexec/...` (including `daemonruntime` and `daemonstate`).

Electron suite: **125 pass, 0 fail**. The new test is registered in `electron/package.json`'s test list, so it actually runs in CI rather than sitting there uncollected — worth stating, since an unregistered node test file is silently skipped.

Part of the same effort as #185 (gateway host + release endpoint validation); this is the runtime half, that one is the configuration half.