### PR TITLE
chore: release v1.7.4

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -13,6 +13,13 @@ Regenerate with: make generate-changelog
 
 Track what's new in each Reliant release.
 
+<Update label="v1.7.4" description="August 20, 2026">
+### Picks up the forge scaffolding fix
+
+- **Generated project code compiles without goimports installed** forge generated a file with an import nothing used. It normally went unnoticed because forge runs goimports over its own output before checking it, and goimports quietly removes unused imports — so the mistake was harmless on machines that had that tool and fatal on machines that did not, which included our own build servers. The import is gone at the source, so the generated code is now correct as written rather than only after a formatter that forge does not install.
+- **The toolchain reports its real version** forge now reads its version from a file committed alongside the code, instead of depending entirely on a value stamped in at build time. A build made from source used to report itself as "dev" and could not say what it actually was.
+</Update>
+
 <Update label="v1.7.3" description="August 20, 2026">
 ### Windows builds again
 

--- a/docs/data/releases/v1.7.4.yaml
+++ b/docs/data/releases/v1.7.4.yaml
@@ -1,0 +1,9 @@
+version: "v1.7.4"
+date: "2026-08-20"
+title: "Picks up the forge scaffolding fix"
+summary: "A dependency bump: forge v0.1.2, which fixes generated project code that could fail to compile on machines without a particular Go formatter installed. No change to the application itself — if you are on v1.7.3 there is nothing here for you."
+items:
+  - title: "Generated project code compiles without goimports installed"
+    description: "forge generated a file with an import nothing used. It normally went unnoticed because forge runs goimports over its own output before checking it, and goimports quietly removes unused imports — so the mistake was harmless on machines that had that tool and fatal on machines that did not, which included our own build servers. The import is gone at the source, so the generated code is now correct as written rather than only after a formatter that forge does not install."
+  - title: "The toolchain reports its real version"
+    description: "forge now reads its version from a file committed alongside the code, instead of depending entirely on a value stamped in at build time. A build made from source used to report itself as \"dev\" and could not say what it actually was."

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reliant",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "AI-powered coding assistant with intelligent agents for professional software development",
   "author": "Reliant Labs <support@reliantlabs.io>",
   "homepage": "https://reliantlabs.io",


### PR DESCRIPTION
Step 2b of the forge v0.1.2 chain — tags a reliant release so control-plane has something to pin.

**Dependency bump only.** No application change from v1.7.3; the only diff is forge v0.1.1 → v0.1.2 in go.mod plus this version bump. The release notes say that plainly rather than implying users gain something.

Why cut it at all: control-plane pins `github.com/reliant-labs/reliant` by version, so the forge fix cannot reach control-plane (or the managed workspace daemon image, which is the reliant binary cross-compiled) without a reliant tag carrying it.

Verified on the branch before merge: `go mod tidy` clean, `go build ./...` clean, `go test ./internal/... ./cmd/...` passing, and full CI green — Backend, E2E Backend, Electron smoke, Web lint/test/build, and both license gates.