### PR TITLE
fix(release): load endpoint config with bash on Windows too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,10 @@ jobs:
       - name: Load release endpoint config
         # Non-sensitive hostnames, version-controlled and reviewable — see
         # .github/release-config.env for why these aren't secrets.
+        #
+        # shell: bash is REQUIRED — windows-latest defaults to PowerShell,
+        # where `grep` does not exist and $GITHUB_ENV is not a shell variable.
+        shell: bash
         run: grep -v '^#' .github/release-config.env | grep -v '^$' >> "$GITHUB_ENV"
 
       - name: Validate release endpoints
@@ -321,6 +325,12 @@ jobs:
           fetch-depth: 1
 
       - name: Load release endpoint config
+        # shell: bash is REQUIRED — windows-latest defaults to PowerShell,
+        # where `grep` does not exist and $GITHUB_ENV is not a shell variable.
+        # The step still reported success there while setting nothing, so the
+        # build-config generator ran with empty endpoints and failed. GitHub
+        # ships bash on the Windows runners, so this works on all three.
+        shell: bash
         run: grep -v '^#' .github/release-config.env | grep -v '^$' >> "$GITHUB_ENV"
 
       - name: Setup Go
@@ -457,6 +467,12 @@ jobs:
         run: echo "ts=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Load release endpoint config
+        # shell: bash is REQUIRED — windows-latest defaults to PowerShell,
+        # where `grep` does not exist and $GITHUB_ENV is not a shell variable.
+        # The step still reported success there while setting nothing, so the
+        # build-config generator ran with empty endpoints and failed. GitHub
+        # ships bash on the Windows runners, so this works on all three.
+        shell: bash
         run: grep -v '^#' .github/release-config.env | grep -v '^$' >> "$GITHUB_ENV"
 
       - name: Setup Node.js
@@ -615,6 +631,12 @@ jobs:
         run: echo "ts=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Load release endpoint config
+        # shell: bash is REQUIRED — windows-latest defaults to PowerShell,
+        # where `grep` does not exist and $GITHUB_ENV is not a shell variable.
+        # The step still reported success there while setting nothing, so the
+        # build-config generator ran with empty endpoints and failed. GitHub
+        # ships bash on the Windows runners, so this works on all three.
+        shell: bash
         run: grep -v '^#' .github/release-config.env | grep -v '^$' >> "$GITHUB_ENV"
 
       - name: Setup Node.js
@@ -759,6 +781,12 @@ jobs:
         run: echo "ts=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Load release endpoint config
+        # shell: bash is REQUIRED — windows-latest defaults to PowerShell,
+        # where `grep` does not exist and $GITHUB_ENV is not a shell variable.
+        # The step still reported success there while setting nothing, so the
+        # build-config generator ran with empty endpoints and failed. GitHub
+        # ships bash on the Windows runners, so this works on all three.
+        shell: bash
         run: grep -v '^#' .github/release-config.env | grep -v '^$' >> "$GITHUB_ENV"
 
       - name: Setup Node.js


### PR DESCRIPTION
The v1.7.2 release build failed on Windows. macOS and Linux were fine.

## Cause

`windows-latest` defaults to **PowerShell**, not bash. The step that loads the endpoint config is written in shell:

```
grep -v '^#' .github/release-config.env | grep -v '^$' >> "$GITHUB_ENV"
```

On PowerShell `grep` does not exist and `$GITHUB_ENV` is not a shell variable. The step **still reported success** while setting nothing, so the failure surfaced several steps later in `Generate runtime build config`, which is a misleading place to look.

Fixed by pinning `shell: bash` on all five load steps. GitHub ships bash on the Windows runners, so one spelling works on all three platforms.

## The guard worked

Worth stating plainly, because it is the thing this release was about: the generator **refused to build** rather than shipping a Windows app silently pointed at `localhost:8080`. Reproduced locally:

```
$ RELIANT_SERVER_URL= node .github/scripts/generate-build-config.mjs
build-config.js has no RELIANT_SERVER_URL — the packaged app would aim the
daemon at localhost:8080. Set RELIANT_SERVER_URL in .github/release-config.env.
```

That is exactly the class of defect that shipped `api.reliant.so` to users for months. This time it failed the build instead. A red Windows job is the correct outcome here — the alternative was another broken artifact.

## Verification

YAML parses; all five load steps now carry `shell: bash`. macOS and Linux already passed with the identical config, which is what isolates this to the shell rather than the config or the generator.

Once merged I'll re-tag v1.7.2 so the release publishes all three platforms.
