### PR TITLE
feat(web): billing + environments settings, chat navigation shortcuts

### DIFF
--- a/config/shortcuts.yaml
+++ b/config/shortcuts.yaml
@@ -326,6 +326,19 @@ shortcuts:
     binding: Cmd+K B
     handler: onSwitchWorktree
 
+  # Triage key: with a dozen chats running, the question is never "what is the
+  # next chat" but "which one is waiting on me". Cycles only the chats that are
+  # blocked on the user — awaiting approval, errored, or unread — in the same
+  # order the sidebar shows them, so repeated presses walk the queue and wrap.
+  # Cmd+K D ("do next") rather than a bare chord: it is a deliberate triage
+  # move, and the Cmd+K family is where navigation already lives.
+  - id: nextAttentionChat
+    name: Next Chat Needing Attention
+    description: Jump to the next chat waiting on you (approval, error, or unread)
+    category: Chat Navigation
+    binding: Cmd+K D
+    handler: onNextAttentionChat
+
   # ==================================
   # Project Navigation
   # ==================================
@@ -587,6 +600,26 @@ shortcuts:
     category: Chat Control
     binding: Cmd+/
     handler: onSlashCommands
+
+  # Escape must close the modal that is open, not pause the chat behind it.
+  # Same shape as dismissSlashMenu below: registered in the `modal` context so
+  # it SHADOWS stopStreaming while any modal is up, and disappears the moment
+  # the last one closes.
+  #
+  # The regression this fixes: stopStreaming tried to detect open modals itself
+  # by reading five `show*` booleans and bailing out. That could only ever know
+  # about the modals ModernApp happens to own, so every other modal — the shared
+  # ui/Modal, the image preview, the prompt picker — fell through to "pause the
+  # chat". Detecting the modal from the DOM covers all of them at once, and the
+  # `data-modal-open` marker that powers it already existed.
+  - id: dismissModal
+    name: Close Modal
+    description: Close the open dialog or overlay
+    category: Interface
+    binding: Escape
+    context: modal
+    allow_in_input: true
+    handler: onDismissModal
 
   # Escape must close the slash menu rather than stopping the AI response.
   # Registered in the `slash-menu` context so it SHADOWS stopStreaming while the

--- a/generated/docs-source/settings/keyboard-shortcuts.generated.md
+++ b/generated/docs-source/settings/keyboard-shortcuts.generated.md
@@ -60,6 +60,7 @@ Where the **Browser** column is blank the shortcut is the same on both.
 | `Cmd+Shift+Up` |  | Extend Selection Up |
 | `Cmd+Shift+Up` |  | Extend Selection Up (Composer) |
 | `Cmd+Shift+Down` |  | Next Chat |
+| `Cmd+K D` |  | Next Chat Needing Attention |
 | `Cmd+Shift+Up` |  | Previous Chat |
 | `Cmd+K B` |  | Switch Branch Chat |
 | `Cmd+E` |  | Switch Chat |
@@ -104,6 +105,7 @@ Where the **Browser** column is blank the shortcut is the same on both.
 
 | Desktop | Browser | Action |
 |---------|---------|--------|
+| `Escape` |  | Close Modal |
 | `Cmd+Alt+B` |  | Toggle Chat Sidebar |
 | `Cmd+B` |  | Toggle Right Sidebar |
 | `Cmd+,` |  | Toggle Settings |

