### PR TITLE
chore: bump forge to v0.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,8 +28,8 @@ require (
 	github.com/pdfcpu/pdfcpu v0.13.0
 	github.com/pressly/goose/v3 v3.25.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/reliant-labs/forge v0.1.1
-	github.com/reliant-labs/forge/pkg v0.1.1
+	github.com/reliant-labs/forge v0.1.2
+	github.com/reliant-labs/forge/pkg v0.1.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/sqlc-dev/pqtype v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -533,10 +533,10 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.1.0 h1:137FnGdk+EQdCbye1FW+qOEcY5S+SpY9T0NiuqvtfMY=
 github.com/redis/go-redis/v9 v9.1.0/go.mod h1:urWj3He21Dj5k4TK1y59xH8Uj6ATueP8AH1cY3lZl4c=
-github.com/reliant-labs/forge v0.1.1 h1:rDyNKpSaipiUI/69YtheKlxt+GcCYD1oHblS1cAnYY8=
-github.com/reliant-labs/forge v0.1.1/go.mod h1:HP6Ih0OpUgKFIN4PV6EHmldG+Ef49oRLJNgMjbyZHDQ=
-github.com/reliant-labs/forge/pkg v0.1.1 h1:RkGZKBdplhGfqvFhmVzexUP+ZnEboepoZTyRAk3Ojs0=
-github.com/reliant-labs/forge/pkg v0.1.1/go.mod h1:yVuNEMU2atdN1obN85YE/Qgv9lBY4m4l8JiCwtNxCRM=
+github.com/reliant-labs/forge v0.1.2 h1:DfHapIDHukuDaEWHhyESbTfWxJNJQ1tFrDJUKGBBLTM=
+github.com/reliant-labs/forge v0.1.2/go.mod h1:voNxiGNN3DBfPwthAdKUIV9E1KUXy/Od3NoXpsIXWpk=
+github.com/reliant-labs/forge/pkg v0.1.2 h1:8rvg0r3BBIlJFBrdZa9MK+H5Zo/imRiG2Xino7GnMuE=
+github.com/reliant-labs/forge/pkg v0.1.2/go.mod h1:ny/z3fmpdV/np0gZwvSK7zxfZZVxwdtRNAasdQM5FX8=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
Step 2 of the forge v0.1.2 propagation chain (forge → reliant → control-plane), per forge's `docs/releasing.md`.

Bumps both modules reliant pins: `github.com/reliant-labs/forge` and `github.com/reliant-labs/forge/pkg`, v0.1.1 → v0.1.2.

## What v0.1.2 contains

A codegen fix that broke `forge project new`. `mounts_services_gen.go.tmpl` emitted a per-service handler import that nothing in the file has used since construction moved to `compose.go`. It stayed invisible because `forge generate` runs `goimports -w` over its own output before validating, and goimports silently deletes unused imports — so the defect was harmless on machines with goimports and fatal on machines without it, including CI.

Also: the version is now read from a checked-in `VERSION` file rather than relying solely on ldflags, so a build from source reports a real version instead of `dev`.

## Verification

`go mod tidy` clean, `go build ./...` clean, and `go test ./internal/... ./cmd/...` passes with no failures.

Reliant embeds the forge CLI, so this bump is also what carries the fix into the managed workspace daemon image — that image is the reliant binary cross-compiled, and its forge version flows transitively from this go.mod. There is no forge pin in any Dockerfile to update.