### PR TITLE
chore: release v1.7.3

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -13,6 +13,13 @@ Regenerate with: make generate-changelog
 
 Track what's new in each Reliant release.
 
+<Update label="v1.7.3" description="August 20, 2026">
+### Windows builds again
+
+- **The Windows installer is published again** the v1.7.2 build failed on Windows only. The step that loads the release endpoints is written in shell, and the Windows runner defaults to PowerShell, where those commands do not exist — it reported success while setting nothing, so the build stopped a few steps later when the configuration turned out to be empty. It now runs under bash on every platform. Nothing about the application changed.
+- **Everything from v1.7.2** the app can reach the backend again: it had been built pointing at a hostname that does not exist, and derived a second one that also does not exist. Sign-in and setup no longer stall waiting on a terminal the packaged app does not have. Billing and environments settings were reworked, and chat navigation gained keyboard shortcuts.
+</Update>
+
 <Update label="v1.7.2" description="August 20, 2026">
 ### The desktop app can reach the backend again
 

--- a/docs/data/releases/v1.7.3.yaml
+++ b/docs/data/releases/v1.7.3.yaml
@@ -1,0 +1,9 @@
+version: "v1.7.3"
+date: "2026-08-20"
+title: "Windows builds again"
+summary: "The Windows installer was missing from v1.7.2 — its build failed while the macOS and Linux ones published. The application is identical to v1.7.2; this release exists so all three platforms are available from the same version. macOS and Linux users gain nothing by updating."
+items:
+  - title: "The Windows installer is published again"
+    description: "the v1.7.2 build failed on Windows only. The step that loads the release endpoints is written in shell, and the Windows runner defaults to PowerShell, where those commands do not exist — it reported success while setting nothing, so the build stopped a few steps later when the configuration turned out to be empty. It now runs under bash on every platform. Nothing about the application changed."
+  - title: "Everything from v1.7.2"
+    description: "the app can reach the backend again: it had been built pointing at a hostname that does not exist, and derived a second one that also does not exist. Sign-in and setup no longer stall waiting on a terminal the packaged app does not have. Billing and environments settings were reworked, and chat navigation gained keyboard shortcuts."

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reliant",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "AI-powered coding assistant with intelligent agents for professional software development",
   "author": "Reliant Labs <support@reliantlabs.io>",
   "homepage": "https://reliantlabs.io",


### PR DESCRIPTION
Republishes all three platforms.

v1.7.2's Windows build failed — the endpoint-config step ran under PowerShell, where its shell commands do not exist — so that version shipped macOS and Linux only. #189 fixed it; this cuts a version that includes the fix.

**No application change from v1.7.2.** The only delta between the tags is 28 lines of CI YAML. The release notes say exactly that, rather than implying macOS and Linux users gain something by updating.

Cutting a new patch rather than moving the v1.7.2 tag: that tag is already published and its macOS/Linux artifacts are live and downloadable. Re-pointing it would mean two different builds shared one version number, which breaks anyone who already has it.