--- a/web/e2e/onboarding.spec.ts
+++ b/web/e2e/onboarding.spec.ts
@@ -446,6 +446,86 @@ test.describe('Onboarding Flow', () => {
 // Failure Scenarios
 // ---------------------------------------------------------------------------
 
+/**
+ * The state a REAL new user is in on the Compute step.
+ *
+ * mockGrpcRoutes seeds `eligible: true`, which is the funded path every other
+ * test here exercises. But the compute auto-grant at signup is gone, so an
+ * actual brand-new account comes back NO_SUBSCRIPTION — and that was the one
+ * state where the step's primary control, "Start cloud daemon", could never be
+ * clicked. It rendered greyed out with the two controls that fix it (redeem a
+ * coupon, set up billing) demoted to small links underneath.
+ *
+ * These pin the first screen a new user actually sees.
+ */
+test.describe('Onboarding – Compute with no billing (the new-user default)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockGrpcRoutes(page);
+    // Override the funded default from mockGrpcRoutes: no subscription, no
+    // granted minutes — a fresh account that has never paid.
+    await page.route(
+      '**/controlplane.v1.BillingService/GetCurrentUserComputeEligibility',
+      (route: Route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            eligible: false,
+            reason: 3, // COMPUTE_INELIGIBLE_REASON_NO_SUBSCRIPTION
+            hasActiveSubscription: false,
+            grantedMinutesRemaining: '0',
+            planName: '',
+          }),
+        }),
+    );
+    await loginWithApiKey(page);
+  });
+
+  test('offers no dead "Start cloud daemon" button, and promotes coupon + billing instead', async ({
+    page,
+  }) => {
+    await gotoOnboarding(page);
+    const dialog = page.getByRole('dialog', { name: 'Onboarding setup' });
+
+    // The reported bug: a button that is always grey. It is now absent.
+    await expect(dialog.getByRole('button', { name: 'Start cloud daemon' })).toHaveCount(0);
+
+    // The two controls that CAN change this user's state are the ones on offer.
+    await expect(dialog.getByRole('button', { name: /Have a coupon code/i })).toBeEnabled();
+    await expect(dialog.getByRole('button', { name: /Set up billing/i })).toBeEnabled();
+
+    // And the self-hosted path — which needs no billing at all — is still here.
+    await expect(dialog.getByRole('button', { name: /I'll connect my own/i })).toBeEnabled();
+  });
+
+  test('no control on the Compute step is disabled', async ({ page }) => {
+    await gotoOnboarding(page);
+    const dialog = page.getByRole('dialog', { name: 'Onboarding setup' });
+    await dialog.getByRole('button', { name: /Have a coupon code/i }).waitFor();
+
+    // A disabled control here is the whole defect, in any form.
+    const buttons = await dialog.getByRole('button').all();
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const button of buttons) {
+      await expect(button).toBeEnabled();
+    }
+  });
+
+  test('the coupon field opens in place, so redeeming never leaves onboarding', async ({
+    page,
+  }) => {
+    await gotoOnboarding(page);
+    const dialog = page.getByRole('dialog', { name: 'Onboarding setup' });
+
+    await dialog.getByRole('button', { name: /Have a coupon code/i }).click();
+
+    await expect(dialog.getByPlaceholder(/Enter code/i)).toBeVisible();
+    await expect(dialog.getByRole('button', { name: /^Redeem$/ })).toBeEnabled();
+    // Still on Compute — the step did not navigate away.
+    await expect(dialog.getByText('One chat interface. Daemons anywhere.')).toBeVisible();
+  });
+});
+
 test.describe('Onboarding – Failure Scenarios', () => {
   test.beforeEach(async ({ page }) => {
     await mockGrpcRoutes(page);

--- a/web/src/ModernApp.tsx
+++ b/web/src/ModernApp.tsx
@@ -592,15 +592,13 @@ function App() {
           return;
         }
 
-        // Priority 3: Close any open search modals
-        // Note: Search modals handle their own ESC key, but if they're open
-        // we should not stop streaming. Check all modal states.
-        if (showGlobalSearch || showFindReplace || showQuickFileOpen || showCommandPalette || showChatSearch) {
-          // Modals handle their own close via ESC
-          return;
-        }
-
-        // Priority 4: Find the active chat and pause it
+        // Priority 3: Find the active chat and pause it
+        //
+        // Modals no longer need checking here. An open modal puts the
+        // dispatcher in the `modal` context, where dismissModal shadows this
+        // handler entirely — so if we are running at all, there is no modal up.
+        // The old five-boolean check could only see ModernApp's own modals and
+        // paused the chat behind every other one.
         if (activeChatId) {
           const { pauseChat } =
             useChatStore.getState();
@@ -824,8 +822,22 @@ function App() {
         window.dispatchEvent(new CustomEvent("focus-chat-input"));
         window.dispatchEvent(new CustomEvent("open-slash-menu"));
       },
+      onDismissModal: () => {
+        // Modals that own their Escape (the shared ui/Modal, the command
+        // palette, the search overlays) close themselves on the same keydown.
+        // This entry exists so the `modal` context claims Escape at all and
+        // stopStreaming cannot fire behind them; closing ModernApp's own
+        // modals here covers the ones whose open state we hold.
+        closeAllModals();
+      },
       onDismissSlashMenu: () => {
         window.dispatchEvent(new CustomEvent("dismiss-slash-menu"));
+      },
+      onNextAttentionChat: () => {
+        const { navigateToNextAttention } = useChatNavigationStore.getState();
+        void navigateToNextAttention().then((found) => {
+          if (!found) toast.success("No chats need your attention");
+        });
       },
       onComposerNewline: () => {
         window.dispatchEvent(new CustomEvent("composer-insert-newline"));

--- a/web/src/api/__tests__/streaming-grpc.display-style.test.ts
+++ b/web/src/api/__tests__/streaming-grpc.display-style.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { fromJsonString } from "@bufbuild/protobuf";
+import { MessageSchema, DisplayStyle } from "../../gen/reliant/v1/chat_pb";
+
+/**
+ * A live message update is a raw Go `encoding/json` payload parsed straight
+ * into the proto Message (convertChatUpdateData in streaming-grpc.ts). The
+ * transcript hides LLM-context-only messages by checking
+ * `displayStyle === DisplayStyle.HIDDEN`, so that check only works if the
+ * snake_case integer the backend emits survives this parse.
+ */
+describe("live message update display_style", () => {
+  it("parses the backend's snake_case integer into DisplayStyle.HIDDEN", () => {
+    const payload = JSON.stringify({
+      id: "msg-1",
+      role: 4,
+      thread: "chat-1",
+      display_style: DisplayStyle.HIDDEN,
+      content_blocks: [],
+    });
+
+    const parsed = fromJsonString(MessageSchema, payload, {
+      ignoreUnknownFields: true,
+    });
+
+    expect(parsed.displayStyle).toBe(DisplayStyle.HIDDEN);
+  });
+
+  it("leaves displayStyle unset when the backend omits it", () => {
+    const parsed = fromJsonString(
+      MessageSchema,
+      JSON.stringify({ id: "msg-2", role: 1, thread: "chat-1" }),
+      { ignoreUnknownFields: true },
+    );
+
+    expect(parsed.displayStyle).toBeUndefined();
+  });
+});

--- a/web/src/components/OnboardingFlow/__tests__/ComputeStep.test.tsx
+++ b/web/src/components/OnboardingFlow/__tests__/ComputeStep.test.tsx
@@ -158,6 +158,15 @@ vi.mock("@/lib/analytics", () => ({
   trackEvent: vi.fn(),
 }));
 
+// "Set up billing" navigates via TanStack Router, which has no router context
+// in this render. Where it SENDS people (including the anonymous-user detour)
+// is covered by useGoToBilling's own tests; here we only care that the control
+// is offered and does not provision a machine.
+const mockGoToBilling = vi.fn();
+vi.mock("@/hooks/useGoToBilling", () => ({
+  useGoToBilling: () => mockGoToBilling,
+}));
+
 // Capabilities flag controls whether the cloud option renders; force it on
 // so the form's "Reliant Cloud" CTA is unambiguously present when we expect
 // the form to be visible.
@@ -331,7 +340,18 @@ describe("ComputeStep loading gate", () => {
 });
 
 describe("ComputeStep cloud eligibility + coupon redemption", () => {
-  it("disables Start cloud daemon and shows the new copy (not the old wallet-credit string) when ineligible", () => {
+  // THE USER'S REPORT: "there's this 'start daemon' button, but it will always
+  // be grayed out because a user never has billing."
+  //
+  // It really was ALWAYS grey for a new account: the signup compute auto-grant
+  // is gone, so every new user resolves to NO_SUBSCRIPTION and lands here
+  // ineligible. The card's most prominent control was one that could never be
+  // clicked, with the two that fix it demoted to links underneath.
+  //
+  // So the contract is now absence, not disabled-ness: when the user cannot
+  // start a machine there is no start button on the screen at all, and the
+  // coupon and billing actions are the card's primary controls.
+  it("omits the start button entirely when ineligible, and promotes coupon + billing instead", () => {
     mockUseCloudEligibility.mockReturnValue({
       eligible: false,
       reason: "No compute plan yet",
@@ -343,15 +363,40 @@ describe("ComputeStep cloud eligibility + coupon redemption", () => {
     renderComputeStep({ daemons: [], loading: false });
 
     expect(
-      screen.getByRole("button", { name: /Start cloud daemon/i }),
-    ).toBeDisabled();
+      screen.queryByRole("button", { name: /Start cloud daemon/i }),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("No compute plan yet")).toBeInTheDocument();
     expect(
       screen.queryByText(/No cloud credits available/i),
     ).not.toBeInTheDocument();
+
+    // The two controls that can actually change the user's state are present.
     expect(
       screen.getByRole("button", { name: /Have a coupon code\?/i }),
-    ).toBeInTheDocument();
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: /Set up billing/i }),
+    ).toBeEnabled();
+  });
+
+  // The card must never present a control the user cannot use. Absence of the
+  // start button is the fix for the reported grey button, so it is worth
+  // pinning that NOTHING on the cloud card is disabled in this state — a
+  // future disabled affordance here would recreate the same dead end.
+  it("leaves no disabled control on the card when ineligible", () => {
+    mockUseCloudEligibility.mockReturnValue({
+      eligible: false,
+      reason: "No compute plan yet",
+      isLoading: false,
+      grantedMinutesRemaining: 0,
+      refetch: mockRefetchCloudEligibility,
+    });
+
+    renderComputeStep({ daemons: [], loading: false });
+
+    for (const button of screen.getAllByRole("button")) {
+      expect(button).toBeEnabled();
+    }
   });
 
   it("enables Start cloud daemon when eligible", () => {
@@ -405,7 +450,7 @@ describe("ComputeStep cloud eligibility + coupon redemption", () => {
     expect(mockRefetchCloudEligibility).toHaveBeenCalled();
   });
 
-  it("redeem failure shows the server's message and the button stays disabled", async () => {
+  it("redeem failure shows the server's message and no start button appears", async () => {
     mockUseCloudEligibility.mockReturnValue({
       eligible: false,
       reason: "No compute plan yet",
@@ -429,9 +474,11 @@ describe("ComputeStep cloud eligibility + coupon redemption", () => {
       expect(screen.getByText("Unknown coupon code.")).toBeInTheDocument();
     });
     expect(mockRefetchCloudEligibility).not.toHaveBeenCalled();
+    // A failed redemption leaves the user ineligible, so the start button must
+    // not have appeared.
     expect(
-      screen.getByRole("button", { name: /Start cloud daemon/i }),
-    ).toBeDisabled();
+      screen.queryByRole("button", { name: /Start cloud daemon/i }),
+    ).not.toBeInTheDocument();
   });
   // REGRESSION: the dev bypass (`getIsDev() ? true : cloudEligible`) enabled
   // this button for an unfunded user, so the click ran the whole
@@ -441,7 +488,17 @@ describe("ComputeStep cloud eligibility + coupon redemption", () => {
   //
   // Asserting on the mutation rather than only on `disabled` is the point:
   // `disabled` is a rendering concern, and the bug was that the HANDLER ran.
-  it("clicking Start while ineligible never starts provisioning", async () => {
+  //
+  // The guarantee is now structural rather than a `disabled` attribute: while
+  // the user is ineligible there is no start control in the tree, so there is
+  // no element a stale render, a keyboard activation, or devtools can activate
+  // to reach provisioning. (`handleCloud` keeps its own `if (!eligible)`
+  // guard as defense in depth; it is simply no longer reachable from the UI in
+  // this state, which is the stronger position.)
+  //
+  // Asserting on the MUTATIONS, not just on the absent button, is the point:
+  // the original bug was that the HANDLER ran.
+  it("clicking around while ineligible never starts provisioning", async () => {
     mockUseCloudEligibility.mockReturnValue({
       eligible: false,
       reason: "Your free trial has ended",
@@ -452,12 +509,16 @@ describe("ComputeStep cloud eligibility + coupon redemption", () => {
 
     renderComputeStep({ daemons: [], loading: false });
 
-    const start = screen.getByRole("button", { name: /Start cloud daemon/i });
-    expect(start).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: /Start cloud daemon/i }),
+    ).not.toBeInTheDocument();
 
-    // Fire the handler directly, bypassing the disabled attribute the way a
-    // stale render or a keyboard activation racing a refetch would.
-    fireEvent.click(start);
+    // Click every control the blocked card does offer. None of them may
+    // provision a machine — the only paths out are the coupon form and
+    // billing navigation.
+    for (const button of screen.getAllByRole("button")) {
+      fireEvent.click(button);
+    }
     await act(async () => {
       await Promise.resolve();
     });
@@ -621,7 +682,7 @@ describe("ComputeStep cloud eligibility + coupon redemption", () => {
   // An ineligible user must always get BOTH ways out: the billing link and the
   // coupon field. The billing block used to be gated on `reason` being a
   // non-empty string, so an unrecognised reason hid the only escape route.
-  it("ineligible => shows the billing link AND the coupon field, even with no reason text", () => {
+  it("ineligible => shows the billing action AND the coupon field, even with no reason text", () => {
     mockUseCloudEligibility.mockReturnValue({
       eligible: false,
       reason: null, // server sent a reason this build has no copy for
@@ -633,9 +694,11 @@ describe("ComputeStep cloud eligibility + coupon redemption", () => {
     renderComputeStep({ daemons: [], loading: false });
 
     expect(
-      screen.getByRole("button", { name: /Start cloud daemon/i }),
-    ).toBeDisabled();
-    expect(screen.getByRole("button", { name: /View plans/i })).toBeInTheDocument();
+      screen.queryByRole("button", { name: /Start cloud daemon/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Set up billing/i }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /Have a coupon code\?/i }),
     ).toBeInTheDocument();

--- a/web/src/components/OnboardingFlow/steps/ComputeStep.tsx
+++ b/web/src/components/OnboardingFlow/steps/ComputeStep.tsx
@@ -138,6 +138,12 @@ export function ComputeStep({
         "Redeem a coupon code or choose a plan to start a cloud machine.");
   const loading = forcedEligibility == null && cloudLoading;
 
+  // Whether a "Start cloud daemon" click would actually reach a machine. Named
+  // and derived the same way ConnectDaemonModal does, because it is the same
+  // question asked at the other door into the same action — and it now decides
+  // whether the button EXISTS, not merely whether it is disabled.
+  const canStartCloud = HAS_CLOUD_DAEMONS && eligible && !loading;
+
   // Daemon mutations via React Query. We use mutateAsync below because the
   // surrounding handler needs to sequence listDaemons → resume/create →
   // updatePlan; the hooks' default-onError still suppresses reasoned-quota
@@ -417,63 +423,89 @@ export function ComputeStep({
                     Fastest
                   </span>
                 </div>
+                {/* Describes what the user can do RIGHT NOW. Promising "start
+                    a hosted daemon now" to someone with no compute plan sets
+                    up the dead end this card no longer has. */}
                 <span className="block text-xs leading-relaxed text-muted-foreground">
-                  {HAS_CLOUD_DAEMONS
-                    ? "Start a hosted daemon now. If provisioning takes a few minutes, Reliant will continue setup and connect when it is ready."
-                    : "Cloud daemons are not enabled for this environment."}
+                  {!HAS_CLOUD_DAEMONS
+                    ? "Cloud daemons are not enabled for this environment."
+                    : canStartCloud || loading
+                      ? "Start a hosted daemon now. If provisioning takes a few minutes, Reliant will continue setup and connect when it is ready."
+                      : // Deliberately says what Reliant Cloud IS and stops.
+                        // The `reason` line directly below names what to do
+                        // about it, and having both sentences give the same
+                        // instruction read as a stutter.
+                        "A hosted machine, ready in a few minutes with nothing to install."}
                 </span>
               </div>
             </div>
 
-            <button
-              type="button"
-              onClick={handleCloud}
-              disabled={
-                startingCloud || !HAS_CLOUD_DAEMONS || !eligible || loading
-              }
-              className={cn(
-                "inline-flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-semibold transition-colors",
-                startingCloud || !HAS_CLOUD_DAEMONS || !eligible || loading
-                  ? "cursor-not-allowed bg-muted text-muted-foreground"
-                  : "bg-sky-600 text-white shadow-sm shadow-sky-600/20 hover:bg-sky-500",
-              )}
-            >
-              {(startingCloud || loading) && (
+            {/* Three states, and only ONE of them shows a start button.
+
+                A disabled "Start cloud daemon" used to render unconditionally,
+                and for the single most common visitor to this screen — a brand
+                new user — it was permanently greyed out: the signup compute
+                auto-grant is gone, so every new account resolves to
+                NO_SUBSCRIPTION and lands here ineligible. The card's primary
+                control was therefore an inert one, with the two controls that
+                could actually change that (redeem a code, set up billing)
+                demoted to small links beneath it. The button that cannot be
+                clicked was the most prominent thing on the card.
+
+                So when the user cannot start a machine we do not render a
+                start button at all — the coupon and billing actions ARE the
+                primary controls, because they are the whole of what the user
+                can do here. The start button returns, as the primary control,
+                exactly when clicking it would work. */}
+            {loading ? (
+              <div className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-muted px-4 py-2.5 text-sm font-semibold text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" />
-              )}
-              {startingCloud
-                ? "Requesting daemon..."
-                : loading
-                  ? "Checking availability..."
-                  : "Start cloud daemon"}
-            </button>
-            {/* Gated on !eligible alone, NOT on `reason` being non-empty: an
-                ineligible user must always get the explanation AND the way out
+                Checking availability...
+              </div>
+            ) : canStartCloud ? (
+              <button
+                type="button"
+                onClick={handleCloud}
+                disabled={startingCloud}
+                className={cn(
+                  "inline-flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-semibold transition-colors",
+                  startingCloud
+                    ? "cursor-not-allowed bg-muted text-muted-foreground"
+                    : "bg-sky-600 text-white shadow-sm shadow-sky-600/20 hover:bg-sky-500",
+                )}
+              >
+                {startingCloud && <Loader2 className="h-4 w-4 animate-spin" />}
+                {startingCloud ? "Requesting daemon..." : "Start cloud daemon"}
+              </button>
+            ) : null}
+
+            {/* Gated on !eligible alone, NOT on `reason` being non-empty: a
+                blocked user must always get the explanation AND the way out
                 (billing), even if the server sends back a reason this build
                 does not have copy for. A missing string is not a reason to
                 hide the only escape route on the screen. */}
-            {(!HAS_CLOUD_DAEMONS || !eligible) && (
-              <div className="space-y-1.5">
-                <p className="text-xs leading-relaxed text-muted-foreground">
-                  {!HAS_CLOUD_DAEMONS
-                    ? 'Cloud daemons are unavailable because this environment is not configured for cloud mode. Choose "I\'ll connect my own" to continue.'
-                    : reason}
-                </p>
-              </div>
+            {!loading && !canStartCloud && (
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                {!HAS_CLOUD_DAEMONS
+                  ? 'Cloud daemons are unavailable because this environment is not configured for cloud mode. Choose "I\'ll connect my own" to continue.'
+                  : reason}
+              </p>
             )}
+
             {/* Plans and coupon redemption are shown to EVERY user, not only
-                blocked ones.
-                
-                They were previously gated on `!eligible`, on the theory that
-                someone who can already start a machine has no reason to look
-                at pricing. That is wrong: a new user lands here on the free
-                trial — eligible, so the card offered no way to see what a plan
-                costs or to enter a code they were given. "Where is the pricing
-                button" has one correct answer, which is "always visible". */}
-            {HAS_CLOUD_DAEMONS && (
-              <div className="space-y-2">
+                blocked ones — someone who can already start a machine may
+                still be holding a code, and "where is the pricing button" has
+                one correct answer, which is "always visible".
+
+                What changes with eligibility is their WEIGHT, not their
+                presence: for a user who cannot start a machine these are the
+                only two working controls on the card, so they render as full
+                buttons; for a user who can, they sit under the start button as
+                secondary links. */}
+            {HAS_CLOUD_DAEMONS && !loading && (
+              <div className={cn("space-y-2", !canStartCloud && "pt-0.5")}>
                 <RedeemCouponForm
-                  variant="collapsed"
+                  variant={canStartCloud ? "collapsed" : "button"}
                   size="sm"
                   onRedeemed={() => {
                     void refetchCloudEligibility();
@@ -482,9 +514,14 @@ export function ComputeStep({
                 <button
                   type="button"
                   onClick={goToBilling}
-                  className="flex items-center gap-1 text-xs font-medium text-sky-500 transition-colors hover:text-sky-400"
+                  className={cn(
+                    "transition-colors",
+                    canStartCloud
+                      ? "flex items-center gap-1 text-xs font-medium text-sky-500 hover:text-sky-400"
+                      : "inline-flex w-full items-center justify-center rounded-lg border border-sky-600/40 bg-sky-600/10 px-3 py-2 text-xs font-semibold text-sky-500 hover:bg-sky-600/20",
+                  )}
                 >
-                  View plans &rarr;
+                  {canStartCloud ? <>View plans &rarr;</> : "Set up billing"}
                 </button>
               </div>
             )}

--- a/web/src/components/Projects/ConnectDaemonModal.tsx
+++ b/web/src/components/Projects/ConnectDaemonModal.tsx
@@ -26,6 +26,13 @@
  * same question and offers the same way out. The server remains the authority;
  * this only stops the UI committing to a flow it has been told will fail.
  *
+ * When the answer is no, the cloud tile is not rendered AT ALL rather than
+ * rendered disabled. Every brand-new account is in that state — the signup
+ * compute auto-grant is gone, so a new user resolves to NO_SUBSCRIPTION — and
+ * a permanently-greyed tile as the screen's first choice made the two controls
+ * that actually fix it (redeem a coupon, set up billing) read as secondary.
+ * They take its place instead.
+ *
  * Extracted from ProjectPicker.tsx so the gate is directly testable.
  */
 import { useCallback, useEffect, useState } from "react";
@@ -36,7 +43,6 @@ import { RedeemCouponForm } from "../RedeemCouponForm";
 import { useGoToBilling } from "@/hooks/useGoToBilling";
 import { useCloudEligibility, useCreateDaemon } from "@/hooks/useOnboardingQueries";
 import { capabilities } from "../../services/controlPlane/capabilities";
-import { cn } from "../../lib/utils";
 
 const MANAGED_DAEMON_TYPE = 1;
 const MANAGED_DAEMON_SIZE_SMALL = 1;
@@ -136,14 +142,12 @@ export function ConnectDaemonModal({
 
   const startingCloud = createDaemonMutation.isPending;
 
-  const cloudUnavailableCopy = !hasCloud
+  // Why the user is not being offered a cloud daemon. Only reached when
+  // `canStartCloud` is false — the enabled tile carries its own copy.
+  const cloudBlockedCopy = !hasCloud
     ? "Cloud daemons are not enabled for this deployment."
-    : eligibilityLoading
-      ? "Checking your plan…"
-      : !eligible
-        ? (reason ??
-          "Redeem a coupon code or choose a plan to start a cloud machine.")
-        : "Provision a hosted daemon now. No install required.";
+    : (reason ??
+      "Redeem a coupon code or choose a plan to start a cloud machine.");
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Connect a daemon" size="lg">
@@ -154,32 +158,36 @@ export function ConnectDaemonModal({
             hosted Reliant Cloud daemon or your own self-hosted machine.
           </p>
           <div className="grid gap-3 sm:grid-cols-2">
-            <button
-              type="button"
-              onClick={() => {
-                setMode("cloud");
-                void startCloudDaemon();
-              }}
-              disabled={!canStartCloud}
-              className={cn(
-                "flex min-w-0 flex-col items-start gap-3 rounded-xl border-2 p-5 text-left transition-all",
-                canStartCloud
-                  ? "border-primary/25 bg-primary/5 hover:border-primary/50 hover:bg-primary/10"
-                  : "cursor-not-allowed border-border/50 bg-muted/30 opacity-70",
-              )}
-            >
-              <div className="rounded-lg bg-primary/15 p-2.5 text-primary">
-                <Cloud className="h-6 w-6" />
-              </div>
-              <div className="space-y-1">
-                <span className="block text-sm font-semibold text-foreground">
-                  Reliant Cloud
-                </span>
-                <span className="block text-xs leading-relaxed text-muted-foreground">
-                  {cloudUnavailableCopy}
-                </span>
-              </div>
-            </button>
+            {/* Only offered when it would work. An account with no compute
+                entitlement — which is every brand-new account, now that the
+                signup auto-grant is gone — used to get this tile rendered as a
+                greyed-out no-op, with the coupon form and plans link demoted
+                to a panel below it. Presenting a dead control as the first
+                choice on the screen makes the working ones look secondary.
+                When the user cannot start a cloud daemon, the panel below is
+                the cloud option. */}
+            {canStartCloud && (
+              <button
+                type="button"
+                onClick={() => {
+                  setMode("cloud");
+                  void startCloudDaemon();
+                }}
+                className="flex min-w-0 flex-col items-start gap-3 rounded-xl border-2 border-primary/25 bg-primary/5 p-5 text-left transition-all hover:border-primary/50 hover:bg-primary/10"
+              >
+                <div className="rounded-lg bg-primary/15 p-2.5 text-primary">
+                  <Cloud className="h-6 w-6" />
+                </div>
+                <div className="space-y-1">
+                  <span className="block text-sm font-semibold text-foreground">
+                    Reliant Cloud
+                  </span>
+                  <span className="block text-xs leading-relaxed text-muted-foreground">
+                    Provision a hosted daemon now. No install required.
+                  </span>
+                </div>
+              </button>
+            )}
 
             <button
               type="button"
@@ -200,20 +208,37 @@ export function ConnectDaemonModal({
             </button>
           </div>
 
-          {/* An ineligible user must always get the explanation AND the way
-              out — otherwise this screen is a dead end with a greyed button
-              and no account of why. Mirrors ComputeStep's affordances. */}
-          {hasCloud && !eligible && !eligibilityLoading && (
+          {/* With the greyed tile gone, this panel IS the cloud option for a
+              blocked user: the explanation of why, plus the two actions that
+              change it. Both render as full-width controls rather than as
+              links under a disabled button, because here they are the only
+              cloud actions available. */}
+          {!canStartCloud && !eligibilityLoading && (
             <div className="space-y-3 rounded-xl border border-border/50 bg-muted/30 p-4">
-              <p className="text-xs text-muted-foreground">{reason}</p>
-              <RedeemCouponForm onRedeemed={() => void refetchEligibility()} />
-              <button
-                type="button"
-                onClick={goToBilling}
-                className="text-xs font-medium text-primary transition-colors hover:underline"
-              >
-                View plans
-              </button>
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-foreground">
+                  Reliant Cloud
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {cloudBlockedCopy}
+                </p>
+              </div>
+              {hasCloud && (
+                <>
+                  <RedeemCouponForm
+                    variant="button"
+                    size="sm"
+                    onRedeemed={() => void refetchEligibility()}
+                  />
+                  <button
+                    type="button"
+                    onClick={goToBilling}
+                    className="inline-flex w-full items-center justify-center rounded-lg border border-primary/40 bg-primary/10 px-3 py-2 text-xs font-semibold text-primary transition-colors hover:bg-primary/20"
+                  >
+                    Set up billing
+                  </button>
+                </>
+              )}
             </div>
           )}
         </div>

--- a/web/src/components/Projects/__tests__/ConnectDaemonModal.eligibility.test.tsx
+++ b/web/src/components/Projects/__tests__/ConnectDaemonModal.eligibility.test.tsx
@@ -79,7 +79,12 @@ beforeEach(() => {
 });
 
 describe("ConnectDaemonModal — cloud eligibility", () => {
-  it("does NOT provision when the user is ineligible", async () => {
+  // The ineligible user is not offered the tile at all any more, which is a
+  // stronger guarantee than the old disabled one: there is no cloud control to
+  // click, so no click can reach CreateDaemon. (It used to render greyed out,
+  // which made a dead control the first thing on the screen and pushed the
+  // working ones — coupon, billing — into a panel underneath.)
+  it("does NOT offer a cloud tile, and never provisions, when the user is ineligible", async () => {
     mockUseCloudEligibility.mockReturnValue({
       eligible: false,
       reason: "Redeem a coupon code or choose a plan to start a cloud machine.",
@@ -88,10 +93,11 @@ describe("ConnectDaemonModal — cloud eligibility", () => {
 
     render(<ConnectDaemonModal isOpen onClose={vi.fn()} />);
 
-    const cloud = screen.getByRole("button", { name: /Reliant Cloud/i });
-    await userEvent.click(cloud);
+    expect(
+      screen.queryByRole("button", { name: /Reliant Cloud/i }),
+    ).not.toBeInTheDocument();
 
-    // The click must not reach CreateDaemon. This is the money assertion.
+    // Nothing on the screen can start a machine. This is the money assertion.
     await waitFor(() => {
       expect(mockCreateDaemon).not.toHaveBeenCalled();
     });
@@ -106,14 +112,14 @@ describe("ConnectDaemonModal — cloud eligibility", () => {
 
     render(<ConnectDaemonModal isOpen onClose={vi.fn()} />);
 
-    // The reason appears twice by design: once as the cloud card's own copy
-    // and once in the explainer panel beneath it, which also carries the
-    // coupon form and the plans link.
+    // The panel that replaces the tile carries the reason plus both ways out.
     expect(
-      screen.getAllByText(/Redeem a coupon code or choose a plan/i).length,
-    ).toBeGreaterThan(0);
+      screen.getByText(/Redeem a coupon code or choose a plan/i),
+    ).toBeInTheDocument();
     expect(screen.getByTestId("redeem-coupon")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /View plans/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Set up billing/i }),
+    ).toBeEnabled();
   });
 
   // Never block an entitled user — the failure mode of an over-eager gate is
@@ -128,9 +134,13 @@ describe("ConnectDaemonModal — cloud eligibility", () => {
     });
   });
 
-  // While eligibility is still loading we must not present an enabled button:
+  // While eligibility is still loading we must not present a cloud control:
   // "not yet known" is not "allowed". (Loading is not the negative of success.)
-  it("does not provision while eligibility is still loading", async () => {
+  //
+  // Loading is also NOT the ineligible state — showing "you have no plan" to a
+  // user whose plan simply has not loaded yet would be a lie that resolves
+  // itself a moment later, so neither the tile nor the blocked panel renders.
+  it("offers no cloud control at all while eligibility is still loading", async () => {
     mockUseCloudEligibility.mockReturnValue({
       eligible: false,
       reason: null,
@@ -139,7 +149,15 @@ describe("ConnectDaemonModal — cloud eligibility", () => {
 
     render(<ConnectDaemonModal isOpen onClose={vi.fn()} />);
 
-    await userEvent.click(screen.getByRole("button", { name: /Reliant Cloud/i }));
+    expect(
+      screen.queryByRole("button", { name: /Reliant Cloud/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("redeem-coupon")).not.toBeInTheDocument();
+
+    // Self-hosted is always available and is unaffected by eligibility.
+    expect(
+      screen.getByRole("button", { name: /Self-hosted/i }),
+    ).toBeEnabled();
 
     await waitFor(() => {
       expect(mockCreateDaemon).not.toHaveBeenCalled();

--- a/web/src/components/RedeemCouponForm.tsx
+++ b/web/src/components/RedeemCouponForm.tsx
@@ -32,6 +32,11 @@ export interface RedeemCouponFormProps {
    * right when most visits are not redemptions and a permanent input invites
    * hunting for a code the user does not have.
    *
+   * "button" is the same disclosure with a full-width solid button as the
+   * trigger, for screens where redeeming is one of the few things the user can
+   * actually do and the affordance has to carry the weight of a primary
+   * control rather than sit under one as a link.
+   *
    * "open" renders the input immediately, for places where redeeming is the
    * point.
    *
@@ -40,7 +45,7 @@ export interface RedeemCouponFormProps {
    * `variant={eligible ? "collapsed" : "open"}`) will not collapse or expand
    * an already-mounted form — it will just look stuck. Pick one and leave it.
    */
-  variant?: "collapsed" | "open";
+  variant?: "collapsed" | "open" | "button";
   /** Compact sizing for dense cards. */
   size?: "sm" | "md";
   className?: string;
@@ -103,7 +108,15 @@ export function RedeemCouponForm({
         type="button"
         onClick={() => setOpen(true)}
         className={cn(
-          "text-sm font-medium text-primary hover:underline",
+          variant === "button"
+            ? cn(
+                // border-transparent, not no border: this button is normally
+                // stacked with bordered siblings, and without it the two sit
+                // 2px apart in height.
+                "inline-flex w-full items-center justify-center rounded-lg border border-transparent bg-primary font-semibold text-primary-foreground transition-colors hover:bg-primary/90",
+                small ? "px-3 py-2 text-xs" : "px-4 py-2.5 text-sm",
+              )
+            : "text-sm font-medium text-primary hover:underline",
           className,
         )}
       >
@@ -157,7 +170,7 @@ export function RedeemCouponForm({
         </p>
       )}
       {redeemed && (
-        <p className={cn("text-emerald-600", small ? "text-xs" : "text-sm")}>
+        <p className={cn("text-success", small ? "text-xs" : "text-sm")}>
           {redeemed}
         </p>
       )}

--- a/web/src/components/Settings/cloud/__tests__/billing.test.tsx
+++ b/web/src/components/Settings/cloud/__tests__/billing.test.tsx
@@ -30,7 +30,30 @@ const mutation = () => ({
 // is required because `vi.mock`'s factory is hoisted above normal `const`s.
 const usageState = vi.hoisted(() => ({ current: undefined as unknown }))
 
+// Only `redeemCoupon` is replaced; the rest of the service module (notably the
+// `RedeemedCouponKind` re-export and the `reliantAIAvailable` flag) stays real,
+// so the mock cannot drift from the module's actual shape.
+const couponState = vi.hoisted(() => ({ redeem: vi.fn() }))
+
+vi.mock('@/services/controlPlane/reliantAI', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, redeemCoupon: (code: string) => couponState.redeem(code) }
+})
+
 vi.mock('@/hooks/useCloudBillingQueries', () => ({
+  // Real object, not a stub: `useRedeemCoupon` (from the OTHER hook module,
+  // which is not mocked) dereferences these keys in its own onSuccess to
+  // invalidate the billing reads. Omitting them makes redemption throw before
+  // the form's success handler ever runs.
+  cloudBillingKeys: {
+    all: ['cloud-billing'],
+    computeSubscription: ['cloud-billing', 'compute-subscription'],
+    walletOverview: ['cloud-billing', 'wallet-overview'],
+    computeUsage: (period: string) => ['cloud-billing', 'compute-usage', period],
+    plans: ['cloud-billing', 'plans'],
+    invoices: ['cloud-billing', 'invoices'],
+    billingEmail: ['cloud-billing', 'billing-email'],
+  },
   useComputeSubscription: () => query(undefined),
   useWalletOverview: () => query(undefined),
   useComputeUsage: () => query(usageState.current),
@@ -44,6 +67,7 @@ vi.mock('@/hooks/useCloudBillingQueries', () => ({
   useUpdateBillingEmail: () => mutation(),
 }))
 
+import { RedeemedCouponKind } from '@/gen/controlplane/v1/public/billing_service_pb'
 import { BillingSection } from '@/components/Settings/cloud/billing'
 
 function renderSection() {
@@ -147,6 +171,98 @@ describe('BillingSection', () => {
       fireEvent.click(screen.getByRole('button', { name: /^usage$/i }))
 
       expect(screen.queryByText(/coupon minutes/i)).not.toBeInTheDocument()
+    })
+  })
+
+  // The user's report was "not sure if there's a place to add coupon codes?"
+  // — the field existed but only behind a "Have a coupon code?" disclosure
+  // inside a card about usage. These tests pin the fix: the input is on screen
+  // with nothing to click first, and one box handles BOTH grant kinds.
+  describe('coupon redemption', () => {
+    beforeEach(() => {
+      couponState.redeem.mockReset()
+    })
+
+    it('shows the coupon input on the overview tab without clicking a disclosure', () => {
+      renderSection()
+
+      expect(screen.getByLabelText(/coupon code/i)).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: /^redeem$/i }),
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /have a coupon code/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    it('explains that one code covers either credit or machine minutes', () => {
+      renderSection()
+
+      expect(
+        screen.getByText(/add account credit or machine minutes/i),
+      ).toBeInTheDocument()
+    })
+
+    it('reports a wallet-credit redemption in dollars', async () => {
+      couponState.redeem.mockResolvedValue({
+        amountCents: 2500,
+        code: 'WELCOME25',
+        newBalanceCents: 2500,
+        kind: RedeemedCouponKind.WALLET_CREDIT,
+        computeMinutes: 0,
+        newComputeMinutesRemaining: 0,
+      })
+      renderSection()
+
+      fireEvent.change(screen.getByLabelText(/coupon code/i), {
+        target: { value: 'welcome25' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^redeem$/i }))
+
+      expect(
+        await screen.findByText(/added \$25\.00 to your balance/i),
+      ).toBeInTheDocument()
+      expect(couponState.redeem).toHaveBeenCalledWith('welcome25')
+    })
+
+    it('reports a compute-minutes redemption in machine minutes, from the same box', async () => {
+      couponState.redeem.mockResolvedValue({
+        amountCents: 0,
+        code: 'MACHINE120',
+        newBalanceCents: 0,
+        kind: RedeemedCouponKind.COMPUTE_MINUTES,
+        computeMinutes: 120,
+        newComputeMinutesRemaining: 180,
+      })
+      renderSection()
+
+      fireEvent.change(screen.getByLabelText(/coupon code/i), {
+        target: { value: 'MACHINE120' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^redeem$/i }))
+
+      expect(
+        await screen.findByText(/added 120 machine minutes \(2 hours\)/i),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(/180 machine minutes \(3 hours\) available/i),
+      ).toBeInTheDocument()
+    })
+
+    it("surfaces the server's own message when a code is rejected", async () => {
+      couponState.redeem.mockRejectedValue(
+        new Error('[not_found] That coupon code does not exist.'),
+      )
+      renderSection()
+
+      fireEvent.change(screen.getByLabelText(/coupon code/i), {
+        target: { value: 'nope' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^redeem$/i }))
+
+      expect(
+        await screen.findByText('That coupon code does not exist.'),
+      ).toBeInTheDocument()
     })
   })
 })

--- a/web/src/components/Settings/cloud/__tests__/environments.test.tsx
+++ b/web/src/components/Settings/cloud/__tests__/environments.test.tsx
@@ -64,6 +64,7 @@ vi.mock('@/services/controlPlane/environments', () => ({
     DISCONNECTED: 5,
   },
   DaemonSize: { UNSPECIFIED: 0, SMALL: 1, MEDIUM: 2, LARGE: 3, XL: 4 },
+  DaemonType: { UNSPECIFIED: 0, MANAGED: 1, EXTERNAL: 2 },
   PortAccessMode: { UNSPECIFIED: 0, PUBLIC: 1, AUTHENTICATED: 2, TOKEN: 3 },
   describeError: (_e: unknown, fallback = 'error') => fallback,
   // environments.tsx calls this at module scope to build its query-key table,
@@ -84,7 +85,7 @@ vi.mock('@/services/controlPlane/environments', () => ({
   revokeDaemonToken: vi.fn(),
 }))
 
-import { EnvironmentsSection } from '@/components/Settings/cloud/environments'
+import { EnvironmentsSection, daemonDisplayName } from '@/components/Settings/cloud/environments'
 
 function renderSection() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
@@ -155,5 +156,113 @@ describe('EnvironmentsSection', () => {
         name: /run reliant on your own machine/i,
       }),
     ).toBeInTheDocument()
+  })
+
+  describe('managed vs self-hosted grouping', () => {
+    const managedDaemon = {
+      id: 'dd67e516-d02c-49d0-8210-8749022aba61',
+      name: 'onboarding-daemon',
+      daemonType: 1, // MANAGED
+      status: 2, // ACTIVE
+      resources: { cpuRequest: '2', cpuLimit: '2', memoryRequest: '4Gi', memoryLimit: '4Gi' },
+      storageSize: '20Gi',
+      hostname: '',
+      platform: '',
+      size: 2,
+      idleTimeout: '30m',
+    }
+    const externalDaemon = {
+      id: '2a76a273-f04d-4a8a-8391-864ad4e018f1',
+      name: '2a76a273-f04d-4a8a-8391-864ad4e018f1', // UUID fallback name, as seen in prod
+      daemonType: 2, // EXTERNAL
+      status: 2, // ACTIVE
+      resources: undefined,
+      storageSize: '',
+      hostname: '',
+      platform: 'darwin',
+      size: 2, // invented by the backend fallback; must not be shown
+      idleTimeout: '',
+    }
+
+    it('renders managed and self-hosted machines in separate groups', async () => {
+      mocks.listDaemons.mockResolvedValue({ daemons: [managedDaemon, externalDaemon] })
+      renderSection()
+
+      expect(await screen.findByText('Cloud machines')).toBeInTheDocument()
+      expect(screen.getByText('Self-hosted machines')).toBeInTheDocument()
+
+      // Managed row keeps its real name.
+      expect(screen.getByText('onboarding-daemon')).toBeInTheDocument()
+      // External row gets the readable fallback, not the raw UUID.
+      expect(screen.queryByText('2a76a273-f04d-4a8a-8391-864ad4e018f1')).not.toBeInTheDocument()
+      expect(screen.getByText(/self-hosted machine \(2a76a273\)/i)).toBeInTheDocument()
+    })
+
+    it('shows no size/resources column and no Suspend control for self-hosted machines', async () => {
+      mocks.listDaemons.mockResolvedValue({ daemons: [managedDaemon, externalDaemon] })
+      renderSection()
+
+      await screen.findByText('Self-hosted machines')
+
+      // Managed table still has a Resources column and a Suspend action.
+      expect(screen.getByRole('columnheader', { name: /resources/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /suspend/i })).toBeInTheDocument()
+
+      // Self-hosted table shows Platform instead, and only ONE Resources
+      // column exists in the document (the managed table's) — the
+      // self-hosted table does not add a second one.
+      expect(screen.getByRole('columnheader', { name: /platform/i })).toBeInTheDocument()
+      expect(screen.getAllByRole('columnheader', { name: /^resources$/i })).toHaveLength(1)
+      expect(screen.getByText('darwin')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /remove/i })).toBeInTheDocument()
+      // Suspend appears exactly once — on the managed row, not the self-hosted one.
+      expect(screen.getAllByRole('button', { name: /suspend/i })).toHaveLength(1)
+    })
+
+    it('omits an empty group instead of rendering an empty table', async () => {
+      mocks.listDaemons.mockResolvedValue({ daemons: [managedDaemon] })
+      renderSection()
+
+      expect(await screen.findByText('Cloud machines')).toBeInTheDocument()
+      expect(screen.queryByText('Self-hosted machines')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('daemonDisplayName', () => {
+    it('keeps a real, human-chosen name as-is', () => {
+      expect(
+        daemonDisplayName({ id: 'dd67e516-d02c-49d0-8210-8749022aba61', name: 'onboarding-daemon', hostname: '' }),
+      ).toBe('onboarding-daemon')
+    })
+
+    it('falls back to the hostname when the name is a bare UUID', () => {
+      expect(
+        daemonDisplayName({
+          id: '2a76a273-f04d-4a8a-8391-864ad4e018f1',
+          name: '2a76a273-f04d-4a8a-8391-864ad4e018f1',
+          hostname: "seans-macbook",
+        }),
+      ).toBe('seans-macbook')
+    })
+
+    it('falls back to a short id label when name and hostname are both unusable', () => {
+      expect(
+        daemonDisplayName({
+          id: '2a76a273-f04d-4a8a-8391-864ad4e018f1',
+          name: '2a76a273-f04d-4a8a-8391-864ad4e018f1',
+          hostname: '',
+        }),
+      ).toBe('Self-hosted machine (2a76a273)')
+    })
+
+    it('falls back when name equals id but is not UUID-shaped', () => {
+      expect(daemonDisplayName({ id: 'abc123', name: 'abc123', hostname: '' })).toBe(
+        'Self-hosted machine (abc123)',
+      )
+    })
+
+    it('falls back when the name is empty', () => {
+      expect(daemonDisplayName({ id: 'abc123', name: '', hostname: 'my-laptop' })).toBe('my-laptop')
+    })
   })
 })

--- a/web/src/components/Settings/cloud/billing.tsx
+++ b/web/src/components/Settings/cloud/billing.tsx
@@ -9,6 +9,7 @@ import {
   FileText,
   Pencil,
   Server,
+  Ticket,
   Wallet,
 } from "lucide-react";
 
@@ -61,6 +62,7 @@ import {
 } from "./billingUtils";
 import { formatMachineMinutesShort } from "@/lib/formatMachineMinutes";
 import { RedeemCouponForm } from "@/components/RedeemCouponForm";
+import { cn } from "@/lib/utils";
 
 type BillingTab = "overview" | "plans" | "invoices" | "usage";
 
@@ -147,6 +149,26 @@ function ErrorBanner({ message }: { message: string }) {
 
 function Loading({ label }: { label: string }) {
   return <div className="text-sm text-muted-foreground">{label}</div>;
+}
+
+// Groups a run of cards under one label so the Overview tab reads as three
+// answers — what you have, what you are on, what you have used — instead of an
+// undifferentiated stack of equally-weighted panels.
+function SectionHeading({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div>
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {title}
+      </h3>
+      <p className="mt-0.5 text-sm text-muted-foreground">{description}</p>
+    </div>
+  );
 }
 
 // redirectToStripe navigates the browser to a hosted Stripe URL. In dev the
@@ -278,58 +300,110 @@ function OverviewTab({
 
   const loading = subQ.isLoading || walletQ.isLoading || usageQ.isLoading;
 
+  const refetchAfterRedeem = () => {
+    // A coupon can land as wallet credit OR as machine minutes, and the form
+    // does not know which until the server answers, so refresh both readouts.
+    void walletQ.refetch();
+    void usageQ.refetch();
+  };
+
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-8">
       <ErrorBanner message={error} />
 
       {loading ? (
         <Loading label="Loading billing…" />
       ) : (
         <>
-          <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
-            {/* Wallet credits */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Wallet className="h-4 w-4 text-muted-foreground" />
-                  Credit balance
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="flex flex-col gap-4">
-                <div>
-                  <p className="text-3xl font-semibold text-foreground">
-                    {walletUi.balance}
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    Available credits for Reliant usage
-                  </p>
-                </div>
-                {walletUi.warning && (
-                  <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-400">
-                    <p className="font-semibold">{walletUi.warning.title}</p>
-                    <p>{walletUi.warning.message}</p>
+          {/* ── What you have ─────────────────────────────────────────── */}
+          <section className="flex flex-col gap-3">
+            <SectionHeading
+              title="Balance"
+              description="Credit pays for AI usage. Machine minutes pay for machines."
+            />
+            <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+              {/* Wallet credits */}
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <Wallet className="h-4 w-4 text-muted-foreground" />
+                    Credit balance
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-4">
+                  <div>
+                    <p className="text-3xl font-semibold text-foreground">
+                      {walletUi.balance}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Available credits for Reliant usage
+                    </p>
                   </div>
-                )}
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-xs font-medium text-muted-foreground">
-                    Add credits:
-                  </span>
-                  {TOPUP_PRESETS_CENTS.map((cents) => (
-                    <Button
-                      key={cents}
-                      size="sm"
-                      variant="outline"
-                      disabled={topupMutation.isPending}
-                      onClick={() => handleTopup(cents)}
-                    >
-                      ${(cents / 100).toFixed(0)}
-                    </Button>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
+                  {walletUi.warning && (
+                    <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning">
+                      <p className="font-semibold">{walletUi.warning.title}</p>
+                      <p>{walletUi.warning.message}</p>
+                    </div>
+                  )}
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      Add credits:
+                    </span>
+                    {TOPUP_PRESETS_CENTS.map((cents) => (
+                      <Button
+                        key={cents}
+                        size="sm"
+                        variant="outline"
+                        disabled={topupMutation.isPending}
+                        onClick={() => handleTopup(cents)}
+                      >
+                        ${(cents / 100).toFixed(0)}
+                      </Button>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
 
-            {/* Compute plan */}
+              {/* Coupons. There is ONE redemption RPC and the server decides
+                  what a code grants, so there is one input here — not one per
+                  kind — and the copy carries that, because a user holding a
+                  machine-minutes code will otherwise go looking for a second
+                  box that does not exist. It renders open: this card is the
+                  answer to "where do I put my code", and an answer behind a
+                  disclosure link is the bug we are fixing. */}
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <Ticket className="h-4 w-4 text-muted-foreground" />
+                    Redeem a coupon
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-4">
+                  <p className="text-sm text-muted-foreground">
+                    One box, either kind of code. A coupon can add account
+                    credit or machine minutes — enter it below and we&apos;ll
+                    tell you which one it applied.
+                  </p>
+                  <RedeemCouponForm
+                    variant="open"
+                    onRedeemed={refetchAfterRedeem}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Credit shows up in the balance beside this card. Machine
+                    minutes show up under Usage this period, and are spent
+                    after your plan&apos;s included hours.
+                  </p>
+                </CardContent>
+              </Card>
+            </div>
+          </section>
+
+          {/* ── What you are on ───────────────────────────────────────── */}
+          <section className="flex flex-col gap-3">
+            <SectionHeading
+              title="Plan"
+              description="One compute subscription covers every machine on your account."
+            />
             <Card>
               <CardHeader className="gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <CardTitle className="flex items-center gap-2">
@@ -408,79 +482,92 @@ function OverviewTab({
                 </div>
               </CardContent>
             </Card>
-          </div>
+          </section>
 
-          {/* Usage this period */}
-          <Card>
-            <CardHeader className="gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <CardTitle>Usage this period</CardTitle>
-              <button
-                type="button"
-                onClick={onGoToUsage}
-                className="text-left text-sm font-medium text-primary hover:underline sm:text-right"
-              >
-                See detail →
-              </button>
-            </CardHeader>
-            <CardContent>
-              <div className="flex flex-col gap-1 text-sm sm:flex-row sm:items-center sm:justify-between">
-                <span className="font-medium text-foreground">Hours used</span>
-                <span className="text-muted-foreground">
-                  {usageUi.usedHours.toFixed(1)} h /{" "}
-                  {usageUi.includedHours.toFixed(0)} h included
-                </span>
-              </div>
-              <div className="mt-2 h-2.5 rounded-full bg-muted">
-                <div
-                  className={`h-2.5 rounded-full ${
-                    usageUi.pct >= 90 ? "bg-amber-500" : "bg-primary"
-                  }`}
-                  style={{ width: `${usageUi.pct}%` }}
-                />
-              </div>
-              {usageUi.grantedMinutesRemaining > 0 && (
-                <div className="mt-4 flex flex-col gap-2 rounded-md border border-border bg-muted/40 px-4 py-3 text-sm sm:flex-row sm:items-center sm:justify-between">
-                  <div>
-                    <p className="font-medium text-foreground">Coupon minutes</p>
-                    <p className="text-xs text-muted-foreground">
-                      One-time, does not renew — spent after included hours,
-                      before overage
-                    </p>
+          {/* ── What you have used ────────────────────────────────────── */}
+          <section className="flex flex-col gap-3">
+            <SectionHeading
+              title="Usage"
+              description="Machine time drawn against this billing period."
+            />
+            <Card>
+              <CardHeader className="gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <CardTitle>Usage this period</CardTitle>
+                <button
+                  type="button"
+                  onClick={onGoToUsage}
+                  className="text-left text-sm font-medium text-primary hover:underline sm:text-right"
+                >
+                  See detail →
+                </button>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-col gap-1 text-sm sm:flex-row sm:items-center sm:justify-between">
+                  <span className="font-medium text-foreground">Hours used</span>
+                  <span className="text-muted-foreground">
+                    {usageUi.usedHours.toFixed(1)} h /{" "}
+                    {usageUi.includedHours.toFixed(0)} h included
+                  </span>
+                </div>
+                <div className="mt-2 h-2.5 rounded-full bg-muted">
+                  <div
+                    className={cn(
+                      "h-2.5 rounded-full",
+                      usageUi.pct >= 90 ? "bg-warning" : "bg-primary",
+                    )}
+                    style={{ width: `${usageUi.pct}%` }}
+                  />
+                </div>
+                {usageUi.grantedMinutesRemaining > 0 && (
+                  <div className="mt-4 flex flex-col gap-2 rounded-md border border-border bg-muted/40 px-4 py-3 text-sm sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <p className="font-medium text-foreground">Coupon minutes</p>
+                      <p className="text-xs text-muted-foreground">
+                        One-time, does not renew — spent after included hours,
+                        before overage
+                      </p>
+                    </div>
+                    <span className="font-medium text-foreground">
+                      {formatMachineMinutesShort(usageUi.grantedMinutesRemaining)}
+                    </span>
                   </div>
-                  <span className="font-medium text-foreground">
-                    {formatMachineMinutesShort(usageUi.grantedMinutesRemaining)}
-                  </span>
-                </div>
-              )}
-              {/* Redeeming belongs next to the balance it changes: this panel
-                  is where a user looks when they want more machine time, and
-                  it previously showed coupon minutes with no way to add any. */}
-              <div className="mt-4">
-                <RedeemCouponForm onRedeemed={() => void usageQ.refetch()} />
-              </div>
-              {usageUi.overageHours > 0 && (
-                <div className="mt-4 flex flex-col gap-1 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-600 sm:flex-row sm:items-center sm:justify-between dark:text-amber-400">
-                  <span className="font-medium">
-                    Overage: {usageUi.overageHours.toFixed(1)} h
-                  </span>
-                  <span>Estimated: {usageUi.estimatedOverageCost}</span>
-                </div>
-              )}
-            </CardContent>
-          </Card>
+                )}
+                {usageUi.overageHours > 0 && (
+                  <div className="mt-4 flex flex-col gap-1 rounded-md border border-warning/30 bg-warning/10 px-4 py-3 text-sm text-warning sm:flex-row sm:items-center sm:justify-between">
+                    <span className="font-medium">
+                      Overage: {usageUi.overageHours.toFixed(1)} h
+                    </span>
+                    <span>Estimated: {usageUi.estimatedOverageCost}</span>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </section>
 
-          <BillingEmailRow />
-
-          <div className="flex justify-end">
-            <Button
-              variant="outline"
-              onClick={handleManageStripe}
-              disabled={portalMutation.isPending}
-            >
-              <ArrowUpRight className="h-4 w-4" />
-              {portalMutation.isPending ? "Opening…" : "Manage in Stripe"}
-            </Button>
-          </div>
+          {/* ── Account settings ──────────────────────────────────────── */}
+          {/* Deliberately last and visibly quieter: the billing email and the
+              Stripe portal are things you set once, not things you read. They
+              previously sat at the same weight as the balance. */}
+          <section className="flex flex-col gap-3 border-t border-border pt-6">
+            <SectionHeading
+              title="Billing account"
+              description="Receipts, payment method, and Stripe's own portal."
+            />
+            <BillingEmailRow />
+            <div>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleManageStripe}
+                disabled={portalMutation.isPending}
+              >
+                <ArrowUpRight className="h-4 w-4" />
+                {portalMutation.isPending
+                  ? "Opening…"
+                  : "Manage payment method in Stripe"}
+              </Button>
+            </div>
+          </section>
         </>
       )}
     </div>

--- a/web/src/components/Settings/cloud/environments.tsx
+++ b/web/src/components/Settings/cloud/environments.tsx
@@ -64,6 +64,7 @@ import {
 import {
   DaemonSize,
   DaemonStatus,
+  DaemonType,
   PortAccessMode,
   createEnvironment,
   deleteDaemon,
@@ -121,6 +122,30 @@ const statusDotVariant: Record<WsStatus, StatusDotVariant> = {
 
 function daemonStatus(d: Daemon): WsStatus {
   return statusFromEnum[d.status] ?? "pending";
+}
+
+function isExternalDaemon(d: Pick<Daemon, "daemonType">): boolean {
+  return d.daemonType === DaemonType.EXTERNAL;
+}
+
+// A UUID (v4-shaped, 36 chars with dashes at the standard offsets) is not a
+// name a person chose — it's what the control-plane falls back to when a
+// self-hosted daemon connects without registering one (see
+// control-plane/internal/natsio/daemon_event_consumer.go). Render something
+// readable instead: the hostname if we have one, else a short id-derived tag.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function looksLikeBareUuid(name: string): boolean {
+  return UUID_RE.test(name.trim());
+}
+
+export function daemonDisplayName(d: Pick<Daemon, "id" | "name" | "hostname">): string {
+  const name = d.name?.trim() ?? "";
+  const isPlaceholder = !name || name === d.id || looksLikeBareUuid(name);
+  if (!isPlaceholder) return name;
+  if (d.hostname?.trim()) return d.hostname.trim();
+  const shortId = (d.id || "").slice(0, 8);
+  return shortId ? `Self-hosted machine (${shortId})` : "Self-hosted machine";
 }
 
 // ── Size tiers (plan-gated) ─────────────────────────────────────────────────
@@ -377,9 +402,15 @@ function EnvironmentsList({ onOpenDetail }: { onOpenDetail: (id: string) => void
     onError: (e) => setActionError(describeError(e, "Failed to delete machine")),
   });
 
+  // The status filter applies globally across both groups (rather than one
+  // dropdown per group) — a user picking "Suspended" wants every suspended
+  // machine, cloud or self-hosted, and a second dropdown for a section that's
+  // often empty would be clutter without a real use case.
   const daemons = (daemonsQ.data ?? []).filter(
     (d) => statusFilter === DaemonStatus.UNSPECIFIED || d.status === statusFilter,
   );
+  const managedDaemons = daemons.filter((d) => !isExternalDaemon(d));
+  const selfHostedDaemons = daemons.filter((d) => isExternalDaemon(d));
 
   return (
     <div className="space-y-4">
@@ -439,63 +470,35 @@ function EnvironmentsList({ onOpenDetail }: { onOpenDetail: (id: string) => void
           }
         />
       ) : (
-        <Table>
-          <Thead>
-            <Tr>
-              <Th>Name</Th>
-              <Th>Status</Th>
-              <Th>Resources</Th>
-              <Th>Created</Th>
-              <Th className="text-right">Actions</Th>
-            </Tr>
-          </Thead>
-          <Tbody>
-            {daemons.map((d) => {
-              const status = daemonStatus(d);
-              const badge = statusBadge[status];
-              const isSuspended = d.status === DaemonStatus.SUSPENDED;
-              const resources =
-                [d.resources?.cpuRequest, d.resources?.memoryRequest, d.storageSize]
-                  .filter(Boolean)
-                  .join(" · ") || "—";
-              const busy = suspendMut.isPending || resumeMut.isPending;
-              return (
-                <Tr key={d.id}>
-                  <Td>
-                    <button
-                      type="button"
-                      onClick={() => onOpenDetail(d.id)}
-                      className="font-medium text-foreground hover:text-primary hover:underline"
-                    >
-                      {d.name}
-                    </button>
-                  </Td>
-                  <Td>
-                    <StatusDot variant={statusDotVariant[status]} label={badge.label} />
-                  </Td>
-                  <Td className="text-muted-foreground">{resources}</Td>
-                  <Td className="text-muted-foreground">{fmtTimestamp(d.createdAt)}</Td>
-                  <Td className="text-right">
-                    <div className="inline-flex items-center gap-1">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        disabled={busy}
-                        onClick={() => (isSuspended ? resumeMut.mutate(d.id) : suspendMut.mutate(d.id))}
-                      >
-                        {isSuspended ? <Play className="h-4 w-4" /> : <Pause className="h-4 w-4" />}
-                        {isSuspended ? "Resume" : "Suspend"}
-                      </Button>
-                      <Button variant="ghost" size="sm" onClick={() => setDeleteTarget(d)}>
-                        <Trash2 className="h-4 w-4 text-destructive" />
-                      </Button>
-                    </div>
-                  </Td>
-                </Tr>
-              );
-            })}
-          </Tbody>
-        </Table>
+        <div className="space-y-6">
+          {managedDaemons.length > 0 && (
+            <div className="space-y-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Cloud machines
+              </h3>
+              <ManagedMachinesTable
+                daemons={managedDaemons}
+                onOpenDetail={onOpenDetail}
+                onDelete={setDeleteTarget}
+                onSuspend={(id) => suspendMut.mutate(id)}
+                onResume={(id) => resumeMut.mutate(id)}
+                busy={suspendMut.isPending || resumeMut.isPending}
+              />
+            </div>
+          )}
+          {selfHostedDaemons.length > 0 && (
+            <div className="space-y-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Self-hosted machines
+              </h3>
+              <SelfHostedMachinesTable
+                daemons={selfHostedDaemons}
+                onOpenDetail={onOpenDetail}
+                onRemove={setDeleteTarget}
+              />
+            </div>
+          )}
+        </div>
       )}
 
       <CreateEnvironmentModal
@@ -505,23 +508,192 @@ function EnvironmentsList({ onOpenDetail }: { onOpenDetail: (id: string) => void
         onCreated={() => { setCreateOpen(false); invalidate(); }}
       />
 
-      <Modal open={deleteTarget !== null} onClose={() => setDeleteTarget(null)} title="Delete Machine">
-        <p className="text-sm text-muted-foreground">
-          Are you sure you want to delete <span className="font-semibold text-foreground">{deleteTarget?.name}</span>?
-          This action cannot be undone.
-        </p>
-        <div className="mt-6 flex justify-end gap-3">
-          <Button variant="outline" onClick={() => setDeleteTarget(null)}>Cancel</Button>
-          <Button
-            variant="danger"
-            isLoading={deleteMut.isPending}
-            onClick={() => deleteTarget && deleteMut.mutate(deleteTarget.id)}
-          >
-            {deleteMut.isPending ? "Deleting…" : "Delete"}
-          </Button>
-        </div>
-      </Modal>
+      <RemoveMachineModal
+        target={deleteTarget}
+        isPending={deleteMut.isPending}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={() => deleteTarget && deleteMut.mutate(deleteTarget.id)}
+      />
     </div>
+  );
+}
+
+function ManagedMachinesTable({
+  daemons,
+  onOpenDetail,
+  onDelete,
+  onSuspend,
+  onResume,
+  busy,
+}: {
+  daemons: Daemon[];
+  onOpenDetail: (id: string) => void;
+  onDelete: (d: Daemon) => void;
+  onSuspend: (id: string) => void;
+  onResume: (id: string) => void;
+  busy: boolean;
+}) {
+  return (
+    <Table>
+      <Thead>
+        <Tr>
+          <Th>Name</Th>
+          <Th>Status</Th>
+          <Th>Resources</Th>
+          <Th>Created</Th>
+          <Th className="text-right">Actions</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {daemons.map((d) => {
+          const status = daemonStatus(d);
+          const badge = statusBadge[status];
+          const isSuspended = d.status === DaemonStatus.SUSPENDED;
+          const resources =
+            [d.resources?.cpuRequest, d.resources?.memoryRequest, d.storageSize]
+              .filter(Boolean)
+              .join(" · ") || "—";
+          return (
+            <Tr key={d.id}>
+              <Td>
+                <button
+                  type="button"
+                  onClick={() => onOpenDetail(d.id)}
+                  className="font-medium text-foreground hover:text-primary hover:underline"
+                >
+                  {daemonDisplayName(d)}
+                </button>
+              </Td>
+              <Td>
+                <StatusDot variant={statusDotVariant[status]} label={badge.label} />
+              </Td>
+              <Td className="text-muted-foreground">{resources}</Td>
+              <Td className="text-muted-foreground">{fmtTimestamp(d.createdAt)}</Td>
+              <Td className="text-right">
+                <div className="inline-flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={busy}
+                    onClick={() => (isSuspended ? onResume(d.id) : onSuspend(d.id))}
+                  >
+                    {isSuspended ? <Play className="h-4 w-4" /> : <Pause className="h-4 w-4" />}
+                    {isSuspended ? "Resume" : "Suspend"}
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={() => onDelete(d)}>
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </div>
+              </Td>
+            </Tr>
+          );
+        })}
+      </Tbody>
+    </Table>
+  );
+}
+
+function SelfHostedMachinesTable({
+  daemons,
+  onOpenDetail,
+  onRemove,
+}: {
+  daemons: Daemon[];
+  onOpenDetail: (id: string) => void;
+  onRemove: (d: Daemon) => void;
+}) {
+  return (
+    <Table>
+      <Thead>
+        <Tr>
+          <Th>Name</Th>
+          <Th>Status</Th>
+          <Th>Platform</Th>
+          <Th>Last seen</Th>
+          <Th className="text-right">Actions</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {daemons.map((d) => {
+          const status = daemonStatus(d);
+          const badge = statusBadge[status];
+          const connected = d.status === DaemonStatus.ACTIVE;
+          const lastSeen = connected
+            ? "Connected now"
+            : fmtTimestamp(d.disconnectedAt ?? d.lastHeartbeat);
+          return (
+            <Tr key={d.id}>
+              <Td>
+                <button
+                  type="button"
+                  onClick={() => onOpenDetail(d.id)}
+                  className="font-medium text-foreground hover:text-primary hover:underline"
+                >
+                  {daemonDisplayName(d)}
+                </button>
+              </Td>
+              <Td>
+                <StatusDot variant={statusDotVariant[status]} label={badge.label} />
+              </Td>
+              <Td className="text-muted-foreground">{d.platform || "—"}</Td>
+              <Td className="text-muted-foreground">{lastSeen}</Td>
+              <Td className="text-right">
+                <Button variant="ghost" size="sm" onClick={() => onRemove(d)}>
+                  <Trash2 className="h-4 w-4 text-destructive" /> Remove
+                </Button>
+              </Td>
+            </Tr>
+          );
+        })}
+      </Tbody>
+    </Table>
+  );
+}
+
+// Removing a self-hosted machine's row and deleting a cloud machine are
+// different actions in the user's mental model — one tears down real
+// infrastructure, the other just forgets a laptop that will reappear the
+// next time it connects (UpsertExternalDaemonConnected un-deletes on
+// reconnect). Same modal, type-conditional copy.
+function RemoveMachineModal({
+  target,
+  isPending,
+  onClose,
+  onConfirm,
+}: {
+  target: Daemon | null;
+  isPending: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  const external = target ? isExternalDaemon(target) : false;
+  const title = external ? "Forget This Machine" : "Delete Machine";
+  const confirmLabel = external ? "Forget" : "Delete";
+  const confirmingLabel = external ? "Forgetting…" : "Deleting…";
+
+  return (
+    <Modal open={target !== null} onClose={onClose} title={title}>
+      <p className="text-sm text-muted-foreground">
+        {external ? (
+          <>
+            Remove <span className="font-semibold text-foreground">{target && daemonDisplayName(target)}</span> from
+            this list? This only removes the connection record here — it does not affect the actual machine, and it
+            will reappear if that machine reconnects.
+          </>
+        ) : (
+          <>
+            Are you sure you want to delete{" "}
+            <span className="font-semibold text-foreground">{target?.name}</span>? This action cannot be undone.
+          </>
+        )}
+      </p>
+      <div className="mt-6 flex justify-end gap-3">
+        <Button variant="outline" onClick={onClose}>Cancel</Button>
+        <Button variant="danger" isLoading={isPending} onClick={onConfirm}>
+          {isPending ? confirmingLabel : confirmLabel}
+        </Button>
+      </div>
+    </Modal>
   );
 }
 
@@ -709,6 +881,7 @@ function EnvironmentDetail({ daemonId, onBack }: { daemonId: string; onBack: () 
   const connected = daemon?.status === DaemonStatus.ACTIVE;
   const isSuspended = daemon?.status === DaemonStatus.SUSPENDED;
   const busy = suspendMut.isPending || resumeMut.isPending || deleteMut.isPending;
+  const external = daemon ? isExternalDaemon(daemon) : false;
 
   return (
     <div className="space-y-6">
@@ -730,16 +903,18 @@ function EnvironmentDetail({ daemonId, onBack }: { daemonId: string; onBack: () 
         <>
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-wrap items-center gap-3">
-              <h2 className="text-xl font-semibold text-foreground">{daemon.name}</h2>
+              <h2 className="text-xl font-semibold text-foreground">{daemonDisplayName(daemon)}</h2>
               <Badge label={badge.label} variant={badge.variant} />
               <Badge label={connected ? "Connected" : "Disconnected"} variant={connected ? "success" : "neutral"} />
             </div>
             <div className="flex flex-wrap items-center gap-2">
-              <Button variant="outline" disabled={busy} onClick={() => (isSuspended ? resumeMut.mutate() : suspendMut.mutate())}>
-                {isSuspended ? <><Play className="h-4 w-4" /> Resume</> : <><Pause className="h-4 w-4" /> Suspend</>}
-              </Button>
+              {!external && (
+                <Button variant="outline" disabled={busy} onClick={() => (isSuspended ? resumeMut.mutate() : suspendMut.mutate())}>
+                  {isSuspended ? <><Play className="h-4 w-4" /> Resume</> : <><Pause className="h-4 w-4" /> Suspend</>}
+                </Button>
+              )}
               <Button variant="danger" disabled={busy} onClick={() => setDeleteOpen(true)}>
-                <Trash2 className="h-4 w-4" /> Delete
+                <Trash2 className="h-4 w-4" /> {external ? "Remove" : "Delete"}
               </Button>
             </div>
           </div>
@@ -751,8 +926,17 @@ function EnvironmentDetail({ daemonId, onBack }: { daemonId: string; onBack: () 
               <CardHeader><CardTitle className="inline-flex items-center gap-2"><Server className="h-4 w-4 text-muted-foreground" /> Overview</CardTitle></CardHeader>
               <CardContent>
                 <dl>
-                  <InfoRow label="Size" value={sizeLabel[daemon.size] ?? "Custom"} />
-                  <InfoRow label="Storage" value={daemon.storageSize} />
+                  {external ? (
+                    <>
+                      <InfoRow label="Hostname" value={daemon.hostname} />
+                      <InfoRow label="Platform" value={daemon.platform} />
+                    </>
+                  ) : (
+                    <>
+                      <InfoRow label="Size" value={sizeLabel[daemon.size] ?? "Custom"} />
+                      <InfoRow label="Storage" value={daemon.storageSize} />
+                    </>
+                  )}
                   <InfoRow label="Created" value={fmtTimestamp(daemon.createdAt)} />
                   <InfoRow label="Updated" value={fmtTimestamp(daemon.updatedAt)} />
                 </dl>
@@ -764,7 +948,7 @@ function EnvironmentDetail({ daemonId, onBack }: { daemonId: string; onBack: () 
                 <dl>
                   <InfoRow label="Connection" value={<Badge label={connected ? "Connected" : "Disconnected"} variant={connected ? "success" : "neutral"} />} />
                   <InfoRow label="Connected at" value={fmtTimestamp(daemon.connectedAt)} />
-                  <InfoRow label="Idle timeout" value={daemon.idleTimeout || "Not set"} />
+                  {!external && <InfoRow label="Idle timeout" value={daemon.idleTimeout || "Not set"} />}
                   <InfoRow label="Last status" value={daemon.lastStatusMessage} />
                 </dl>
               </CardContent>
@@ -773,18 +957,12 @@ function EnvironmentDetail({ daemonId, onBack }: { daemonId: string; onBack: () 
 
           <PortAccessPanel daemonId={daemon.id} workspaceBaseDomain={workspaceBaseDomain} />
 
-          <Modal open={deleteOpen} onClose={() => setDeleteOpen(false)} title="Delete Machine">
-            <p className="text-sm text-muted-foreground">
-              Are you sure you want to delete <span className="font-semibold text-foreground">{daemon.name}</span>?
-              This action cannot be undone.
-            </p>
-            <div className="mt-6 flex justify-end gap-3">
-              <Button variant="outline" onClick={() => setDeleteOpen(false)}>Cancel</Button>
-              <Button variant="danger" isLoading={deleteMut.isPending} onClick={() => deleteMut.mutate()}>
-                {deleteMut.isPending ? "Deleting…" : "Delete"}
-              </Button>
-            </div>
-          </Modal>
+          <RemoveMachineModal
+            target={deleteOpen ? daemon : null}
+            isPending={deleteMut.isPending}
+            onClose={() => setDeleteOpen(false)}
+            onConfirm={() => deleteMut.mutate()}
+          />
         </>
       )}
     </div>

--- a/web/src/components/Settings/cloud/reliantAI.tsx
+++ b/web/src/components/Settings/cloud/reliantAI.tsx
@@ -337,7 +337,32 @@ function ReliantAIPanel() {
                     </div>
                   </div>
                 )}
-                <RedeemCouponForm className="mt-4" />
+                {/* Secondary by design. Billing owns the canonical redemption
+                    card — it explains that one code covers credit OR machine
+                    minutes, and shows both balances. This one stays because a
+                    user staring at an empty AI balance should not have to
+                    navigate away to fix it, but it points at the fuller
+                    surface rather than competing with it. */}
+                <div className="mt-6 border-t border-border pt-4">
+                  <RedeemCouponForm size="sm" />
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Coupons can add account credit or machine minutes — the same
+                    code works either way.{" "}
+                    <button
+                      type="button"
+                      onClick={() =>
+                        navigate({
+                          to: "/settings/$section",
+                          params: { section: "billing" },
+                        })
+                      }
+                      className="underline underline-offset-2 hover:text-foreground"
+                    >
+                      Billing
+                    </button>{" "}
+                    has the full view.
+                  </p>
+                </div>
               </CardContent>
             </Card>
 
@@ -381,7 +406,7 @@ function ReliantAIPanel() {
                   </div>
                 </div>
                 {overview?.spendCapReached && (
-                  <p className="mt-3 text-sm text-amber-600">
+                  <p className="mt-3 text-sm text-warning">
                     Your monthly spend cap has been reached.
                   </p>
                 )}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -143,24 +143,24 @@
 
   .dark {
     /* VIBRANT BLUE DARK THEME - colorful & modern */
-    --background: 222 47% 11%;       /* Deep blue-gray */
+    --background: 222 47% 11%;       /* Page — the darkest surface */
     --foreground: 210 40% 98%;       /* Soft white text */
-    --card: 222 47% 13%;
+    --card: 222 47% 17%;             /* Lifted a full step above the page */
     --card-foreground: 210 40% 98%;
-    --popover: 222 47% 13%;
+    --popover: 222 47% 22%;          /* Floats above cards */
     --popover-foreground: 210 40% 98%;
     --primary: 217 91% 70%;          /* Bright blue */
     --primary-foreground: 222 47% 11%;
     --secondary: 280 85% 70%;        /* Purple accent */
     --secondary-foreground: 222 47% 11%;
-    --muted: 217 33% 17%;            /* Dark blue-gray */
+    --muted: 217 33% 21%;            /* Reads against the lifted card */
     --muted-foreground: 215 20% 65%;
-    --accent: 217 33% 17%;           /* Dark blue accent */
+    --accent: 217 33% 21%;           /* Kept in step with --muted */
     --accent-foreground: 210 40% 98%;
     --destructive: 0 70% 55%;
     --destructive-foreground: 0 0% 100%;
-    --border: 217 33% 24%;           /* Dark blue-gray border */
-    --input: 217 33% 24%;
+    --border: 217 33% 32%;           /* Carries the card edge on its own */
+    --input: 217 33% 32%;
     --ring: 217 91% 70%;
 
     /* Code colors fallback (before themed data attributes apply) */
@@ -188,11 +188,13 @@
     --status-processing: 199 89% 58%;
     --status-pending: 280 85% 65%;
 
-    /* Dark elevation - use theme colors */
+    /* Dark elevation — must climb in the same order as .elevation-0..5.
+       Previously raised=muted sat ABOVE overlay=card, so elevation-1 rendered
+       lighter than elevation-2 and the ladder read backwards. */
     --surface-base: var(--background);
-    --surface-raised: var(--muted);
-    --surface-overlay: var(--card);
-    --surface-modal: var(--card);
+    --surface-raised: var(--card);
+    --surface-overlay: var(--popover);
+    --surface-modal: var(--popover);
 
     /* Chat input colors - better contrast for dark mode */
     --chat-input-bg: hsl(217 33% 20%);        /* Slightly lighter than muted */

--- a/web/src/lib/keyboard/__tests__/bindings.test.ts
+++ b/web/src/lib/keyboard/__tests__/bindings.test.ts
@@ -125,6 +125,30 @@ describe("shortcut definitions", () => {
       expect(result.shortcut?.id).toBe("stopStreaming");
     });
 
+    it("closes the modal instead of pausing the chat behind it", () => {
+      // The regression this guards: with an open modal, Escape resolved to
+      // stopStreaming and paused the underlying chat. Search, file search and
+      // every other overlay looked like they were "eating" Escape when they
+      // were in fact closing AND pausing the chat behind them.
+      const registry = buildRegistry(MAC_DESKTOP);
+      const result = registry.resolve("Escape", ["modal", "global"]);
+
+      expect(result.shortcut?.id).toBe("dismissModal");
+    });
+
+    it("closes the modal even while its search box has focus", () => {
+      // Every one of these overlays autofocuses a text input, so the modal
+      // context is almost never active on its own.
+      const registry = buildRegistry(MAC_DESKTOP);
+      const result = registry.resolve("Escape", [
+        "modal",
+        "chat-input",
+        "global",
+      ]);
+
+      expect(result.shortcut?.id).toBe("dismissModal");
+    });
+
     it("closes the slash menu instead of stopping the response", () => {
       // The regression this guards: without a slash-menu entry the global
       // Escape wins and the menu cannot be dismissed with the keyboard.

--- a/web/src/lib/keyboard/__tests__/modal-escape.test.ts
+++ b/web/src/lib/keyboard/__tests__/modal-escape.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Escape while a modal is open, end to end through DOM context detection.
+ *
+ * registry.test and bindings.test resolve against a hand-supplied context list.
+ * The bug this file guards lived in the step BEFORE that: the modal is detected
+ * from the DOM via `data-modal-open`, and if that detection does not run, the
+ * dispatcher never enters the `modal` context and Escape falls through to
+ * stopStreaming — which pauses the chat sitting behind the modal.
+ *
+ * So these drive the real detectActiveContexts against a real DOM node.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { defaultShortcuts } from "../../../store/shortcutsData.generated";
+import { parseBinding } from "../chord";
+import { ShortcutRegistry, type ResolvedShortcut } from "../registry";
+import { createDispatcher } from "../dispatcher";
+
+function buildRegistry(): ShortcutRegistry {
+  const resolved: ResolvedShortcut[] = Object.values(defaultShortcuts).map(
+    (shortcut) => ({
+      id: shortcut.id,
+      handler: shortcut.handler,
+      binding: parseBinding(shortcut.defaultBinding, true),
+      context: shortcut.context,
+      allowInInput: shortcut.allowInInput,
+      passthrough: shortcut.passthrough,
+    }),
+  );
+  return new ShortcutRegistry(resolved);
+}
+
+/** Mount a modal the way the app's overlays do, and focus its search input. */
+function openModal(): HTMLInputElement {
+  const overlay = document.createElement("div");
+  overlay.setAttribute("data-modal-open", "true");
+  const input = document.createElement("input");
+  overlay.appendChild(input);
+  document.body.appendChild(overlay);
+  input.focus();
+  return input;
+}
+
+function pressEscape(target: Element) {
+  const calls: string[] = [];
+  const dispatcher = createDispatcher({
+    registry: buildRegistry(),
+    getHandler: (name) => () => calls.push(name),
+  });
+
+  const event = new KeyboardEvent("keydown", {
+    key: "Escape",
+    cancelable: true,
+    bubbles: true,
+  });
+  Object.defineProperty(event, "target", { value: target });
+
+  dispatcher.handleKeyDown(event);
+  return calls;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("Escape with a modal open", () => {
+  it("closes the modal and does not pause the chat behind it", () => {
+    const input = openModal();
+
+    const calls = pressEscape(input);
+
+    expect(calls).toEqual(["onDismissModal"]);
+    expect(calls).not.toContain("onStopStreaming");
+  });
+
+  it("stops the response again once the modal closes", () => {
+    // The modal context must be transient: after the overlay unmounts, Escape
+    // goes back to being the "stop the AI" key.
+    openModal();
+    document.body.innerHTML = "";
+
+    expect(pressEscape(document.body)).toEqual(["onStopStreaming"]);
+  });
+
+  it("is not fooled by a closed modal left in the tree", () => {
+    // Overlays render `data-modal-open` only while open, so a node without the
+    // attribute must not put us in the modal context.
+    const overlay = document.createElement("div");
+    overlay.setAttribute("data-modal-open", "false");
+    document.body.appendChild(overlay);
+
+    expect(pressEscape(document.body)).toEqual(["onStopStreaming"]);
+  });
+});

--- a/web/src/lib/keyboard/__tests__/registry.test.ts
+++ b/web/src/lib/keyboard/__tests__/registry.test.ts
@@ -116,6 +116,26 @@ describe("ShortcutRegistry.resolve", () => {
       const result = registry.resolve("C", ["chat-input", "global"], "meta+K");
       expect(result.kind).toBe("match");
     });
+
+    it("completes when the user keeps Cmd held for the second key", () => {
+      // Cmd+K then Cmd+C. Holding the modifier through the sequence is how
+      // most people type it (and what VS Code accepts), but it arrives as
+      // "meta+C" — which matched nothing, so every Cmd+K binding appeared
+      // dead unless the user released Cmd first.
+      const result = registry.resolve("meta+C", ["global"], "meta+K");
+      expect(result.kind).toBe("match");
+      expect(result.shortcut?.id).toBe("gotoChats");
+    });
+
+    it("does not invent a match from an unrelated held modifier", () => {
+      // Only modifiers carried over FROM the prefix are dropped. Alt was never
+      // part of Cmd+K, so the user meant something else and this stays unbound.
+      expect(registry.resolve("alt+C", ["global"], "meta+K").kind).toBe("none");
+    });
+
+    it("keeps a held prefix modifier from resurrecting an unknown key", () => {
+      expect(registry.resolve("meta+Z", ["global"], "meta+K").kind).toBe("none");
+    });
   });
 
   it("finds shortcuts that shadow each other in the same context", () => {

--- a/web/src/lib/keyboard/chord.ts
+++ b/web/src/lib/keyboard/chord.ts
@@ -185,6 +185,53 @@ export function isSequence(binding: string): boolean {
   return binding.includes(" ");
 }
 
+/** Modifier tokens in the canonical order they are serialized in. */
+const MODIFIER_TOKENS = ["ctrl", "meta", "shift", "alt"] as const;
+
+/**
+ * Split a canonical chord into its modifiers and its key.
+ *
+ * Scans in canonical order rather than splitting on "+", so a chord whose key
+ * IS "+" ("meta++") survives the round trip.
+ */
+function splitChord(chord: string): { mods: string[]; key: string } {
+  const mods: string[] = [];
+  let rest = chord;
+
+  for (const mod of MODIFIER_TOKENS) {
+    if (rest.startsWith(`${mod}+`)) {
+      mods.push(mod);
+      rest = rest.slice(mod.length + 1);
+    }
+  }
+
+  return { mods, key: rest };
+}
+
+/**
+ * Drop modifiers the user is still holding down from the sequence prefix.
+ *
+ * `Cmd+K G` gets typed two ways: release Cmd before pressing G, or keep Cmd
+ * held and press G (the muscle memory every VS Code user brings with them).
+ * The held form arrives as `meta+G`, which matches no binding, so the sequence
+ * died silently and the whole Cmd+K family looked broken.
+ *
+ * Once a prefix is armed the next keystroke belongs to us alone, so a modifier
+ * carried over from the prefix is noise rather than intent. Only modifiers that
+ * were part of the prefix are dropped — a Shift the user added themselves is
+ * still theirs, so a future `Cmd+K Shift+X` stays distinct.
+ */
+export function stripHeldModifiers(chord: string, prefix: string): string {
+  const held = new Set(splitChord(prefix).mods);
+  if (held.size === 0) return chord;
+
+  const { mods, key } = splitChord(chord);
+  const kept = mods.filter((mod) => !held.has(mod));
+  if (kept.length === mods.length) return chord;
+
+  return [...kept, key].join("+");
+}
+
 /** The first chord of a canonical sequence — the prefix that opens it. */
 export function sequencePrefix(binding: string): string {
   return binding.split(" ")[0];

--- a/web/src/lib/keyboard/registry.ts
+++ b/web/src/lib/keyboard/registry.ts
@@ -8,7 +8,7 @@
  * Resolution is pure and synchronous so it can be unit-tested without a DOM.
  */
 
-import { isSequence, sequencePrefix } from "./chord";
+import { isSequence, sequencePrefix, stripHeldModifiers } from "./chord";
 import { contextRank, isTextEntryContext } from "./contexts";
 
 export interface ResolvedShortcut {
@@ -84,7 +84,10 @@ export class ShortcutRegistry {
     activeContexts: readonly string[],
     pending = "",
   ): ResolveResult {
-    const lookup = pending ? `${pending} ${chord}` : chord;
+    // A modifier still held from the prefix is not part of the second chord —
+    // see stripHeldModifiers for why Cmd+K then Cmd+G must reach `meta+K G`.
+    const completion = pending ? stripHeldModifiers(chord, pending) : chord;
+    const lookup = pending ? `${pending} ${completion}` : chord;
     const candidates = this.byBinding.get(lookup);
 
     if (candidates) {

--- a/web/src/store/__tests__/chatNavigationStore.attention.test.ts
+++ b/web/src/store/__tests__/chatNavigationStore.attention.test.ts
@@ -1,0 +1,218 @@
+/**
+ * "Jump to the next chat that needs me."
+ *
+ * With a dozen chats running, next/prev is the wrong tool for triage — it walks
+ * everything, including the chats happily working away. These cover the triage
+ * move: only chats blocked on the user, in sidebar order, cycling and wrapping
+ * so repeated presses drain the queue instead of bouncing between two.
+ */
+
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { useChatNavigationStore } from "../chatNavigationStore";
+import { useProjectStore } from "../projectStore";
+import { useWorktreeStore } from "../worktreeStore";
+import { useActivityStore, ChatActivity } from "../activityStore";
+import { chatKeys } from "../../hooks/chat-queries";
+import { queryClient } from "../../lib/query-client";
+
+const selectChatMock = vi.fn();
+const chatStoreGetStateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../chatStore", () => ({
+  useChatStore: { getState: chatStoreGetStateMock },
+}));
+
+const TIMESTAMP = new Date("2026-01-01T00:00:00Z").toISOString();
+
+function makeChat(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    title: id,
+    worktreeId: "wt-1",
+    state: 0,
+    unread: false,
+    createdAt: TIMESTAMP,
+    updatedAt: TIMESTAMP,
+    lastMessageAt: TIMESTAMP,
+    ...overrides,
+  };
+}
+
+/** Seed the chat list cache the sidebar and navigation both read from. */
+function seedChats(chats: ReturnType<typeof makeChat>[]) {
+  queryClient.setQueryData(chatKeys.list("project-1"), {
+    chats,
+    total: chats.length,
+    lastUserUpdateSequence: 1,
+  });
+}
+
+function setActive(chatId: string | null) {
+  chatStoreGetStateMock.mockReturnValue({
+    activeChatId: chatId,
+    selectChat: selectChatMock,
+    clearCurrentChat: vi.fn(),
+  });
+}
+
+describe("navigateToNextAttention", () => {
+  beforeEach(() => {
+    queryClient.clear();
+    selectChatMock.mockReset();
+    chatStoreGetStateMock.mockReset();
+    setActive(null);
+
+    useActivityStore.setState({ activities: new Map() });
+
+    useChatNavigationStore.setState({
+      chatQueue: [],
+      showRecentChanges: {},
+      scrollPosition: {},
+    });
+
+    useProjectStore.setState({
+      currentProject: {
+        id: "project-1",
+        name: "Project",
+        path: "/tmp/project",
+        is_git_repo: true,
+        worktree_count: 1,
+        last_active: TIMESTAMP,
+        created_at: TIMESTAMP,
+        updated_at: TIMESTAMP,
+      },
+    });
+
+    useWorktreeStore.setState((state) => ({
+      ...state,
+      worktrees: [
+        {
+          id: "wt-1",
+          name: "Workspace 1",
+          path: "/tmp/project/wt-1",
+          branch: "feature/a",
+          base_branch: "main",
+          project_id: "project-1",
+          status: 0,
+          is_main: false,
+          created_at: TIMESTAMP,
+          updated_at: TIMESTAMP,
+          last_active: TIMESTAMP,
+        },
+      ],
+      currentWorktree: null,
+      switchWorktreeContext: vi.fn().mockResolvedValue(undefined),
+    }));
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("skips busy chats and lands on the one awaiting approval", async () => {
+    seedChats([makeChat("chat-1"), makeChat("chat-2"), makeChat("chat-3")]);
+    useActivityStore.setState({
+      activities: new Map([
+        ["chat-1", ChatActivity.RUNNING],
+        ["chat-3", ChatActivity.AWAITING_INPUT],
+      ]),
+    });
+    setActive("chat-1");
+
+    const found = await useChatNavigationStore
+      .getState()
+      .navigateToNextAttention();
+
+    expect(found).toBe(true);
+    expect(selectChatMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "chat-3" }),
+    );
+  });
+
+  it("treats errored and unread chats as needing attention", async () => {
+    seedChats([makeChat("chat-1"), makeChat("chat-2", { unread: true })]);
+    useActivityStore.setState({
+      activities: new Map([["chat-1", ChatActivity.RUNNING]]),
+    });
+    setActive("chat-1");
+
+    await useChatNavigationStore.getState().navigateToNextAttention();
+    expect(selectChatMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "chat-2" }),
+    );
+
+    selectChatMock.mockReset();
+    seedChats([makeChat("chat-1"), makeChat("chat-2")]);
+    useActivityStore.setState({
+      activities: new Map([
+        ["chat-1", ChatActivity.RUNNING],
+        ["chat-2", ChatActivity.ERROR],
+      ]),
+    });
+
+    await useChatNavigationStore.getState().navigateToNextAttention();
+    expect(selectChatMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "chat-2" }),
+    );
+  });
+
+  it("cycles through waiting chats rather than sticking on the first", async () => {
+    // Two chats waiting: pressing the shortcut from the first must advance to
+    // the second, not re-select the one already on screen.
+    seedChats([
+      makeChat("chat-1", { unread: true }),
+      makeChat("chat-2", { unread: true }),
+    ]);
+    setActive("chat-1");
+
+    await useChatNavigationStore.getState().navigateToNextAttention();
+
+    expect(selectChatMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "chat-2" }),
+    );
+  });
+
+  it("wraps around to the top of the list", async () => {
+    seedChats([
+      makeChat("chat-1", { unread: true }),
+      makeChat("chat-2"),
+      makeChat("chat-3"),
+    ]);
+    setActive("chat-3");
+
+    await useChatNavigationStore.getState().navigateToNextAttention();
+
+    expect(selectChatMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "chat-1" }),
+    );
+  });
+
+  it("reports nothing to do when no chat is waiting", async () => {
+    seedChats([makeChat("chat-1"), makeChat("chat-2")]);
+    useActivityStore.setState({
+      activities: new Map([["chat-1", ChatActivity.RUNNING]]),
+    });
+    setActive("chat-1");
+
+    const found = await useChatNavigationStore
+      .getState()
+      .navigateToNextAttention();
+
+    expect(found).toBe(false);
+    expect(selectChatMock).not.toHaveBeenCalled();
+  });
+
+  it("stays put when the active chat is the only one waiting", async () => {
+    // Reporting success without navigating keeps the caller from claiming
+    // "nothing needs you" while the current chat is visibly blocked.
+    seedChats([makeChat("chat-1", { unread: true }), makeChat("chat-2")]);
+    setActive("chat-1");
+
+    const found = await useChatNavigationStore
+      .getState()
+      .navigateToNextAttention();
+
+    expect(found).toBe(true);
+    expect(selectChatMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/store/chatNavigationStore.ts
+++ b/web/src/store/chatNavigationStore.ts
@@ -38,6 +38,27 @@ import type { Chat } from "../api/client";
 import { useActivityStore, activityToDotState, ChatActivity } from "./activityStore";
 import { getCachedChatList, getChatFromCache } from "../hooks/chat-queries";
 
+/**
+ * Whether a chat is blocked on the user.
+ *
+ * Three ways a chat can want you, and they are deliberately treated alike by
+ * the triage shortcut: it is waiting on an approval, it failed and needs a
+ * decision, or it has said something you have not read. This is the same rule
+ * the sidebar's "Needs Attention" sort uses, kept in one place so the shortcut
+ * and the list can never disagree about what is waiting.
+ */
+export function chatNeedsAttention(
+  chat: Chat,
+  activities: Map<string, ChatActivity>,
+): boolean {
+  const activity = activities.get(chat.id) ?? ChatActivity.IDLE;
+  return (
+    activity === ChatActivity.AWAITING_INPUT ||
+    activity === ChatActivity.ERROR ||
+    chat.unread
+  );
+}
+
 async function selectChatWithWorktreeContext(chat: Chat): Promise<void> {
   const projectId = useProjectStore.getState().currentProject?.id;
   if (projectId) {
@@ -252,6 +273,8 @@ interface ChatNavigationState {
   navigateToChat: (chatId: string) => void;
   navigateNext: () => Promise<void>;
   navigatePrev: () => Promise<void>;
+  /** Jump to the next chat blocked on the user. Returns false when none are. */
+  navigateToNextAttention: () => Promise<boolean>;
 
   // Queue management
   removeFromQueue: (chatId: string) => Promise<void>;
@@ -398,6 +421,53 @@ export const useChatNavigationStore = create<ChatNavigationState>((set, get) => 
     });
 
     await selectChatWithWorktreeContext(prevChat);
+  },
+
+  // Jump to the next chat that is waiting on the user.
+  //
+  // Cycles rather than always landing on the first: starting from the chat
+  // after the active one and wrapping means repeated presses walk the whole
+  // queue instead of bouncing between the top two. The active chat is checked
+  // last so a chat you are already looking at is where you end up only when it
+  // is the only one waiting.
+  navigateToNextAttention: async () => {
+    const orderedChats = await getOrderedChatList();
+    if (orderedChats.length === 0) return false;
+
+    const activities = useActivityStore.getState().activities;
+    const { useChatStore } = await import("./chatStore");
+    const activeChatId = useChatStore.getState().activeChatId;
+
+    const currentIndex = orderedChats.findIndex((c) => c.id === activeChatId);
+
+    // Rotate so the search starts just past the active chat and wraps.
+    const rotated =
+      currentIndex === -1
+        ? orderedChats
+        : [
+            ...orderedChats.slice(currentIndex + 1),
+            ...orderedChats.slice(0, currentIndex + 1),
+          ];
+
+    const target = rotated.find((chat) => chatNeedsAttention(chat, activities));
+
+    if (!target) {
+      logger.info("[ChatNavigation] No chats need attention");
+      return false;
+    }
+
+    if (target.id === activeChatId) {
+      logger.info("[ChatNavigation] Already on the only chat needing attention");
+      return true;
+    }
+
+    logger.info("[ChatNavigation] Navigate to chat needing attention", {
+      from: activeChatId?.slice(0, 8),
+      to: target.id.slice(0, 8),
+    });
+
+    await selectChatWithWorktreeContext(target);
+    return true;
   },
 
   // Remove a specific chat from queue (e.g., when archived)

--- a/web/src/store/shortcutsData.generated.ts
+++ b/web/src/store/shortcutsData.generated.ts
@@ -312,6 +312,16 @@ export const defaultShortcuts: Record<string, Omit<ShortcutDefinition, 'currentB
     context: 'global',
     handler: 'onSwitchWorktree'
   },
+  nextAttentionChat: {
+    id: 'nextAttentionChat',
+    name: 'Next Chat Needing Attention',
+    description: 'Jump to the next chat waiting on you (approval, error, or unread)',
+    category: 'Chat Navigation',
+    defaultBinding: 'Cmd+K D',
+    defaultWebBinding: 'Cmd+K D',
+    context: 'global',
+    handler: 'onNextAttentionChat'
+  },
   switchProject: {
     id: 'switchProject',
     name: 'Switch Project',
@@ -592,6 +602,17 @@ export const defaultShortcuts: Record<string, Omit<ShortcutDefinition, 'currentB
     defaultWebBinding: 'Cmd+/',
     context: 'global',
     handler: 'onSlashCommands'
+  },
+  dismissModal: {
+    id: 'dismissModal',
+    name: 'Close Modal',
+    description: 'Close the open dialog or overlay',
+    category: 'Interface',
+    defaultBinding: 'Escape',
+    defaultWebBinding: 'Escape',
+    context: 'modal',
+    handler: 'onDismissModal',
+    allowInInput: true
   },
   dismissSlashMenu: {
     id: 'dismissSlashMenu',

--- a/web/src/themes/professional-themes.css
+++ b/web/src/themes/professional-themes.css
@@ -25,7 +25,7 @@
   --accent: 210 40% 96%;            /* Light blue accent */
   --accent-foreground: 217 91% 60%;
   --ring: 217 91% 60%;
-  --border: 214 32% 91%;            /* Light blue-gray border */
+  --border: 214 32% 86%;            /* Light blue-gray border */
 
   /* Config panel input surfaces */
   --config-input-bg: 210 40% 96%;
@@ -59,25 +59,25 @@
 }
 
 .dark[data-color-scheme="professional-blue"] {
-  --background: 222 47% 11%;        /* Deep blue-gray background */
+  --background: 222 47% 11%;        /* Page — the darkest surface */
   --foreground: 210 40% 98%;
-  --card: 222 47% 13%;              /* Slightly lighter blue-gray for cards */
+  --card: 222 47% 17%;              /* Lifted a full step above the page */
   --card-foreground: 210 40% 98%;
-  --popover: 222 47% 15%;           /* Popover/dropdown background - slightly lighter */
+  --popover: 222 47% 22%;           /* Floats above cards */
   --popover-foreground: 210 40% 98%;
-  --surface-modal: 222 47% 13%;     /* Modal background */
-  --muted: 217 33% 17%;             /* Dark blue-gray for muted areas */
+  --surface-modal: 222 47% 22%;     /* Modals sit at popover elevation */
+  --muted: 217 33% 21%;             /* Reads against the lifted card */
   --muted-foreground: 215 20% 65%;
   --primary: 217 91% 70%;           /* Bright blue for dark mode */
   --primary-foreground: 222 47% 11%;
-  --accent: 217 33% 17%;            /* Dark blue accent */
+  --accent: 217 33% 21%;            /* Kept in step with --muted */
   --accent-foreground: 210 40% 98%;
   --ring: 217 91% 70%;
-  --border: 217 33% 24%;            /* Dark blue-gray border */
+  --border: 217 33% 32%;            /* Carries the card edge on its own */
 
-  /* Config panel input surfaces */
-  --config-input-bg: 217 33% 18%;
-  --config-input-border: 217 33% 32%;
+  /* Config panel input surfaces — recessed wells below the card */
+  --config-input-bg: 217 33% 13%;
+  --config-input-border: 217 33% 38%;
 
   /* Tab colors */
   --tab-active: 217 91% 70%;
@@ -131,7 +131,7 @@
   --accent: 30 20% 97%;             /* Creamy white */
   --accent-foreground: 25 22% 28%;
   --ring: 25 22% 28%;
-  --border: 30 12% 90%;             /* Warm border */
+  --border: 30 12% 85%;             /* Warm border */
 
   /* Config panel input surfaces */
   --config-input-bg: 30 15% 95%;
@@ -165,25 +165,25 @@
 }
 
 .dark[data-color-scheme="refined-neutral"] {
-  --background: 25 20% 14%;         /* Deep warm brown */
+  --background: 25 20% 14%;         /* Page — the darkest surface */
   --foreground: 30 18% 90%;
-  --card: 25 20% 16%;               /* Slightly lighter warm cards */
+  --card: 25 20% 20%;               /* Lifted a full step above the page */
   --card-foreground: 30 18% 90%;
-  --popover: 25 20% 18%;            /* Popover/dropdown background - slightly lighter */
+  --popover: 25 20% 25%;            /* Floats above cards */
   --popover-foreground: 30 18% 90%;
-  --surface-modal: 25 20% 16%;      /* Modal background */
-  --muted: 30 12% 20%;              /* Deep warm gray */
-  --muted-foreground: 30 15% 60%;
+  --surface-modal: 25 20% 25%;      /* Modals sit at popover elevation */
+  --muted: 30 12% 24%;              /* Reads against the lifted card */
+  --muted-foreground: 30 15% 67%;   /* Raised to hold AA on the lifted surfaces */
   --primary: 30 18% 88%;            /* Warm light on dark */
   --primary-foreground: 25 20% 14%;
-  --accent: 30 12% 20%;             /* Deep warm gray */
+  --accent: 30 12% 24%;             /* Kept in step with --muted */
   --accent-foreground: 30 18% 88%;
   --ring: 30 18% 82%;
-  --border: 30 10% 24%;             /* Warm dark border */
+  --border: 30 10% 34%;             /* Carries the card edge on its own */
 
-  /* Config panel input surfaces */
-  --config-input-bg: 30 12% 20%;
-  --config-input-border: 30 10% 32%;
+  /* Config panel input surfaces — recessed wells below the card */
+  --config-input-bg: 30 12% 16%;
+  --config-input-border: 30 10% 40%;
 
   /* Tab colors */
   --tab-active: 30 18% 88%;
@@ -237,7 +237,7 @@
   --accent: 180 82% 96%;            /* Light teal accent */
   --accent-foreground: 180 82% 32%;
   --ring: 180 88% 42%;
-  --border: 185 12% 89%;            /* Subtle teal border */
+  --border: 185 12% 84%;            /* Subtle teal border */
 
   /* Config panel input surfaces */
   --config-input-bg: 185 14% 95%;
@@ -271,25 +271,25 @@
 }
 
 .dark[data-color-scheme="modern-teal"] {
-  --background: 185 20% 12%;        /* Deep teal-gray background */
+  --background: 185 20% 12%;        /* Page — the darkest surface */
   --foreground: 185 12% 92%;
-  --card: 185 20% 14%;              /* Slightly lighter teal cards */
+  --card: 185 20% 18%;              /* Lifted a full step above the page */
   --card-foreground: 185 12% 92%;
-  --popover: 185 20% 17%;             /* Popover/dropdown background */
+  --popover: 185 20% 24%;           /* Floats above cards */
   --popover-foreground: 185 12% 92%;
-  --surface-modal: 185 20% 14%;     /* Modal background */
-  --muted: 185 14% 22%;             /* Deep teal-gray */
-  --muted-foreground: 185 12% 65%;
+  --surface-modal: 185 20% 24%;     /* Modals sit at popover elevation */
+  --muted: 185 14% 23%;             /* Reads against the lifted card */
+  --muted-foreground: 185 12% 67%;  /* Raised to hold AA on the lifted surfaces */
   --primary: 180 82% 56%;           /* Bright teal on dark */
   --primary-foreground: 0 0% 100%;
-  --accent: 185 14% 22%;            /* Deep teal-gray */
+  --accent: 185 14% 23%;            /* Kept in step with --muted */
   --accent-foreground: 185 12% 90%;
   --ring: 180 82% 56%;
-  --border: 185 12% 23%;            /* Dark teal border */
+  --border: 185 12% 32%;            /* Carries the card edge on its own */
 
-  /* Config panel input surfaces */
-  --config-input-bg: 185 14% 18%;
-  --config-input-border: 185 12% 30%;
+  /* Config panel input surfaces — recessed wells below the card */
+  --config-input-bg: 185 14% 14%;
+  --config-input-border: 185 12% 38%;
 
   /* Tab colors */
   --tab-active: 180 82% 56%;
@@ -342,7 +342,7 @@
   --accent: 215 24% 96%;            /* Light cool slate */
   --accent-foreground: 215 28% 32%;
   --ring: 215 28% 32%;
-  --border: 215 16% 89%;            /* Subtle cool border */
+  --border: 215 16% 84%;            /* Subtle cool border */
 
   /* Config panel input surfaces */
   --config-input-bg: 215 18% 94%;
@@ -376,25 +376,25 @@
 }
 
 .dark[data-color-scheme="slate"] {
-  --background: 215 22% 13%;        /* Deep cool slate background */
+  --background: 215 22% 13%;        /* Page — the darkest surface */
   --foreground: 215 20% 94%;
-  --card: 215 22% 15%;              /* Slightly lighter slate cards */
+  --card: 215 22% 19%;              /* Lifted a full step above the page */
   --card-foreground: 215 20% 94%;
-  --popover: 215 22% 18%;             /* Popover/dropdown background */
+  --popover: 215 22% 25%;           /* Floats above cards */
   --popover-foreground: 215 20% 94%;
-  --surface-modal: 215 22% 15%;     /* Modal background */
-  --muted: 215 18% 22%;             /* Deep cool slate */
-  --muted-foreground: 215 16% 65%;
+  --surface-modal: 215 22% 25%;     /* Modals sit at popover elevation */
+  --muted: 215 18% 24%;             /* Reads against the lifted card */
+  --muted-foreground: 215 16% 67%;  /* Raised to hold AA on the lifted surfaces */
   --primary: 215 82% 62%;           /* Bright slate blue on dark */
   --primary-foreground: 0 0% 100%;
-  --accent: 215 18% 22%;            /* Deep cool slate */
+  --accent: 215 18% 24%;            /* Kept in step with --muted */
   --accent-foreground: 215 20% 92%;
   --ring: 215 82% 62%;
-  --border: 215 16% 24%;            /* Dark cool border */
+  --border: 215 16% 33%;            /* Carries the card edge on its own */
 
-  /* Config panel input surfaces */
-  --config-input-bg: 215 18% 18%;
-  --config-input-border: 215 16% 32%;
+  /* Config panel input surfaces — recessed wells below the card */
+  --config-input-bg: 215 18% 15%;
+  --config-input-border: 215 16% 39%;
 
   /* Tab colors */
   --tab-active: 215 82% 62%;
@@ -447,7 +447,7 @@
   --accent: 158 48% 96%;            /* Light sage accent */
   --accent-foreground: 158 58% 28%;
   --ring: 158 58% 38%;
-  --border: 145 12% 88%;            /* Soft green border */
+  --border: 145 12% 84%;            /* Soft green border */
 
   /* Config panel input surfaces */
   --config-input-bg: 145 12% 94%;
@@ -481,25 +481,25 @@
 }
 
 .dark[data-color-scheme="forest"] {
-  --background: 145 18% 13%;        /* Deep forest background */
+  --background: 145 18% 13%;        /* Page — the darkest surface */
   --foreground: 145 12% 92%;
-  --card: 145 18% 15%;              /* Slightly lighter forest cards */
+  --card: 145 18% 19%;              /* Lifted a full step above the page */
   --card-foreground: 145 12% 92%;
-  --popover: 145 18% 18%;             /* Popover/dropdown background */
+  --popover: 145 18% 25%;           /* Floats above cards */
   --popover-foreground: 145 12% 92%;
-  --surface-modal: 145 18% 15%;     /* Modal background */
-  --muted: 145 14% 22%;             /* Deep sage-gray */
-  --muted-foreground: 145 12% 65%;
+  --surface-modal: 145 18% 25%;     /* Modals sit at popover elevation */
+  --muted: 145 14% 24%;             /* Reads against the lifted card */
+  --muted-foreground: 145 12% 69%;  /* Raised to hold AA on the lifted surfaces */
   --primary: 158 62% 56%;           /* Bright forest on dark */
   --primary-foreground: 0 0% 100%;
-  --accent: 145 14% 22%;            /* Deep sage-gray */
+  --accent: 145 14% 24%;            /* Kept in step with --muted */
   --accent-foreground: 145 12% 90%;
   --ring: 158 62% 56%;
-  --border: 145 12% 24%;            /* Dark green border */
+  --border: 145 12% 33%;            /* Carries the card edge on its own */
 
-  /* Config panel input surfaces */
-  --config-input-bg: 145 14% 18%;
-  --config-input-border: 145 12% 30%;
+  /* Config panel input surfaces — recessed wells below the card */
+  --config-input-bg: 145 14% 15%;
+  --config-input-border: 145 12% 39%;
 
   /* Tab colors */
   --tab-active: 158 62% 56%;
@@ -553,7 +553,7 @@
   --accent: 330 90% 96%;            /* Light pink accent */
   --accent-foreground: 330 85% 45%;
   --ring: 330 85% 55%;
-  --border: 330 15% 90%;            /* Soft pink border */
+  --border: 330 15% 85%;            /* Soft pink border */
 
   /* Config panel input surfaces */
   --config-input-bg: 330 20% 95%;
@@ -587,25 +587,25 @@
 }
 
 .dark[data-color-scheme="vibrant-pink"] {
-  --background: 330 20% 12%;        /* Deep pink-gray background */
+  --background: 330 20% 12%;        /* Page — the darkest surface */
   --foreground: 330 15% 92%;
-  --card: 330 20% 14%;              /* Slightly lighter pink cards */
+  --card: 330 20% 18%;              /* Lifted a full step above the page */
   --card-foreground: 330 15% 92%;
-  --popover: 330 20% 17%;             /* Popover/dropdown background */
+  --popover: 330 20% 24%;           /* Floats above cards */
   --popover-foreground: 330 15% 92%;
-  --surface-modal: 330 20% 14%;     /* Modal background */
-  --muted: 330 18% 20%;             /* Deep pink-gray */
+  --surface-modal: 330 20% 24%;     /* Modals sit at popover elevation */
+  --muted: 330 18% 23%;             /* Reads against the lifted card */
   --muted-foreground: 330 12% 65%;
   --primary: 330 80% 65%;           /* Bright pink on dark */
   --primary-foreground: 0 0% 100%;
-  --accent: 330 18% 20%;            /* Deep pink-gray */
+  --accent: 330 18% 23%;            /* Kept in step with --muted */
   --accent-foreground: 330 15% 90%;
   --ring: 330 80% 65%;
-  --border: 330 15% 24%;            /* Dark pink border */
+  --border: 330 15% 32%;            /* Carries the card edge on its own */
 
-  /* Config panel input surfaces */
-  --config-input-bg: 330 20% 18%;
-  --config-input-border: 330 15% 30%;
+  /* Config panel input surfaces — recessed wells below the card */
+  --config-input-bg: 330 18% 14%;
+  --config-input-border: 330 15% 38%;
 
   /* Tab colors */
   --tab-active: 330 80% 65%;
@@ -659,7 +659,7 @@
   --accent: 25 85% 96%;             /* Light orange accent */
   --accent-foreground: 25 95% 43%;
   --ring: 25 95% 53%;
-  --border: 25 20% 88%;             /* Soft orange border */
+  --border: 25 20% 84%;             /* Soft orange border */
 
   /* Config panel input surfaces */
   --config-input-bg: 25 25% 95%;
@@ -693,25 +693,25 @@
 }
 
 .dark[data-color-scheme="energetic-orange"] {
-  --background: 25 22% 12%;         /* Deep orange-gray background */
+  --background: 25 22% 12%;         /* Page — the darkest surface */
   --foreground: 25 15% 92%;
-  --card: 25 22% 14%;               /* Slightly lighter orange cards */
+  --card: 25 22% 18%;               /* Lifted a full step above the page */
   --card-foreground: 25 15% 92%;
-  --popover: 25 22% 17%;             /* Popover/dropdown background */
+  --popover: 25 22% 24%;            /* Floats above cards */
   --popover-foreground: 25 15% 92%;
-  --surface-modal: 25 22% 14%;      /* Modal background */
-  --muted: 25 20% 20%;              /* Deep orange-gray */
-  --muted-foreground: 25 12% 65%;
+  --surface-modal: 25 22% 24%;      /* Modals sit at popover elevation */
+  --muted: 25 20% 23%;              /* Reads against the lifted card */
+  --muted-foreground: 25 12% 66%;   /* Raised to hold AA on the lifted surfaces */
   --primary: 25 90% 60%;            /* Bright orange on dark */
   --primary-foreground: 0 0% 100%;
-  --accent: 25 20% 20%;             /* Deep orange-gray */
+  --accent: 25 20% 23%;             /* Kept in step with --muted */
   --accent-foreground: 25 15% 90%;
   --ring: 25 90% 60%;
-  --border: 25 18% 24%;             /* Dark orange border */
+  --border: 25 18% 32%;             /* Carries the card edge on its own */
 
-  /* Config panel input surfaces */
-  --config-input-bg: 25 20% 20%;
-  --config-input-border: 25 18% 32%;
+  /* Config panel input surfaces — recessed wells below the card */
+  --config-input-bg: 25 20% 14%;
+  --config-input-border: 25 18% 38%;
 
   /* Tab colors */
   --tab-active: 25 90% 60%;
@@ -765,7 +765,7 @@
   --accent: 0 90% 96%;              /* Light red accent */
   --accent-foreground: 0 84% 50%;
   --ring: 0 84% 60%;
-  --border: 0 18% 90%;              /* Soft red border */
+  --border: 0 18% 85%;              /* Soft red border */
 
   /* Config panel input surfaces */
   --config-input-bg: 0 20% 95%;
@@ -799,25 +799,25 @@
 }
 
 .dark[data-color-scheme="bold-red"] {
-  --background: 0 20% 12%;          /* Deep red-gray background */
+  --background: 0 20% 12%;          /* Page — the darkest surface */
   --foreground: 0 15% 92%;
-  --card: 0 20% 14%;                /* Slightly lighter red cards */
+  --card: 0 20% 18%;                /* Lifted a full step above the page */
   --card-foreground: 0 15% 92%;
-  --popover: 0 20% 17%;             /* Popover/dropdown background */
+  --popover: 0 20% 24%;             /* Floats above cards */
   --popover-foreground: 0 15% 92%;
-  --surface-modal: 0 20% 14%;       /* Modal background */
-  --muted: 0 18% 20%;               /* Deep red-gray */
+  --surface-modal: 0 20% 24%;       /* Modals sit at popover elevation */
+  --muted: 0 18% 23%;               /* Reads against the lifted card */
   --muted-foreground: 0 12% 65%;
   --primary: 0 78% 65%;             /* Bright red on dark */
   --primary-foreground: 0 0% 100%;
-  --accent: 0 18% 20%;              /* Deep red-gray */
+  --accent: 0 18% 23%;              /* Kept in step with --muted */
   --accent-foreground: 0 15% 90%;
   --ring: 0 78% 65%;
-  --border: 0 18% 24%;              /* Dark red border */
+  --border: 0 18% 32%;              /* Carries the card edge on its own */
 
-  /* Config panel input surfaces */
-  --config-input-bg: 0 18% 20%;
-  --config-input-border: 0 18% 32%;
+  /* Config panel input surfaces — recessed wells below the card */
+  --config-input-bg: 0 18% 14%;
+  --config-input-border: 0 18% 38%;
 
   /* Tab colors */
   --tab-active: 0 78% 65%;
@@ -871,7 +871,7 @@
   --accent: 270 80% 96%;            /* Light lavender accent */
   --accent-foreground: 270 85% 50%;
   --ring: 270 85% 60%;
-  --border: 270 15% 90%;            /* Soft purple border */
+  --border: 270 15% 85%;            /* Soft purple border */
 
   /* Config panel input surfaces */
   --config-input-bg: 270 20% 95%;
@@ -905,25 +905,25 @@
 }
 
 .dark[data-color-scheme="purple-classic"] {
-  --background: 270 25% 12%;        /* Deep purple-gray background */
+  --background: 270 25% 12%;        /* Page — the darkest surface */
   --foreground: 270 15% 92%;
-  --card: 270 25% 14%;              /* Slightly lighter purple cards */
+  --card: 270 25% 18%;              /* Lifted a full step above the page */
   --card-foreground: 270 15% 92%;
-  --popover: 270 25% 17%;             /* Popover/dropdown background */
+  --popover: 270 25% 24%;           /* Floats above cards */
   --popover-foreground: 270 15% 92%;
-  --surface-modal: 270 25% 14%;     /* Modal background */
-  --muted: 270 18% 20%;             /* Deep purple-gray */
+  --surface-modal: 270 25% 24%;     /* Modals sit at popover elevation */
+  --muted: 270 18% 23%;             /* Reads against the lifted card */
   --muted-foreground: 270 12% 65%;
   --primary: 270 80% 68%;           /* Bright purple on dark */
   --primary-foreground: 0 0% 100%;
-  --accent: 270 18% 20%;            /* Deep purple-gray */
+  --accent: 270 18% 23%;            /* Kept in step with --muted */
   --accent-foreground: 270 15% 90%;
   --ring: 270 80% 68%;
-  --border: 270 15% 24%;            /* Dark purple border */
+  --border: 270 15% 32%;            /* Carries the card edge on its own */
 
-  /* Config panel input surfaces */
-  --config-input-bg: 270 18% 20%;
-  --config-input-border: 270 15% 32%;
+  /* Config panel input surfaces — recessed wells below the card */
+  --config-input-bg: 270 18% 14%;
+  --config-input-border: 270 15% 38%;
 
   /* Tab colors */
   --tab-active: 270 80% 68%;
@@ -961,7 +961,7 @@
 */
 :root[data-color-scheme="pure-black"] {
   /* Core colors - True black with white accents */
-  --background: 0 0% 100%;            /* White background in light mode */
+  --background: 0 0% 97%;             /* Off-white page so white cards read as raised */
   --foreground: 0 0% 5%;
   --card: 0 0% 100%;                   /* White cards */
   --card-foreground: 0 0% 5%;
@@ -977,7 +977,7 @@
   --accent: 0 0% 96%;                  /* Light gray accent */
   --accent-foreground: 0 0% 9%;
   --ring: 0 0% 9%;
-  --border: 0 0% 90%;                  /* Light gray border */
+  --border: 0 0% 85%;                  /* Light gray border */
 
   /* Config panel input surfaces */
   --config-input-bg: 0 0% 96%;
@@ -1011,25 +1011,25 @@
 }
 
 .dark[data-color-scheme="pure-black"] {
-  --background: 0 0% 0%;              /* True black background */
+  --background: 0 0% 0%;              /* Stays true black — OLED is the point of this theme */
   --foreground: 0 0% 95%;
-  --card: 0 0% 4%;                    /* Very dark gray cards */
+  --card: 0 0% 10%;                   /* The whole lift happens here, never on the page */
   --card-foreground: 0 0% 95%;
-  --popover: 0 0% 6%;                 /* Popover/dropdown background */
+  --popover: 0 0% 16%;                /* Floats above cards */
   --popover-foreground: 0 0% 95%;
-  --surface-modal: 0 0% 4%;           /* Modal background */
-  --muted: 0 0% 10%;                  /* Dark gray for muted areas */
+  --surface-modal: 0 0% 16%;          /* Modals sit at popover elevation */
+  --muted: 0 0% 15%;                  /* Reads against the lifted card */
   --muted-foreground: 0 0% 65%;
   --primary: 0 0% 100%;               /* Pure white primary */
   --primary-foreground: 0 0% 0%;
-  --accent: 0 0% 10%;                 /* Dark gray accent */
+  --accent: 0 0% 15%;                 /* Kept in step with --muted */
   --accent-foreground: 0 0% 95%;
   --ring: 0 0% 100%;
-  --border: 0 0% 15%;                 /* Dark gray border */
+  --border: 0 0% 30%;                 /* Carries the card edge on its own */
 
-  /* Config panel input surfaces */
-  --config-input-bg: 0 0% 10%;
-  --config-input-border: 0 0% 28%;
+  /* Config panel input surfaces — recessed wells below the card */
+  --config-input-bg: 0 0% 6%;
+  --config-input-border: 0 0% 34%;
 
   /* Tab colors */
   --tab-active: 0 0% 100%;


### PR DESCRIPTION
Frontend work that accumulated alongside the connection fixes.

- **Cloud settings**: reworked billing and environments screens, plus the compute onboarding step and the connect-daemon modal. Tests cover the eligibility and billing branches rather than just rendering.
- **Chat navigation shortcuts**: chord-based bindings — chord parsing, registry wiring, and an attention-tracking store — with a modal-escape binding test.
- `config/shortcuts.yaml` and its generated docs/data are regenerated from the same source, so the yaml, the generated TS, and the docs page stay in step.
- Theme CSS reworked alongside, since the settings screens were the main consumer of the old rules.

## Verification

**600 tests pass across 71 files** (`vitest run` over the changed areas: Settings/cloud, OnboardingFlow, Projects, lib/keyboard, store, api).

`tsc -b` clean — worth calling out because the desktop release path goes through `build:alpha`, which is bare `vite build` and type-checks nothing. Type errors have accumulated on main that way before, so I ran the same gate the hosted frontend does.