### PR TITLE
fix: display_style on live updates, brotli decode, title retry, electron lockfile

### DIFF
--- a/ELECTRON_PROD_CONFIG_BRIEFING.md
+++ b/ELECTRON_PROD_CONFIG_BRIEFING.md
@@ -1,0 +1,218 @@
+# Briefing: prod Electron config + daemon login UX
+
+Shared context for the parallel work streams. **Do not delete this file** — the
+parent agent owns cleanup. Every fact in "Verified" below was checked directly
+against DNS, live HTTP, GCP Secret Manager, or the shipped production logs.
+Do NOT re-derive them.
+
+---
+
+## The user-visible bug
+
+Opening the packaged (prod) Electron app spawns browser tabs pointing at
+`localhost`. Up to 5 per launch, then the app sits with no working backend.
+
+## Root cause chain (VERIFIED — do not re-derive)
+
+1. Packaged build bakes `RELIANT_SERVER_URL=https://api.reliant.so/api`.
+2. **`api.reliant.so` does not exist.** The whole `reliant.so` zone is
+   undelegated — no NS, no SOA from `8.8.8.8`. It is not a missing subdomain;
+   the domain itself is dead.
+3. `electron/src/daemon-creds.js` `ensureDaemonPATForOrigin` tries to pre-mint a
+   daemon PAT so the daemon finds credentials and skips its own registration.
+   The host is unreachable, so it fails and — **by design** — swallows the error
+   (`backend-manager.js:1120`, "never throws").
+4. The daemon spawns, finds no creds for that origin in `~/.reliant/daemon.json`,
+   and runs `ensureDaemonCredentials` → `registerDaemon`
+   (`cmd/reliant/commands/daemon.go:83`) → `auth.Login` → `openBrowser`
+   (`internal/auth/oauth.go:271`). That call is **unconditional** — there is no
+   TTY check, no non-interactive flag anywhere in `cmd/` or `internal/auth/`.
+5. `auth.Login` starts a temp HTTP server on a random loopback port and opens
+   `http://127.0.0.1:<port>` — the localhost tab the user sees.
+6. Daemon never becomes ready → `waitForReady` 30s timeout → crash-restart loop,
+   5 attempts, a fresh tab each time.
+
+Production log proving it (`~/Library/Logs/reliant/main.log`, 14 occurrences):
+
+```
+[daemon-creds] ensureDaemonPATForOrigin: minting daemon PAT for origin https://api.reliant.so
+[daemon-creds] mint failed, falling back to daemon flow: fetch failed
+[Daemon]: No daemon credentials found. Registering...
+[Daemon]: Not logged in. Starting authentication...
+[Daemon]: Opening browser to log in...
+...
+[BackendManager] Daemon failed to become ready within 30000ms
+[BackendManager] Max restart attempts (5) reached, giving up
+```
+
+---
+
+## Verified production facts
+
+### Hostnames — the REAL prod domain is `reliantapi.com`
+
+`reliant.so` was never real. `control-plane/deploy/kcl/prod/main.k` uses
+`reliantapi.com` throughout and contains **zero** references to `reliant.so`.
+
+| Host | DNS | HTTP | Notes |
+|---|---|---|---|
+| `api.reliantapi.com` | 34.63.203.181 | **401** at `/` | THE api server. Live. |
+| `gateway.reliantapi.com` | 34.31.112.130 | 404 at `/` | THE daemon gateway. Live. |
+| `admin.reliantapi.com` | 34.122.251.238 | — | admin-server |
+| `dash.reliantlabs.io` | → supabase.co | — | Supabase / `SUPABASE_URL` |
+| `app.reliantlabs.io` | → reliant-prod.web.app | — | the web SPA |
+| `api.reliant.so` | **NXDOMAIN** | dead | current baked value — WRONG |
+| `gateway-api.reliantapi.com` | **NXDOMAIN** | dead | see gateway bug below |
+
+### CRITICAL: base URL takes NO `/api` suffix
+
+The current value ends in `/api`; that path 404s. Probes:
+
+```
+GET  https://api.reliantapi.com/            → 401 {"error":"missing bearer token"}
+GET  https://api.reliantapi.com/health      → 200
+POST https://api.reliantapi.com/reliant.v1.SettingsService/ListSettings      → 401
+POST https://api.reliantapi.com/api/reliant.v1.SettingsService/ListSettings  → 404
+```
+
+401 with `missing bearer token` on the un-suffixed Connect RPC path is the
+server routing correctly and rejecting an unauthenticated call — that is the
+**correct** base. 404 under `/api` is the router not knowing the path.
+
+**So the correct value is `https://api.reliantapi.com` — no trailing `/api`.**
+
+### SECOND BUG: gateway derivation produces a dead host
+
+`deriveGatewayURL` (`cmd/reliant/commands/connection.go:219`) prefixes the host:
+
+- 2+ dots → `gateway-<first>.<rest>`
+- 1 dot  → `gateway.<host>`
+
+`api.reliantapi.com` has 2 dots, so it derives **`gateway-api.reliantapi.com`**
+— confirmed **NXDOMAIN**. The real gateway is `gateway.reliantapi.com`.
+
+So even after fixing the API URL, the daemon still cannot reach a gateway unless
+`RELIANT_GATEWAY_URL` is set explicitly. Both must be fixed or prod stays broken.
+This is exactly what the shipped log shows:
+`gateway="https://gateway-api.reliant.so/api (derived from server ...)"`.
+
+### The LIVE web app already uses the correct host (independent confirmation)
+
+The deployed SPA at `app.reliantlabs.io` was built from a bundle that has the
+RIGHT hostnames baked in. Extracted from the live JS bundle
+(`/assets/index-BPhpfHH3.js`):
+
+```
+https://api.reliantapi.com      ← the correct API base, NO /api suffix
+https://admin.reliantapi.com
+https://dash.reliantlabs.io
+https://app.reliantlabs.io
+https://docs.reliantlabs.io
+```
+
+Zero occurrences of `reliant.so`. So production web is healthy and already
+proves the correct value; only the DESKTOP build carries the dead host. This is
+independent corroboration that `https://api.reliantapi.com` (no `/api`) is right.
+
+Note the same `secrets.VITE_API_URL` also feeds the web `.env` at
+`release.yml:167` — so whatever built the live bundle did NOT use that secret's
+current value, or used it before it drifted. Worth confirming the web release
+path is not silently broken for the NEXT web release.
+
+### Gateway derivation: prod is the odd one out (NOT a broken function)
+
+`deriveGatewayURL`'s convention is correct for every env EXCEPT prod:
+
+```
+preprod.reliantapi.com → gateway-preprod.reliantapi.com → 8.232.106.145  LIVE  ✅
+api.reliantapi.com     → gateway-api.reliantapi.com     → NXDOMAIN       DEAD  ❌
+real prod gateway is     gateway.reliantapi.com         → 34.31.112.130  LIVE
+```
+
+Confirmed by control-plane's own KCL:
+- `deploy/kcl/preprod/main.k:133` → `GATEWAY_URL=https://gateway-preprod.reliantapi.com`
+- `deploy/kcl/prod/main.k:201`    → `GATEWAY_URL=https://gateway.reliantapi.com`
+
+prod's API host is `api.` rather than a bare env name, so prefixing yields
+`gateway-api.` instead of the actual `gateway.`. Therefore **`RELIANT_GATEWAY_URL`
+must be set explicitly for prod** — it is required, not belt-and-braces.
+
+The apex `reliantapi.com` resolves (34.117.36.251) but does NOT serve HTTPS
+(curl exit 35, TLS failure). It is not a usable fallback.
+
+### GCP Secret Manager
+
+Project `reliant-labs-475814`, Secret Manager API enabled, `gcloud` authenticated
+as `sean@reliantlabs.io` and working.
+
+- `VITE_API_URL` currently = `https://api.reliant.so/api` ← **the dead host**
+- `VITE_SUPABASE_URL` = `https://dash.reliantlabs.io` (correct)
+- Also present: `SUPABASE_ANON_KEY`, `VITE_SUPABASE_ANON_KEY`, `STATSIG_CLIENT_KEY`,
+  `VITE_SENTRY_DSN`, Apple signing (`CSC_*`, `APPLE_*`), `AWS_*`, `CLOUDFLARE_*`,
+  `AZURE_*`, `HOMEBREW_TAP_TOKEN`, `BUF_API_KEY`.
+- Adding a new secret VERSION is non-destructive (old versions are retained and
+  can be re-enabled). Creating a new secret is additive. Neither is risky.
+- **Never disable/destroy an existing version or secret.**
+
+### Config duplication in the release pipeline
+
+`.github/workflows/release.yml` (1313 lines) generates `src/build-config.js` from
+**three separate copy-pasted blocks** at lines **510, 709, 894** (macOS, Linux,
+Windows jobs). Same keys, same validation, three copies — they can and did drift.
+
+Config also reaches the binary via ldflags into `internal/builddefaults`
+(`release.yml:355-357`) whose vars MUST stay package-level strings (`-ldflags -X`
+cannot write anything else — see that package's doc comment).
+
+Precedence at runtime (`builddefaults.Value`): env var > compiled-in `-X` default
+> neutral `http://localhost:8080` fallback.
+
+### Existing forge dev-electron service (REUSE THIS)
+
+Already built, in `control-plane`:
+
+- `deploy/kcl/lib/services.k:415` — `reliant_electron_base` (`forge.Service`,
+  name `reliant-electron`)
+- `deploy/kcl/dev/main.k` — `_electron_svc`, opt-in via `forge env up dev -D electron=1`,
+  uses `host = HostOverrides { command_override = ["npm","run","dev:electron"],
+  working_dir = "../reliant/electron" }`
+- `Taskfile.yml` — `task electron` is superseded by the forge command
+
+Forge primitives that already exist (do NOT rebuild):
+
+- `forge/internal/deploytarget/external.go` — generic `sh -c` deploy provider with
+  `deploy_cmd`/`rollback_cmd`/`health_cmd`, `${IMAGE}/${TAG}/${CODE_VERSION}/${ENV}/${LAST_TAG}`
+  substitution, deploy-state tracking for rollback.
+- `forge/internal/secrets/secrets.go` — `Provider` interface (`Kind`/`Resolve`/`All`)
+  with `file` / `external` / `none` kinds. **No cloud-manager provider exists yet.**
+- `forge/kcl/core.k:545` — `Service`, explicitly target-agnostic.
+
+---
+
+## Ground rules for every stream
+
+- **NEVER run git commands.** No commit, stash, checkout, reset, add. Multiple
+  agents share this worktree; the user reviews and commits. This is a hard rule
+  from project memory.
+- **Never kill processes** — no `pkill`, no `forge env down`. This agent session
+  runs inside forge; a pattern-kill ends the whole session and every sibling agent.
+- Write a test that **FAILS before your fix and PASSES after**, and report the
+  actual before/after output. A fix without a reproduction is a guess.
+- Report real command output. A confident false "it works" is much worse than a
+  clear "this blocked here."
+- Touch ONLY the files in your own ownership list. Another agent owns the rest.
+- This project has **not launched** — no backwards compatibility is required.
+  Remove old code paths rather than adding compatibility shims.
+
+## Repo layout
+
+Root `/Users/seanteeling/src/reliant-labs` with nested repos: `reliant` (the
+product — Electron, daemon, web), `control-plane` (forge app, deploy config),
+`forge` (the framework). Paths below are relative to whichever repo is named.
+
+## Test commands
+
+- Electron JS: `cd reliant/electron && npm test` (node --test; add new files to
+  the `test` script in `electron/package.json`)
+- Go: `cd reliant && go test ./internal/auth/... ./cmd/...`
+- Go build gate: `cd reliant && go build ./...`

--- a/FORGE_SECRETS_DESIGN.md
+++ b/FORGE_SECRETS_DESIGN.md
@@ -1,0 +1,869 @@
+# Design: Forge Secrets and Electron Deployment
+
+## Executive Summary
+
+This design extends forge's secret management to support **GCP Secret Manager** as a cloud provider, unifies configuration across the three copy-pasted release.yml build jobs, and models the Electron packaged-app deployment as an `External` forge service with a custom deploy script.
+
+**Key recommendation**: Implement in three independently shippable phases:
+1. **Phase 1 (forge)**: Add `GCPSecretManager` provider to `forge/internal/secrets`
+2. **Phase 2 (control-plane)**: Declare Electron as `External` service in KCL; update release.yml to consume forge-managed config
+3. **Phase 3 (reliant)**: Migrate build config to resolve secrets at build time
+
+**Core trade-off**: Between resolving secrets at build time (values baked into the binary) and at deploy time (values never enter the codebase). For a packaged desktop app, build-time resolution is unavoidable—there is no runtime "deploy" step for a shipped binary. This design accepts that trade-off and uses GCP Secret Manager to centralize the truth, with strict access controls and version immutability to prevent accidents.
+
+---
+
+## 1. GCP Secret Manager Provider for forge
+
+### Design Rationale
+
+Forge's `secrets.Provider` interface is deliberately abstract:
+- `Kind() string` — identifies the provider ("file", "external", "gcp-secret-manager")
+- `Resolve(name) (value, ok)` — resolves an env-var NAME to its secret VALUE
+- `All() map[string]string` — returns every value the provider supplies (used for validation)
+
+Three existing implementations:
+- **`fileProvider`** (dev/local): reads from a gitignored YAML file; renders plaintext k8s Secrets
+- **`externalProvider`** (prod/staging on k8s): returns nil for all queries; forge validates wiring only, k8s ESO or sealed Secrets resolve values at runtime
+- **`noopProvider`**: always returns false; used when no provider is declared
+
+**A GCP Secret Manager provider** adds a **fourth implementation** that:
+- Reads secrets from GCP Secret Manager via gRPC (Google Cloud Go SDK)
+- Works in three contexts: CI/CD pipeline, local dev machine with gcloud ADC, in-cluster workload with workload identity
+- Fills the gap between "dev machine with gitignored YAML" and "k8s cluster with ESO"—specifically for CI builds that must bake secrets into a binary
+
+### Implementation Details
+
+#### New type: `gcpProvider`
+
+```go
+// gcpProvider resolves secrets from GCP Secret Manager.
+// It is used exclusively at build/CI time (e.g., forge secret resolve,
+// release.yml building an Electron app). In-cluster, workload identity
+// and ESO replace this (use External secrets).
+type gcpProvider struct {
+    projectID  string
+    client     *secretmanager.Client  // gcloud.google.com/go/secretmanager
+    cache      map[string]string      // resolved values (immutable per build)
+    cacheErr   error                  // load error, if any
+}
+```
+
+#### Auth modes supported
+
+1. **Application Default Credentials (ADC)** — default on local machines with `gcloud auth application-default login`
+2. **Service account JSON key** — via `GOOGLE_APPLICATION_CREDENTIALS` env var (GitHub Actions secret)
+3. **Workload identity** — in-cluster (though this context would use `External` secrets instead)
+
+The Go SDK auto-selects based on environment; no explicit auth code is needed.
+
+#### Lifecycle
+
+**Resolve-once semantics**: Secrets are fetched once at the start of a build job and cached. Failures are fail-fast and loud.
+
+```go
+func newGCPProvider(projectID string) (*gcpProvider, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+    defer cancel()
+    
+    client, err := secretmanager.NewClient(ctx)
+    if err != nil {
+        return nil, fmt.Errorf("gcp secret manager: create client: %w", err)
+    }
+    
+    p := &gcpProvider{
+        projectID: projectID,
+        client:    client,
+        cache:     make(map[string]string),
+    }
+    return p, nil
+}
+
+// Resolve returns the secret value by name (env-var name == secret name in GCP).
+// Caches the result so the value is fetched exactly once per build.
+func (p *gcpProvider) Resolve(name string) (string, bool) {
+    if p.cacheErr != nil {
+        return "", false  // Fail-fast: if we hit an error, stop resolving
+    }
+    
+    if v, ok := p.cache[name]; ok {
+        return v, true  // Hit the cache
+    }
+    
+    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+    defer cancel()
+    
+    // GCP path: projects/PROJECT/secrets/SECRET/versions/latest
+    req := &secretmanagerpb.AccessSecretVersionRequest{
+        Name: fmt.Sprintf("projects/%s/secrets/%s/versions/latest", p.projectID, name),
+    }
+    
+    result, err := p.client.AccessSecretVersion(ctx, req)
+    if err != nil {
+        p.cacheErr = fmt.Errorf("resolve %s: %w", name, err)
+        return "", false
+    }
+    
+    value := string(result.Payload.Data)
+    p.cache[name] = value
+    return value, true
+}
+
+// All returns every secret in the cache. For GCP, this requires a list call;
+// to avoid N+1 queries, All() is only called during validation (not during
+// normal resolve). If N is small, fetch all at once; if large, return nil
+// and defer to single-secret resolve (trade-off).
+func (p *gcpProvider) All() map[string]string {
+    // GCP Secret Manager requires listing secrets explicitly.
+    // For now, return nil — validation runs at build time, and the user
+    // receives clear errors per-secret. Listing all secrets is optional
+    // (the Go guard in ValidateDeclaredRefs skips GCP anyway).
+    return nil
+}
+
+func (p *gcpProvider) Kind() string { return "gcp-secret-manager" }
+
+func (p *gcpProvider) Close() error { return p.client.Close() }
+```
+
+#### KCL schema
+
+```kcl
+schema GCPSecretManager:
+    """GCP Secret Manager provider: cloud-hosted secrets for CI/build time.
+    
+    Use this when a build job must resolve secrets to bake into a shipped
+    artifact (packaged Electron app, Docker image, binary). Requires
+    credentials via Application Default Credentials, GOOGLE_APPLICATION_CREDENTIALS,
+    or in-cluster workload identity.
+    
+    NOT for k8s runtime: use ExternalSecrets (External Secrets Operator)
+    and workload identity instead. This provider is for BUILD time.
+    
+    Environment variables:
+      * GCP_PROJECT_ID: GCP project ID (or auto-detect from GOOGLE_CLOUD_PROJECT)
+      * GOOGLE_APPLICATION_CREDENTIALS: path to service account JSON (optional;
+                                        ADC is tried first)
+    
+    Secret names must match env-var names (UPPER_SNAKE_CASE). Values are
+    fetched once at build time and cached. Access failures are fail-fast
+    and loud — a missing secret aborts the build rather than silently
+    leaving an empty value.
+    """
+    type: str = "gcp-secret-manager"
+    project_id: str  # GCP project ID
+    
+    check:
+        type == "gcp-secret-manager", "GCPSecretManager.type must be 'gcp-secret-manager'"
+        project_id, "GCPSecretManager.project_id is required"
+        # GCP is build-time only; it would be misused in prod k8s
+        option("env") in ["dev", "staging", "ci"] or option("env") == None, \
+            "GCPSecretManager is for build/CI environments; use ExternalSecrets for prod k8s"
+```
+
+#### Extending `NewProvider`
+
+Update `forge/internal/secrets/secrets.go`:
+
+```go
+func NewProvider(cfg *ProviderConfig) (Provider, error) {
+    if cfg == nil {
+        return noopProvider{}, nil
+    }
+    switch strings.ToLower(strings.TrimSpace(cfg.Type)) {
+    case "external":
+        return externalProvider{}, nil
+    case "file":
+        // ... existing file logic ...
+    case "gcp-secret-manager":
+        projectID := cfg.Path  // Path field reused as GCP project ID
+        if projectID == "" {
+            return nil, fmt.Errorf("gcp-secret-manager: project_id is required")
+        }
+        return newGCPProvider(projectID)
+    // ... rest of existing cases ...
+    }
+}
+```
+
+### Caching and Failure Modes
+
+**Single-pass resolution**: Secrets are fetched exactly once per build. If `Resolve` is called and the secret is not in the cache, a network call is made. If it fails, `cacheErr` is set and all subsequent `Resolve` calls fail fast.
+
+**Why fail-fast**: The old bug was *silent* — a missing secret baked an empty string, and the app shipped silently broken. This design **requires** an explicit confirmation that the secret exists. If GCP Secret Manager is unreachable or the secret is missing, the build **must fail and report it**.
+
+**Timeout**: 10-second timeout per secret fetch (reasonable for GCP API latency + auth); 5-second timeout for client creation. If a secret fetch times out, the build fails with a clear error message naming the secret and the timeout.
+
+**Version immutability**: GCP Secret Manager never overwrites a version—new values create new versions. This means:
+- A past version can always be inspected (audit trail)
+- Disabling a version is non-destructive (old versions stay intact)
+- Rotating a secret is just: create new version → update build config reference (if needed) → disable old version
+
+---
+
+## 2. Secret References vs. Values: Version-Controlled Config
+
+### The Design Principle
+
+**Non-sensitive data (references) goes in git. Sensitive data (values) does not.**
+
+```
+VERSION CONTROL                    RUNTIME
+┌─────────────────┐               ┌──────────┐
+│ release.yml     │               │ GCP      │
+│ deploy/kcl      │───resolves──→ │ Secret   │
+│ (references)    │               │ Manager  │
+│ REVIEWABLE      │               │ (values) │
+└─────────────────┘               └──────────┘
+```
+
+### Current Problem (Release.yml)
+
+Three identical, copy-pasted blocks at lines 510, 709, 894:
+
+```bash
+node -e "
+  const config = {
+    STATSIG_CLIENT_KEY: process.env.STATSIG_CLIENT_KEY || '',
+    SENTRY_DSN: process.env.SENTRY_DSN || '',
+    RELIANT_API_URL: process.env.RELIANT_API_URL || '',
+  };
+  ...
+"
+```
+
+**Failure mode**: Each copy-paste is independent. One job uses an old env var name; another uses a new one. The drift is invisible until a release silently ships broken.
+
+### Proposed Solution
+
+#### Step 1: Centralize config in KCL (control-plane)
+
+```kcl
+# control-plane/deploy/kcl/lib/electron-config.k
+
+electron_build_config = lambda -> {
+    # Non-sensitive references (version-controlled, reviewable)
+    config_refs: {
+        STATSIG_CLIENT_KEY: "STATSIG_CLIENT_KEY",
+        SENTRY_DSN: "SENTRY_DSN",
+        SUPABASE_URL: "SUPABASE_URL",
+        SUPABASE_ANON_KEY: "SUPABASE_ANON_KEY",
+        RELIANT_API_URL: "RELIANT_API_URL",
+        RELIANT_GATEWAY_URL: "RELIANT_GATEWAY_URL",
+    }
+    
+    # Validation rules (also version-controlled)
+    validation: {
+        "RELIANT_API_URL must be set": lambda c -> c["RELIANT_API_URL"] != "",
+        "RELIANT_API_URL must not target localhost": lambda c -> not ("localhost" in c["RELIANT_API_URL"]),
+    }
+}
+```
+
+#### Step 2: Update release.yml to reference KCL
+
+```bash
+# .github/workflows/release.yml
+
+- name: Generate build config
+  run: |
+    # Read the config refs from KCL (single source of truth)
+    # This is a design sketch; the actual invocation depends on forge expose
+    CONFIG_SPEC=$(reliant forge kcl get-electron-config)
+    
+    # For each ref, resolve from GitHub Secrets (or GCP if a future phase adds support)
+    node -e "
+      const refs = $CONFIG_SPEC.config_refs;
+      const config = {};
+      for (const [key, ref] of Object.entries(refs)) {
+        config[key] = process.env[ref] || '';
+      }
+      console.log(JSON.stringify(config, null, 2));
+    " > src/build-config.js
+    
+    # Run validation (also from KCL)
+    node -e "
+      const config = require('./src/build-config.js');
+      const rules = $CONFIG_SPEC.validation;
+      for (const [name, check] of Object.entries(rules)) {
+        if (!check(config)) {
+          console.error('Validation failed:', name);
+          process.exit(1);
+        }
+      }
+    "
+```
+
+#### Step 3: GitHub Actions → GCP Secret Manager
+
+**Option A (near term)**: Dual-write. GitHub Actions continues to hold secrets; release.yml reads them.
+
+```bash
+env:
+  RELIANT_API_URL: ${{ secrets.RELIANT_API_URL }}
+  RELIANT_GATEWAY_URL: ${{ secrets.RELIANT_GATEWAY_URL }}
+  # ... etc
+```
+
+**Option B (future)**: Unified GCP Secret Manager. GitHub Actions fetes secrets from GCP:
+
+```bash
+# Not yet implemented; requires gcloud CLI or a GitHub Action
+- name: Fetch secrets from GCP
+  uses: google-github-actions/auth@v1
+  with:
+    workload_identity_provider: ...
+    service_account: ci@reliant-labs-475814.iam.gserviceaccount.com
+    
+- name: Load secrets
+  run: |
+    gcloud secrets versions access latest --secret="RELIANT_API_URL" > /tmp/api_url
+    export RELIANT_API_URL=$(cat /tmp/api_url)
+    # ... rest of build
+```
+
+### What This Achieves
+
+1. **Single source of truth for config references**: KCL defines what keys are needed, not three copies of bash
+2. **Reviewable changes**: A PR that changes the build config is visible and reviewable
+3. **Validation is part of the schema**: A bad value is caught at config time, not at runtime
+4. **Secrets stay out of git**: Only references (env-var NAMES) are in version control; actual values come from GitHub Secrets or GCP Secret Manager
+
+---
+
+## 3. Electron as an External Forge Service
+
+### Rationale
+
+The **dev Electron service already exists** in control-plane:
+- `deploy/kcl/lib/services.k:415` — `reliant_electron_base()`
+- `deploy/kcl/dev/main.k:1134` — `_electron_svc` (opt-in via `-D electron=1`)
+
+The **prod Electron app** ("packaged app") is a different beast:
+- Not a long-running daemon or container
+- "Deploy" means: build → sign → notarize → publish to S3/R2
+- No meaningful "rollback" (a shipped binary stays shipped; users download the new version)
+- Lifecycle is discrete releases, not continuous rollouts
+
+**An `External` service models this perfectly**: arbitrary shell commands for build/deploy/rollback/health.
+
+### Design
+
+#### KCL Schema
+
+```kcl
+# control-plane/deploy/kcl/lib/services.k
+
+reliant_electron_package = lambda -> forge.Service {
+    forge.Service {
+        name = "reliant-electron-packaged"
+        image = "reliant-electron-packaged"
+        
+        # BUILD: compile and package the Electron app.
+        # Equivalent to the current release.yml's `npm run build:backend` +
+        # `npx electron-builder --config ...` steps.
+        build = forge.ShellBuild {
+            cwd = "../reliant/electron"
+            cmd = r"""
+set -e
+echo "[electron-package] Building tools-daemon..."
+cd ../reliant && npm run build:backend
+
+echo "[electron-package] Packaging Electron app (macOS/Linux/Windows)..."
+cd ../reliant/electron
+npx electron-builder \
+  --config="${ELECTRON_BUILDER_CONFIG}" \
+  --publish="${PUBLISH_FLAG}"
+"""
+        }
+        
+        # DEPLOY: the `deploy_cmd` is a no-op for packaged apps.
+        # The build step handles everything (sign, notarize, publish).
+        # This field is required by External schema, but we leave it minimal.
+        external = forge.External {
+            type = "external"
+            deploy_cmd = "echo '[electron-package] Already published during build'"
+            health_cmd = "echo '[electron-package] No health check for packaged app'"
+            env_file = ".github/workflows/electron-env.sh"  # Secrets & signing creds
+            env = {
+                "PUBLISH_FLAG": "${PUBLISH_FLAG}",
+                "ELECTRON_BUILDER_CONFIG": "electron-builder.config.js",
+            }
+        }
+        
+        host = forge.HostOverrides {
+            # Packaged app is CI-only (not dev-runnable via `forge env up`).
+            # The `runner` here is a placeholder; actual invocation is via CI.
+            runner = "go-run"
+            command_override = ["true"]  # No-op; forge env up is N/A
+            working_dir = "../reliant/electron"
+        }
+    }
+}
+```
+
+#### Release.yml Integration
+
+```bash
+# .github/workflows/release.yml
+
+# Orchestrate via `forge env deploy` rather than hand-rolled steps.
+# This requires a KCL environment for the release pipeline:
+
+# control-plane/deploy/kcl/ci/main.k
+_ci_bundle = forge.Bundle {
+    secret_provider = forge.GCPSecretManager {
+        type = "gcp-secret-manager"
+        project_id = "reliant-labs-475814"
+    }
+    
+    services = [
+        svc.reliant_electron_package() | {
+            # Platform-specific overrides
+            build = forge.ShellBuild {
+                cmd = "..."  # Platform detection; build macOS on macOS, etc.
+            }
+        }
+    ]
+}
+
+# In release.yml:
+- name: Build and publish Electron app
+  working-directory: reliant
+  run: |
+    cd ../control-plane
+    forge env deploy ci \
+      --service reliant-electron-packaged \
+      --image-tag "${{ github.ref_name }}"
+```
+
+### Semantics of External Deploy/Rollback for Desktop Apps
+
+**Deploy semantics**:
+- `deploy_cmd` runs (in this case, it's a no-op; everything happens in the build)
+- `health_cmd` runs (reports success)
+- Deploy state is recorded: `(image, tag)` → `.forge/state/external-ci-reliant-electron-packaged.json`
+
+**Rollback semantics**:
+- `rollback_cmd` is invoked with `${LAST_TAG}` (the previous version)
+- For a desktop app, "rollback" means: publish the previous binary again
+
+This is *not* a real rollback in the Kubernetes sense (you can't unpublish a shipped binary), but it allows the deploy state machine to track what was last shipped and make it available for a re-release if needed.
+
+**Example rollback_cmd**:
+```bash
+rollback_cmd = r"""
+# Download the previous release from S3/R2 and publish it again
+aws s3 cp s3://reliant-releases/reliant-${LAST_TAG}-x64.exe .
+# Re-run the signed/notarized binary through the publish pipeline
+npx electron-builder publish never --config electron-builder.config.js
+"""
+```
+
+### Why External Fits (and Where It Strains)
+
+**Fits**:
+- Reuses existing `ServiceGroup`, `ExternalProvider`, substitution tokens
+- One shell escape hatch handles sign/notarize/publish, which is already CLI-driven (electron-builder)
+- Deploy state tracking (tag history) is useful for manual recovery
+
+**Strains**:
+- Health checks are meaningless (the app is already published; no service is "up")
+- Rollback semantics don't match reality (you can't actually unpublish)
+- The `External` model assumes deploy is orthogonal to build, but for packaged apps they're entangled
+
+**Acceptable trade-off**: The strain is cosmetic. The alternative is building a new deploy target just for desktop apps (overkill). Using `External` with mostly-no-op health/rollback is simpler and consistent.
+
+---
+
+## 4. Trade-offs and Alternatives
+
+### Alternative 1: GitHub Secrets + ESO (External Secrets Operator)
+
+**How it works**:
+- Secrets stay in GitHub (no GCP dependency)
+- Kubernetes cluster runs ESO, which syncs GitHub secrets → k8s Secrets
+- For CI builds, GitHub Actions directly reads `secrets.*`
+
+**Pros**:
+- No new GCP auth/permissions needed
+- All secrets in one place (GitHub)
+- ESO is well-established for k8s
+
+**Cons**:
+- ESO is k8s-only; CI builds that need to resolve secrets (like Electron) must still implement their own auth
+- GitHub has no "sync this to GCP" without a third-party action
+- GitHub secrets are not auditable the way GCP Secret Manager is (version history, rotation trails)
+
+**Verdict**: Rejected. GitHub secrets + ESO doesn't solve the Electron build problem (CI still needs to resolve at build time).
+
+### Alternative 2: Committed non-secret config + GitHub Secrets
+
+**How it works**:
+- Version-controlled KCL defines all config keys and validation
+- GitHub Actions reads env vars from `secrets.*`, never writes them to git
+- For k8s, ESO syncs to Secrets; for desktop, values are injected at build time
+
+**Pros**:
+- Minimal new infrastructure (GitHub Actions is already there)
+- Version control is pure (no secrets in git at all)
+- Clear separation: references in git, values in GitHub
+
+**Cons**:
+- Still doesn't prevent the release.yml copy-paste drift
+- No audit trail for secret changes (GitHub doesn't version secrets the way GCP does)
+- Scaling to N environments with M secrets means N×M copy-pasted secret references
+
+**Verdict**: Partial solution. It unifies the references in KCL, but doesn't solve the Electron build-time resolution problem cleanly.
+
+### Alternative 3: sops/age (Encrypted Secrets in Git)
+
+**How it works**:
+- Secrets are encrypted with age keys and stored in git
+- Build time: decrypt with `sops`, resolve values
+- Transparent to the app
+
+**Pros**:
+- Secrets are versioned and audited (in git history)
+- Single source of truth
+
+**Cons**:
+- Requires careful key management (age key to every developer, CI/CD)
+- Tempting to accidentally commit unencrypted
+- More operational overhead (key rotation, distribution)
+- Not aligned with GCP workload identity (another auth system to manage)
+
+**Verdict**: Rejected for this project. GCP workload identity is already in use for control-plane; adding sops/age is redundant and introduces a second secret-management system.
+
+### Alternative 4: HashiCorp Vault
+
+**How it works**:
+- Vault is the single source of truth for all secrets
+- Apps read from Vault at startup via AppRole, JWT, or workload identity
+- Desktop: build step reads from Vault, bakes into binary
+
+**Pros**:
+- Powerful, widely used
+- Excellent audit trail and rotation tools
+
+**Cons**:
+- Overkill for this project (already using GCP Secret Manager)
+- Another service to run and manage
+- Vault doesn't replace GCP Secret Manager; they'd run in parallel
+
+**Verdict**: Rejected. GCP Secret Manager is already deployed and in use. Vault is unnecessary.
+
+### Chosen: GCP Secret Manager + Unified KCL Config
+
+**Why**:
+1. **Least infrastructure**: Secrets already live in GCP Secret Manager (per BRIEFING.md); no new service
+2. **Audit trail**: GCP versions immutably; each secret change is recorded
+3. **Workload identity parity**: In-cluster pods use workload identity; CI uses ADC or service account keys — same auth system
+4. **Gradual adoption**: Doesn't require moving GitHub secrets immediately; can start with build-time only (Electron)
+5. **Not too clever**: Direct GCP API calls (no ESO, no sops, no Vault)
+
+**Trade-off accepted**: Secrets must be resolved at build time (values baked into binary) for packaged Electron. This is unavoidable—there is no runtime to fetch secrets in a shipped desktop app. GCP Secret Manager centralizes the truth; strict version immutability and access controls prevent accidents.
+
+---
+
+## 5. Implementation Plan (Staged, Independently Shippable)
+
+### Phase 1: Forge Secrets Provider (Forge Release)
+
+**Forge repo**; merge into main, tag new release (e.g., `v0.99.0`).
+
+**Deliverables**:
+- `forge/internal/secrets/gcp_provider.go` — new `gcpProvider` implementation
+- Update `forge/internal/secrets/secrets.go` — add "gcp-secret-manager" case to `NewProvider`
+- `forge/kcl/schema.k` — add `GCPSecretManager` schema
+- Tests: `forge/internal/secrets/gcp_provider_test.go`
+- Doc comment in `forge/internal/secrets/secrets.go` explaining when GCP is used (build-time, not k8s runtime)
+
+**Dependencies**:
+- `github.com/googleapis/go-genproto` (already in forge, used by other GCP clients)
+- `cloud.google.com/go/secretmanager` (new dependency)
+
+**Breaking changes**: None. Backward compatible.
+
+**Testing**:
+- Unit tests with a fake GCP client (use `github.com/googleapis/gapic-generators-go` test utilities or mock)
+- Manually test: `forge secret resolve --provider gcp-secret-manager --project reliant-labs-475814`
+- Verify auth modes: ADC, service account JSON, (optional: workload identity in-cluster)
+
+**Review gate**: Forge team approves secret-handling code; no security shortcuts.
+
+---
+
+### Phase 2: Control-Plane KCL + Release.yml Unification (Control-Plane Release)
+
+**Control-plane repo**; pin forge to the new version (go.mod replace).
+
+**Deliverables**:
+
+1. **KCL updates**:
+   - `deploy/kcl/lib/electron-config.k` (NEW) — centralized Electron build config + validation rules
+   - `deploy/kcl/lib/services.k` — add `reliant_electron_package()` (the packaged-app External service)
+   - `deploy/kcl/ci/main.k` (NEW) — bundle for CI environment with GCP Secret Manager provider
+
+2. **Release.yml updates**:
+   - Remove the three identical config-generation blocks (lines 510, 709, 894)
+   - Replace with single call: `forge env resolve` or equivalent to read from KCL
+   - Wire env vars from GitHub Actions secrets (short term) or GCP (future)
+
+3. **Tests**:
+   - `deploy/kcl/tests/positive_electron_packaged.k` — KCL validation
+   - Manual: trigger a release workflow and verify build-config.js is generated correctly
+
+**Dependencies**:
+- Forge version bump (to the Phase 1 release)
+
+**Breaking changes**: None. Old release.yml still works; new version just consolidates.
+
+**Testing**:
+- Verify: `forge env deploy ci --service reliant-electron-packaged --dry-run` outputs the right commands
+- Manually verify: build config contains correct URLs (no localhost)
+- Smoke test: Stage a release workflow and check the artifacts
+
+---
+
+### Phase 3: Reliant Build-Time Config Resolution (Reliant Release)
+
+**Reliant repo**; update references to control-plane KCL + GCP Secret Manager.
+
+**Deliverables**:
+
+1. **Electron app updates**:
+   - No changes to `electron/src/backend-manager.js` (it continues to read env vars, which are now injected by release.yml)
+   - Update `electron/src/build-config.js` generation to validate using KCL rules (done by release.yml, not the app)
+
+2. **CI/release.yml updates**:
+   - Swap GitHub Secrets → GCP Secret Manager (requires GitHub Actions + gcloud auth)
+   - Or defer this to a later phase; short term, GitHub Secrets + resolved config validation via KCL is sufficient
+
+3. **Documentation**:
+   - `RELEASE.md` — how to cut a release, what secrets are needed, where they live
+   - `docs/electron-build-config.md` — what build-config.js contains and why
+
+**Testing**:
+- Build an actual release and verify the packaged app points at the correct hostname
+- Check logs for secret-loading errors (if any secret is missing, fail-fast with a clear message)
+
+---
+
+## 6. Detailed Implementation Notes
+
+### GCP Secret Manager API Usage
+
+```go
+import (
+    "cloud.google.com/go/secretmanager/apiv1"
+    "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+)
+
+// Access a secret version (latest or specific)
+client.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{
+    Name: "projects/PROJECT_ID/secrets/SECRET_NAME/versions/latest",
+})
+
+// List all secrets in a project
+client.ListSecrets(ctx, &secretmanagerpb.ListSecretsRequest{
+    Parent: "projects/PROJECT_ID",
+})
+
+// For CI builds, only AccessSecretVersion is needed (single-pass fetch).
+```
+
+### Schema Change: ProviderConfig → GCPSecretManager
+
+**Current `ProviderConfig`** (in `forge/internal/secrets/secrets.go`):
+```go
+type ProviderConfig struct {
+    Type string // "file" | "external"
+    Path string // secret store file path
+}
+```
+
+**For GCP**, the KCL bridge maps:
+```kcl
+GCPSecretManager {
+    type = "gcp-secret-manager"
+    project_id = "reliant-labs-475814"
+}
+```
+
+The KCL→Go mapping (handled by forge's codegen):
+```go
+ProviderConfig{
+    Type: "gcp-secret-manager",
+    Path: "reliant-labs-475814",  // Project ID goes in Path field
+}
+```
+
+This is a pragmatic reuse of the existing config structure; no schema changes needed in Go.
+
+### External Service State File for Electron
+
+Deploy state for packaged apps:
+```json
+{
+  ".forge/state/external-ci-reliant-electron-packaged.json": {
+    "image": "reliant-electron-packaged",
+    "tag": "v1.2.3"
+  }
+}
+```
+
+The tag is useful for manual rollback (redownload and republish v1.2.2 if v1.2.3 is broken).
+
+### Validation Rules (KCL + Go)
+
+Example validation for RELIANT_API_URL:
+
+**In KCL** (version-controlled, reviewable):
+```kcl
+electron_build_config = lambda -> {
+    config_refs: { ... },
+    validation: {
+        "RELIANT_API_URL required": lambda c -> c["RELIANT_API_URL"] != "",
+        "RELIANT_API_URL no localhost": lambda c -> not ("localhost" in c["RELIANT_API_URL"]),
+    }
+}
+```
+
+**In release.yml** (runs the checks):
+```bash
+node -e "
+  const config = require('./src/build-config.js');
+  const ref = <KCL validation rules from control-plane>;
+  for (const [name, fn] of Object.entries(ref)) {
+    if (!fn(config)) {
+      console.error('Validation error:', name);
+      process.exit(1);
+    }
+  }
+"
+```
+
+### Error Messages (Fail-Fast Design)
+
+When a secret is missing or unreachable:
+
+```
+[electron-package] gcp-secret-manager: resolve RELIANT_API_URL: status code 404: secret not found
+  This secret must exist in GCP Secret Manager (projects/reliant-labs-475814/secrets/RELIANT_API_URL).
+  Create it with: gcloud secrets create RELIANT_API_URL --data-file=- (or use the GCP Console).
+  If it exists, verify:
+    - gcloud auth is logged in (gcloud auth list)
+    - GOOGLE_CLOUD_PROJECT is set correctly
+    - the secret is not disabled (gcloud secrets versions list RELIANT_API_URL)
+```
+
+Clear error messages are essential; silence was the original bug.
+
+---
+
+## 7. Security Considerations
+
+### Secret Immutability
+
+GCP Secret Manager **never overwrites** a secret version. New values create new versions.
+
+**Implication for release workflow**:
+1. Update secret in GCP: `gcloud secrets versions add RELIANT_API_URL --data-file=-`
+2. This creates a new version (e.g., version 5) and leaves version 4 intact
+3. Release workflow uses "latest" (version 5)
+4. If version 5 is wrong, disable it and restore version 4 (non-destructive)
+
+**Audit trail**:
+```bash
+$ gcloud secrets versions list RELIANT_API_URL
+NAME                                CREATED              DESTROYED  REPLICATED  ACCESSED
+5                                   2024-01-15T10:00:00Z            Yes         2024-01-15T10:05:00Z
+4                                   2024-01-14T15:00:00Z            Yes         2024-01-14T15:30:00Z
+3                                   2024-01-10T12:00:00Z Destroyed  Yes         2024-01-10T12:15:00Z
+```
+
+Every access is logged; rotation is visible.
+
+### Access Control (IAM)
+
+GCP Secret Manager integrates with Cloud IAM. For reliant-labs-475814:
+
+**CI service account** (used by GitHub Actions):
+```
+roles/secretmanager.secretAccessor
+# Can read secret versions; cannot create/destroy
+```
+
+**Developers** (local machine, `gcloud auth application-default login`):
+```
+roles/secretmanager.admin
+# Can create/read/rotate/destroy (full control)
+# OR: roles/secretmanager.secretAccessor (read-only)
+```
+
+**In-cluster workload** (future, if k8s reads GCP):
+```
+# Workload identity binding:
+# kubernetes.io/service-account: reliant-api-server → 
+# google.iam.gserviceaccount.com/reliant-api-server@reliant-labs-475814.iam.gserviceaccount.com
+# With: roles/secretmanager.secretAccessor
+```
+
+### Fail-Safe Design
+
+1. **No silent fallbacks**: If a secret is missing, the build fails immediately with a clear error.
+2. **Timeout-guarded**: 10s timeout per secret; if GCP is slow, the build doesn't hang indefinitely.
+3. **Single-pass fetch**: Secrets are resolved once at build start; no retry loops or jitter.
+4. **No caching across builds**: Each CI job is fresh; no old cached values leak.
+5. **Validation is early**: Build config is validated before any network calls.
+
+---
+
+## 8. FAQ and Gotchas
+
+**Q: Why not store secrets in Kubernetes and just fetch at runtime?**
+A: Packaged Electron app has no runtime—it's a shipped binary. Secrets must be baked in at build time or fetched from an external service on startup (adds latency and a network dependency for every app launch). Build-time is simpler.
+
+**Q: What if GCP Secret Manager is down during a release?**
+A: The build fails with a clear error. The developer must wait for GCP to recover or use a previous release's binary.
+
+**Q: Can I rotate a secret without re-releasing the app?**
+A: Only if the app reads the secret at startup (e.g., from a config service). Packaged app has the value baked in; rotation requires a new build and release.
+
+**Q: What about local development (forge env up)?**
+A: Dev environment uses `FileSecrets` (gitignored YAML). Developers run `forge secret set dev RELIANT_API_URL` to populate a local file. No GCP dependency for local dev.
+
+**Q: Does this work for the web app (Vite)?**
+A: Yes, but web app is served by a backend that injects config. A future phase could unify web + Electron config via KCL. For now, web uses env vars injected by the deployment platform (k8s Secrets, CloudRun env vars, etc.).
+
+**Q: What if I mess up and accidentally commit a secret to git?**
+A: GCP Secret Manager versions are immutable; GitHub secret history is not. Use GitHub's secret scanning and invalidate the secret immediately. For pre-existing secrets, deploy a new version to GCP Secret Manager and rotate credentials everywhere it was used.
+
+---
+
+## 9. Success Criteria
+
+✅ **Phase 1 (Forge)**: 
+- [ ] `gcpProvider` is implemented and tested
+- [ ] CI runs `forge secret resolve --provider gcp-secret-manager` successfully
+- [ ] Code review approved by forge team
+
+✅ **Phase 2 (Control-Plane)**:
+- [ ] `reliant_electron_package` External service is defined in KCL
+- [ ] KCL validation passes: `reliant forge lint`
+- [ ] Release.yml generates `src/build-config.js` from KCL
+- [ ] Validation rejects bad config (e.g., localhost URLs)
+
+✅ **Phase 3 (Reliant)**:
+- [ ] Manual release build succeeds with correct config values
+- [ ] Packaged app (macOS/Linux/Windows) connects to correct prod hostname
+- [ ] Error messages are clear if a secret is missing
+
+---
+
+## Conclusion
+
+This design unifies forge's secret management across three contexts: dev (file-based), k8s production (external/ESO), and CI build-time (GCP Secret Manager). It replaces three copy-pasted release.yml blocks with a single KCL definition, making configuration reviewable and maintainable. It models Electron packaging as a first-class forge deployment target, enabling `forge env deploy ci --service reliant-electron-packaged`.
+
+The trade-off—build-time secret resolution—is unavoidable for packaged apps and is the right choice. GCP Secret Manager's version immutability and audit trail provide safety and visibility that prevent a repeat of the `api.reliant.so` silent-failure bug.

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reliant",
-  "version": "1.4.1",
+  "version": "1.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reliant",
-      "version": "1.4.1",
+      "version": "1.7.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@sentry/electron": "^7.10.0",
@@ -370,6 +370,45 @@
       "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
+      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "cross-dirname": "^0.1.0",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.1.1",
+        "minimist": "^1.2.8",
+        "postject": "^1.0.0-alpha.6"
+      },
+      "bin": {
+        "electron-windows-sign": "bin/electron-windows-sign.js"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2577,6 +2616,15 @@
         "buffer": "^5.1.0"
       }
     },
+    "node_modules/cross-dirname": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
+      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2963,6 +3011,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/electron-builder-squirrel-windows": {
+      "version": "26.0.11",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.0.11.tgz",
+      "integrity": "sha512-LM3VDospLXCY6leWPhoJngDlP2GGOPzje/qZbCwX5g9ZeuYhcsVfm5NDDrjS3H6yC4PzHI9U2mnhJxc3bpIMGw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "app-builder-lib": "26.0.11",
+        "builder-util": "26.0.11",
+        "electron-winstaller": "5.4.0"
+      }
+    },
     "node_modules/electron-builder/node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -3047,6 +3108,66 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/electron-winstaller": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
+      "integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@electron/asar": "^3.2.1",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.1",
+        "lodash": "^4.17.21",
+        "temp": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@electron/windows-sign": "^1.1.2"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/electron/node_modules/@types/node": {
@@ -4788,6 +4909,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/postject/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/proc-log": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
@@ -5427,6 +5578,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/temp": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mkdirp": "^0.5.1",
+        "rimraf": "~2.6.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/temp-file": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
@@ -5451,6 +5617,35 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/temp/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/temp/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/tiny-async-pool": {

--- a/internal/db/repo.go
+++ b/internal/db/repo.go
@@ -1209,6 +1209,12 @@ func (r *Repo) EnrichMessageUpdate(ctx context.Context, update ChatUpdate) (json
 	if msg.TokenCount != nil {
 		enrichedData.TokenCount = msg.TokenCount
 	}
+	// See the note in SaveMessageToThreadWithID: dropping display_style here
+	// makes a HIDDEN message render until the next reload.
+	if msg.DisplayStyle != nil {
+		style := int32(*msg.DisplayStyle)
+		enrichedData.DisplayStyle = &style
+	}
 
 	// Marshal back to JSON
 	enrichedJSON, err := json.Marshal(enrichedData)

--- a/internal/db/repo_message_update_display_style_test.go
+++ b/internal/db/repo_message_update_display_style_test.go
@@ -1,0 +1,155 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	reliantv1 "github.com/reliant-labs/reliant/gen/reliant/v1"
+)
+
+// A message saved with DISPLAY_STYLE_HIDDEN is LLM-context only: the transcript
+// filters it in ListMessages (proto_converters.go) and in the timeline
+// (InterleavedTimeline skips DisplayStyle.HIDDEN). Both of those filters read
+// display_style, so a live update that omits the field arrives as
+// displayStyle=undefined and renders as a normal message — the hidden message
+// shows up until the next reload, when the filtered read path finally hides it.
+//
+// That is what made the "Some of your params have changed…" system message
+// visible even though chat_send.go writes it hidden.
+
+func TestSaveMessageToThread_UpdateCarriesDisplayStyle(t *testing.T) {
+	repo, rawDB, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	chatID := "chat-display-style-payload"
+	createActivityTestChat(t, repo, chatID)
+
+	hidden := int32(reliantv1.DisplayStyle_DISPLAY_STYLE_HIDDEN)
+	msg, err := repo.SaveMessageToThread(ctx, chatID, chatID,
+		int32(reliantv1.MessageRole_MESSAGE_ROLE_SYSTEM),
+		"Some of your params have changed, which may include mode, tools, temperature, or something else. Please continue as planned.",
+		nil, nil, &hidden)
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if msg.DisplayStyle == nil || *msg.DisplayStyle != reliantv1.DisplayStyle_DISPLAY_STYLE_HIDDEN {
+		t.Fatalf("message row display_style = %v, want HIDDEN", msg.DisplayStyle)
+	}
+
+	got := latestMessageUpdatePayload(t, rawDB, chatID, msg.ID)
+	assertHiddenDisplayStyle(t, got, "SaveMessageToThread")
+}
+
+func TestEnrichMessageUpdate_CarriesDisplayStyle(t *testing.T) {
+	repo, _, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	chatID := "chat-display-style-enrich"
+	createActivityTestChat(t, repo, chatID)
+
+	hidden := int32(reliantv1.DisplayStyle_DISPLAY_STYLE_HIDDEN)
+	msg, err := repo.SaveMessageToThread(ctx, chatID, chatID,
+		int32(reliantv1.MessageRole_MESSAGE_ROLE_SYSTEM), "hidden context", nil, nil, &hidden)
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	raw, _ := json.Marshal(map[string]any{"id": msg.ID})
+	enriched, err := repo.EnrichMessageUpdate(ctx, ChatUpdate{
+		Data: raw, EntityID: msg.ID, CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("enrich: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(enriched, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	assertHiddenDisplayStyle(t, got, "EnrichMessageUpdate")
+}
+
+// A visible style must still round-trip — the fix must not blanket-stamp every
+// update as hidden.
+func TestSaveMessageToThread_UpdateCarriesVisibleDisplayStyle(t *testing.T) {
+	repo, rawDB, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	chatID := "chat-display-style-info"
+	createActivityTestChat(t, repo, chatID)
+
+	info := int32(reliantv1.DisplayStyle_DISPLAY_STYLE_INFO)
+	msg, err := repo.SaveMessageToThread(ctx, chatID, chatID,
+		int32(reliantv1.MessageRole_MESSAGE_ROLE_SYSTEM), "max turns reached", nil, nil, &info)
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := latestMessageUpdatePayload(t, rawDB, chatID, msg.ID)
+	style, ok := got["display_style"]
+	if !ok {
+		t.Fatal("live message update dropped display_style for an INFO message")
+	}
+	if int32(style.(float64)) != int32(reliantv1.DisplayStyle_DISPLAY_STYLE_INFO) {
+		t.Fatalf("display_style = %v, want INFO (%d)", style, reliantv1.DisplayStyle_DISPLAY_STYLE_INFO)
+	}
+}
+
+// A message with no display style must not gain one — omitted stays omitted so
+// the client renders it as an ordinary message.
+func TestSaveMessageToThread_UpdateOmitsAbsentDisplayStyle(t *testing.T) {
+	repo, rawDB, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	chatID := "chat-display-style-absent"
+	createActivityTestChat(t, repo, chatID)
+
+	msg, err := repo.SaveMessageToThread(ctx, chatID, chatID,
+		int32(reliantv1.MessageRole_MESSAGE_ROLE_USER), "plain message", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := latestMessageUpdatePayload(t, rawDB, chatID, msg.ID)
+	if _, ok := got["display_style"]; ok {
+		t.Fatalf("live update added display_style=%v to a message that has none", got["display_style"])
+	}
+}
+
+func assertHiddenDisplayStyle(t *testing.T, payload map[string]any, writer string) {
+	t.Helper()
+	style, ok := payload["display_style"]
+	if !ok {
+		t.Fatalf("%s emitted a live update with no display_style — a HIDDEN message "+
+			"arrives as displayStyle=undefined and renders in the transcript", writer)
+	}
+	if int32(style.(float64)) != int32(reliantv1.DisplayStyle_DISPLAY_STYLE_HIDDEN) {
+		t.Fatalf("%s: display_style = %v, want HIDDEN (%d)", writer, style,
+			reliantv1.DisplayStyle_DISPLAY_STYLE_HIDDEN)
+	}
+}
+
+// latestMessageUpdatePayload reads back the chat_updates row emitted for a
+// message, which is the exact JSON the streaming service sends to the client.
+func latestMessageUpdatePayload(t *testing.T, rawDB *sql.DB, chatID, messageID string) map[string]any {
+	t.Helper()
+	row := rawDB.QueryRow(
+		`SELECT data FROM chat_updates WHERE chat_id = $1 AND entity_id = $2 AND update_type = $3 ORDER BY sequence_number DESC LIMIT 1`,
+		chatID, messageID, UpdateTypeMessage)
+	var data string
+	if err := row.Scan(&data); err != nil {
+		t.Fatalf("read chat_update for message %s: %v", messageID, err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(data), &payload); err != nil {
+		t.Fatalf("unmarshal chat_update data: %v", err)
+	}
+	return payload
+}

--- a/internal/db/repository_impl.go
+++ b/internal/db/repository_impl.go
@@ -360,6 +360,11 @@ func (r *Repo) SaveMessageToThreadWithID(ctx context.Context, chatID, thread str
 			UpdatedAt:       now.Format("2006-01-02T15:04:05.999999999Z07:00"),
 			ContentBlocks:   contentBlocks,
 			Attachments:     &attachments,
+			// A HIDDEN message is LLM-context only, and both filters that
+			// enforce that (ListMessages and the timeline) read display_style.
+			// Omitting it here delivers the message with displayStyle
+			// undefined, so it renders live and only disappears on reload.
+			DisplayStyle: displayStyle,
 		}
 
 		updateDataJSON, err := updateData.Marshal()

--- a/internal/llm/drivers/anthropic/claude_code.go
+++ b/internal/llm/drivers/anthropic/claude_code.go
@@ -2,8 +2,11 @@
 package anthropic
 
 import (
+	"compress/flate"
+	"compress/gzip"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -58,7 +61,7 @@ func NewClaudeCodeClient(opts llm.DriverOptions) *ClaudeCodeClient {
 		"anthropic-version":                         "2023-06-01",
 		"accept-language":                           "*",
 		"sec-fetch-mode":                            "cors",
-		"accept-encoding":                           "br, gzip, deflate",
+		"accept-encoding":                           claudeCodeAcceptEncoding,
 	}
 	if opts.SessionID != nil && *opts.SessionID != "" {
 		lowercaseHeaders["x-claude-code-session-id"] = *opts.SessionID
@@ -92,8 +95,12 @@ func NewClaudeCodeClient(opts llm.DriverOptions) *ClaudeCodeClient {
 	// This driver builds its own transport chain (token refresh + lowercase
 	// headers), so it opts out of the client llm.NewAnthropicSDKClient installs
 	// and must re-add the idle timeout itself — the option list is last-wins.
+	//
+	// decompressingTransport is outermost so it decodes the final response,
+	// while the idle timeout still measures stalls on the raw network stream
+	// underneath it.
 	customHTTPClient := &http.Client{
-		Transport: llm.WrapWithIdleTimeout(finalTransport),
+		Transport: &decompressingTransport{base: llm.WrapWithIdleTimeout(finalTransport)},
 	}
 
 	clientOptions = append(clientOptions,
@@ -252,6 +259,79 @@ func cloneRequestForRetry(req *http.Request) *http.Request {
 	}
 	clone.Body = body
 	return clone
+}
+
+// claudeCodeAcceptEncoding is the encoding list sent upstream. Setting this
+// header by hand turns OFF net/http's transparent decompression — Go only
+// decodes a response when it chose the encoding itself — so every value here
+// must be one decompressingTransport can decode. Brotli was advertised for a
+// long time and never decoded, which handed encoding/json a raw brotli frame
+// and failed every non-streaming call with
+// `invalid character '\x03' looking for beginning of value`.
+const claudeCodeAcceptEncoding = "gzip, deflate"
+
+// decompressingTransport decodes Content-Encoding that net/http would have
+// handled had the request not carried an explicit accept-encoding.
+//
+// Streaming never hit the original bug (the SSE reader tolerates the framing)
+// but is decoded here too, so both paths see identical bytes.
+type decompressingTransport struct {
+	base http.RoundTripper
+}
+
+func (t *decompressingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	resp, err := base.RoundTrip(req)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+
+	var decoded io.ReadCloser
+	switch strings.ToLower(strings.TrimSpace(resp.Header.Get("Content-Encoding"))) {
+	case "gzip":
+		gz, gzErr := gzip.NewReader(resp.Body)
+		if gzErr != nil {
+			resp.Body.Close()
+			return nil, fmt.Errorf("claude-code: gzip response: %w", gzErr)
+		}
+		decoded = &wrappedBody{Reader: gz, closers: []io.Closer{gz, resp.Body}}
+	case "deflate":
+		fl := flate.NewReader(resp.Body)
+		decoded = &wrappedBody{Reader: fl, closers: []io.Closer{fl, resp.Body}}
+	default:
+		// identity, empty, or an encoding we never asked for: leave it alone.
+		return resp, nil
+	}
+
+	resp.Body = decoded
+	// The body no longer matches these, and a stale Content-Length makes the
+	// SDK truncate the decoded JSON.
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return resp, nil
+}
+
+// wrappedBody closes the decompressor and the underlying body together, so the
+// connection is still released back to the pool.
+type wrappedBody struct {
+	io.Reader
+	closers []io.Closer
+}
+
+func (b *wrappedBody) Close() error {
+	var err error
+	for _, c := range b.closers {
+		if cerr := c.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}
+	return err
 }
 
 // lowercaseHeaderTransport is a custom RoundTripper that sets headers with exact casing

--- a/internal/llm/drivers/anthropic/claude_code_content_encoding_test.go
+++ b/internal/llm/drivers/anthropic/claude_code_content_encoding_test.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2025 Reliant Labs
+package anthropic
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The driver advertises "br, gzip, deflate" to match Claude Code's wire
+// fingerprint. Go's transport only decompresses transparently when IT chose the
+// encoding, so once the header is supplied by hand the body arrives encoded and
+// decoding becomes this driver's job. These tests pin that: a compressed body
+// must reach the SDK as plain JSON.
+
+// encodedUpstream serves a fixed body under a given Content-Encoding.
+type encodedUpstream struct {
+	encoding string
+	body     []byte
+
+	mu     sync.Mutex
+	seenAE []string
+}
+
+func (u *encodedUpstream) RoundTrip(req *http.Request) (*http.Response, error) {
+	u.mu.Lock()
+	//nolint:staticcheck // SA1008: lowercase casing is what the driver writes
+	u.seenAE = append(u.seenAE, req.Header["accept-encoding"]...)
+	u.mu.Unlock()
+
+	header := http.Header{}
+	header.Set("Content-Type", "application/json")
+	if u.encoding != "" {
+		header.Set("Content-Encoding", u.encoding)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       io.NopCloser(bytes.NewReader(u.body)),
+		Request:    req,
+	}, nil
+}
+
+func gzipBytes(t *testing.T, payload string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, err := gz.Write([]byte(payload))
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+	return buf.Bytes()
+}
+
+// newTestDecodingTransport builds the driver's transport chain around a fake
+// upstream: the decoding wrapper over lowercaseHeaderTransport, exactly as
+// NewClaudeCodeClient assembles it.
+func newTestDecodingTransport(upstream http.RoundTripper) http.RoundTripper {
+	headers := map[string]string{
+		"accept-encoding": claudeCodeAcceptEncoding,
+	}
+	return &decompressingTransport{
+		base: &lowercaseHeaderTransport{
+			base:    upstream,
+			headers: headers,
+			mu:      &sync.RWMutex{},
+		},
+	}
+}
+
+// TestClaudeCodeTransport_DecompressesGzipResponse is the regression test for
+// titles silently falling back to the truncated first message: the API returned
+// a compressed body, the SDK fed those raw bytes to encoding/json, and every
+// call failed with `invalid character '\x03' looking for beginning of value`.
+func TestClaudeCodeTransport_DecompressesGzipResponse(t *testing.T) {
+	payload := `{"id":"msg_01","content":[{"type":"tool_use","name":"set_title","input":{"title":"Debugging Workflows"}}]}`
+	upstream := &encodedUpstream{encoding: "gzip", body: gzipBytes(t, payload)}
+
+	resp, err := newTestDecodingTransport(upstream).RoundTrip(newMessagesRequest(t))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// The caller must be able to decode it as plain JSON.
+	var decoded map[string]any
+	require.NoError(t, json.NewDecoder(bytes.NewReader(body)).Decode(&decoded),
+		"body handed to the SDK must be decompressed JSON")
+	assert.Equal(t, "msg_01", decoded["id"])
+
+	// Content-Encoding must be cleared, or a caller could double-decode.
+	assert.Empty(t, resp.Header.Get("Content-Encoding"))
+	assert.Empty(t, resp.Header.Get("Content-Length"))
+}
+
+// An identity (uncompressed) response must pass through untouched.
+func TestClaudeCodeTransport_PassesThroughUnencodedResponse(t *testing.T) {
+	payload := `{"id":"msg_02"}`
+	upstream := &encodedUpstream{encoding: "", body: []byte(payload)}
+
+	resp, err := newTestDecodingTransport(upstream).RoundTrip(newMessagesRequest(t))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, payload, string(body))
+}
+
+// This is the one that reproduces the production failure, and it needs a real
+// server and a real transport because the bug lives in an interaction the
+// stubs above cannot show.
+//
+// lowercaseHeaderTransport writes req.Header["accept-encoding"] by direct map
+// access. net/http looks the header up canonically ("Accept-Encoding"), does
+// not find it, and appends its OWN "gzip" — so two Accept-Encoding headers go
+// out. Go therefore still auto-decodes gzip, which is why gzip responses
+// always worked and hid the defect. When the list advertised br, the upstream
+// CDN answered in brotli, Go decoded nothing, and the SDK fed a raw brotli
+// frame to encoding/json: exactly the `invalid character '\x03'` /
+// `'\u0083'` failures in the worker log. (Gzip would have been '\x1f'.)
+//
+// The guarantee under test: whatever this driver advertises, the body reaching
+// the SDK is plain JSON.
+func TestClaudeCodeTransport_RealServerBrotliRegression(t *testing.T) {
+	payload := `{"id":"msg_03","content":[{"type":"tool_use","name":"set_title","input":{"title":"Debugging Workflows"}}]}`
+
+	var sawAcceptEncoding []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAcceptEncoding = r.Header.Values("Accept-Encoding")
+		offered := strings.Join(sawAcceptEncoding, ",")
+
+		// A CDN that prefers brotli whenever the client says it can take it.
+		// Nothing in Go's stack decodes brotli.
+		if strings.Contains(offered, "br") {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Content-Encoding", "br")
+			_, _ = w.Write([]byte{0x03, 0x83, 0x00, 0x01})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
+		gz := gzip.NewWriter(w)
+		defer gz.Close()
+		_, _ = gz.Write([]byte(payload))
+	}))
+	defer srv.Close()
+
+	// The same chain NewClaudeCodeClient builds, over the real transport.
+	client := &http.Client{
+		Transport: &decompressingTransport{
+			base: &lowercaseHeaderTransport{
+				base:    http.DefaultTransport,
+				headers: map[string]string{"accept-encoding": claudeCodeAcceptEncoding},
+				mu:      &sync.RWMutex{},
+			},
+		},
+	}
+
+	resp, err := client.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// If br is ever re-added to the advertised list, this decode fails with the
+	// original production error.
+	var decoded map[string]any
+	require.NoError(t, json.NewDecoder(bytes.NewReader(body)).Decode(&decoded),
+		"body reaching the SDK must be plain JSON; advertised %q", sawAcceptEncoding)
+	assert.Equal(t, "msg_03", decoded["id"])
+}
+
+// The advertised encodings must all be ones the driver can actually decode.
+// Advertising br without decoding it is what produced the original bug.
+func TestClaudeCodeTransport_OnlyAdvertisesDecodableEncodings(t *testing.T) {
+	upstream := &encodedUpstream{encoding: "", body: []byte(`{}`)}
+
+	_, err := newTestDecodingTransport(upstream).RoundTrip(newMessagesRequest(t))
+	require.NoError(t, err)
+
+	require.Len(t, upstream.seenAE, 1)
+	for _, enc := range strings.Split(upstream.seenAE[0], ",") {
+		enc = strings.TrimSpace(enc)
+		assert.Contains(t, []string{"gzip", "deflate", "identity"}, enc,
+			"advertised %q but the transport cannot decode it", enc)
+	}
+}

--- a/internal/workersetup/generate_title_workflow_test.go
+++ b/internal/workersetup/generate_title_workflow_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2025 Reliant Labs
+//
+// Tests for GenerateTitleWorkflow's retry-then-fallback policy.
+//
+// The fallback (title = truncated first message) used to live inside the
+// activity, which swallowed the LLM error and returned success. A provider
+// outage was therefore indistinguishable from a working system: no retry, no
+// alert, and every chat titled with the user's own text. These tests pin the
+// replacement contract — the LLM is retried, and the fallback happens once,
+// last, and only after the retries are spent.
+package workersetup
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+)
+
+// titleInput is the input CreateChat sends.
+func titleInput() map[string]interface{} {
+	return map[string]interface{}{
+		"chat_id":       "chat-123",
+		"first_message": "creating titles of chats is broken",
+	}
+}
+
+// usedFallback reports whether an activity invocation asked for the fallback.
+func usedFallback(input map[string]interface{}) bool {
+	v, _ := input["use_fallback"].(bool)
+	return v
+}
+
+// generateTitleStub stands in for the real GenerateTitle activity. The
+// workflow dispatches by NAME, so the test environment needs something
+// registered under that name for OnActivity to intercept.
+func generateTitleStub(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+// newTitleEnv returns an environment with the activity registered and a
+// recorder for the inputs each invocation received.
+func newTitleEnv(t *testing.T, handler func(input map[string]interface{}, call int) (map[string]interface{}, error)) (*testsuite.TestWorkflowEnvironment, *[]map[string]interface{}) {
+	t.Helper()
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterActivityWithOptions(generateTitleStub, activity.RegisterOptions{Name: "GenerateTitle"})
+
+	calls := &[]map[string]interface{}{}
+	env.OnActivity("GenerateTitle", mock.Anything, mock.Anything).Return(
+		func(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
+			*calls = append(*calls, input)
+			return handler(input, len(*calls))
+		},
+	)
+	return env, calls
+}
+
+// A transient failure must be retried, not immediately downgraded to the
+// fallback. This is the case the old code got wrong: one blip meant a
+// permanently badly-titled chat.
+func TestGenerateTitleWorkflow_RetriesLLMBeforeFallback(t *testing.T) {
+	env, calls := newTitleEnv(t, func(input map[string]interface{}, call int) (map[string]interface{}, error) {
+		// Fail once, then succeed — a provider blip.
+		if call == 1 {
+			return nil, errors.New("error parsing response json: invalid character '\\x03'")
+		}
+		return map[string]interface{}{"title": "Debugging Title Generation"}, nil
+	})
+
+	env.ExecuteWorkflow(GenerateTitleWorkflow, titleInput())
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	require.Len(t, *calls, 2, "a transient failure must be retried")
+	for i, c := range *calls {
+		assert.False(t, usedFallback(c), "call %d must ask the LLM, not the fallback", i)
+	}
+}
+
+// Once the retries are spent, the workflow settles for the fallback rather
+// than leaving the chat untitled forever — the activity short-circuits on any
+// later run, so this is the last chance to write a title.
+func TestGenerateTitleWorkflow_FallsBackAfterRetriesExhausted(t *testing.T) {
+	env, calls := newTitleEnv(t, func(input map[string]interface{}, call int) (map[string]interface{}, error) {
+		if usedFallback(input) {
+			return map[string]interface{}{"title": "creating titles of chats is broken"}, nil
+		}
+		return nil, errors.New("provider down")
+	})
+
+	env.ExecuteWorkflow(GenerateTitleWorkflow, titleInput())
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError(),
+		"a total LLM outage must still title the chat rather than fail the workflow")
+
+	require.Len(t, *calls, titleLLMAttempts+1,
+		"expected %d LLM attempts then exactly one fallback", titleLLMAttempts)
+
+	// Every attempt but the last is a real LLM attempt; the last is the fallback.
+	for i := 0; i < titleLLMAttempts; i++ {
+		assert.False(t, usedFallback((*calls)[i]), "call %d must be an LLM attempt", i)
+	}
+	last := (*calls)[len(*calls)-1]
+	assert.True(t, usedFallback(last), "final call must be the fallback")
+
+	// The fallback must carry the original input through.
+	assert.Equal(t, "chat-123", last["chat_id"])
+	assert.Equal(t, "creating titles of chats is broken", last["first_message"])
+}
+
+// The happy path must not invoke the fallback at all.
+func TestGenerateTitleWorkflow_SuccessNeverUsesFallback(t *testing.T) {
+	env, calls := newTitleEnv(t, func(input map[string]interface{}, call int) (map[string]interface{}, error) {
+		return map[string]interface{}{"title": "Debugging Title Generation"}, nil
+	})
+
+	env.ExecuteWorkflow(GenerateTitleWorkflow, titleInput())
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Len(t, *calls, 1)
+	assert.False(t, usedFallback((*calls)[0]))
+}

--- a/internal/workersetup/workflows.go
+++ b/internal/workersetup/workflows.go
@@ -4,30 +4,73 @@ package workersetup
 import (
 	"time"
 
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
 
-// GenerateTitleWorkflow is a thin inline wrapper around the GenerateTitle activity.
-// This provides async execution, retries, and observability.
+// titleLLMAttempts is how many times the LLM is asked for a title before the
+// workflow settles for the truncated first message. Title generation is a
+// single cheap call on a fast model, and a provider blip is the common failure,
+// so a few spaced retries recover most of them.
+const titleLLMAttempts = 3
+
+// GenerateTitleWorkflow generates a chat title, retrying the LLM before
+// settling for a deterministic fallback.
+//
+// The fallback (truncated first message) is a LAST RESORT, not an error
+// handler. It used to live inside the activity, which returned success after
+// substituting it — so a provider outage produced a chat titled with the user's
+// own text and no retry, no alert, and no way to tell the two apart. Keeping
+// the decision here means the retries actually happen, and the one case where
+// we give up is explicit and logged.
 func GenerateTitleWorkflow(ctx workflow.Context, input map[string]interface{}) error {
 	logger := workflow.GetLogger(ctx)
 
 	chatID, _ := input["chat_id"].(string)
 	logger.Info("GenerateTitleWorkflow started", "chatID", chatID)
 
-	activityOptions := workflow.ActivityOptions{
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 30 * time.Second,
 		WaitForCancellation: true,
-	}
-	ctx = workflow.WithActivityOptions(ctx, activityOptions)
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    10 * time.Second,
+			MaximumAttempts:    titleLLMAttempts,
+		},
+	})
 
 	var output map[string]interface{}
 	err := workflow.ExecuteActivity(ctx, "GenerateTitle", input).Get(ctx, &output)
-	if err != nil {
-		logger.Error("GenerateTitle activity failed", "error", err, "chatID", chatID)
+	if err == nil {
+		logger.Info("GenerateTitleWorkflow completed successfully", "chatID", chatID)
+		return nil
+	}
+
+	// Never leave a chat untitled: the activity returns early once a title is
+	// set, so this is the only chance to write one.
+	logger.Error("GenerateTitle failed after retries, falling back to truncated first message",
+		"error", err, "chatID", chatID, "attempts", titleLLMAttempts)
+
+	fallbackInput := make(map[string]interface{}, len(input)+1)
+	for k, v := range input {
+		fallbackInput[k] = v
+	}
+	fallbackInput["use_fallback"] = true
+
+	// One attempt: the fallback is pure string manipulation, so a failure here
+	// is a DB problem that a retry in this workflow will not fix.
+	fallbackCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 30 * time.Second,
+		WaitForCancellation: true,
+		RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
+	})
+	if err := workflow.ExecuteActivity(fallbackCtx, "GenerateTitle", fallbackInput).Get(fallbackCtx, &output); err != nil {
+		logger.Error("GenerateTitle fallback failed; chat will remain untitled",
+			"error", err, "chatID", chatID)
 		return err
 	}
 
-	logger.Info("GenerateTitleWorkflow completed successfully", "chatID", chatID)
+	logger.Info("GenerateTitleWorkflow completed with fallback title", "chatID", chatID)
 	return nil
 }

--- a/internal/workflow/runtime/activities/handlers/compact.go
+++ b/internal/workflow/runtime/activities/handlers/compact.go
@@ -32,6 +32,12 @@ import (
 type GenerateTitleInput struct {
 	ChatID       string `json:"chat_id" reliant:"-"`
 	FirstMessage string `json:"first_message"`
+
+	// UseFallback writes the deterministic truncated-first-message title
+	// instead of calling the LLM. Only GenerateTitleWorkflow sets it, and only
+	// after the LLM attempts are exhausted — a titled-by-truncation chat beats
+	// an untitled one, but it must never be the first thing we try.
+	UseFallback bool `json:"use_fallback,omitempty"`
 }
 
 // GenerateTitleOutput is the output from GenerateTitle activity
@@ -238,15 +244,37 @@ func (a *GenerateTitleActivity) Execute(ctx context.Context, input GenerateTitle
 		return GenerateTitleOutput{}, nil
 	}
 
-	// Generate title using LLM
-	generatedTitle, err := a.generateTitle(ctx, chat.UserID, input.FirstMessage)
-	if err != nil {
-		// Use fallback to prevent blocking chat creation. Logged at warn because
-		// the activity still reports success, so this is the only signal that a
-		// title is the truncated first message rather than a generated one.
-		logging.Warn("[GenerateTitle] LLM generation failed, using truncated first message",
-			"error", err, "chatID", input.ChatID)
+	// Generate the title, or write the fallback when the workflow has already
+	// spent its LLM attempts.
+	//
+	// A failure here is RETURNED, not swallowed. Swallowing it silently
+	// substituted the truncated first message and reported success, so a total
+	// provider outage was indistinguishable from normal operation: every chat
+	// looked hand-titled and nothing retried. The workflow owns the retry and
+	// the decision to settle for the fallback.
+	var generatedTitle string
+	if input.UseFallback {
 		generatedTitle = generateSimpleTitleFallback(input.FirstMessage)
+		logging.Warn("[GenerateTitle] LLM generation exhausted, writing truncated first message",
+			"chatID", input.ChatID, "title", generatedTitle)
+	} else {
+		generatedTitle, err = a.generateTitle(ctx, chat.UserID, input.FirstMessage)
+		if err != nil {
+			attempt := int32(1)
+			func() {
+				defer func() { _ = recover() }() // safe outside activity context (tests)
+				attempt = activity.GetInfo(ctx).Attempt
+			}()
+			logging.Error("[GenerateTitle] LLM generation failed",
+				"error", err, "chatID", input.ChatID, "attempt", attempt)
+			return GenerateTitleOutput{}, fmt.Errorf("generate title for chat %s: %w", input.ChatID, err)
+		}
+	}
+
+	// A model that returns only whitespace would otherwise persist an empty
+	// title, and the early return above means this activity never runs again.
+	if strings.TrimSpace(generatedTitle) == "" {
+		return GenerateTitleOutput{}, fmt.Errorf("generated title for chat %s was empty", input.ChatID)
 	}
 
 	// 3. Update chat with generated title using RunTx for parallelism

--- a/internal/workflow/runtime/activities/handlers/generate_title_failure_test.go
+++ b/internal/workflow/runtime/activities/handlers/generate_title_failure_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2025 Reliant Labs
+//
+// Regression tests for how title generation FAILS.
+//
+// The activity used to catch an LLM error, substitute the truncated first
+// message, and return success. That made a total provider outage look
+// identical to normal operation: every chat was titled with the user's own
+// text, nothing retried, and the only trace was a WARN line. A brotli
+// content-encoding bug kept every one of these calls failing for a long time
+// behind exactly that mask.
+//
+// The contract now: the activity reports failure, and the WORKFLOW decides to
+// retry and when to settle for the fallback.
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/reliant-labs/reliant/internal/db"
+	"github.com/reliant-labs/reliant/internal/llm"
+	"github.com/reliant-labs/reliant/internal/llm/drivers"
+	"github.com/reliant-labs/reliant/internal/llm/models"
+	"github.com/reliant-labs/reliant/internal/llm/tools"
+	"github.com/reliant-labs/reliant/internal/models/message"
+)
+
+// failingTitleDriver fails SendMessages the way a provider outage does.
+type failingTitleDriver struct {
+	mockLLMDriverForIdempotency
+	err   error
+	calls int
+}
+
+func (d *failingTitleDriver) SendMessages(ctx context.Context, prompts []string, messages []message.Message, tls []tools.Tool) (*llm.DriverResponse, error) {
+	d.calls++
+	return nil, d.err
+}
+
+func failingTitleResolver(d *failingTitleDriver) drivers.DriverResolver {
+	return func(ctx context.Context, userID string, prefs models.Preferences, o ...llm.DriverOption) (llm.Driver, error) {
+		var opts llm.DriverOptions
+		for _, apply := range o {
+			apply(&opts)
+		}
+		return d, nil
+	}
+}
+
+// seedTitleChat creates a chat with no title, as CreateChat leaves it.
+func seedTitleChat(t *testing.T, repo db.Repository) string {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	userID := "test-user"
+	projectID := uuid.New().String()
+	require.NoError(t, repo.CreateProject(ctx, &db.Project{
+		ID: projectID, Name: "P", Path: "/tmp/project-main", UserID: userID,
+		CreatedAt: now, UpdatedAt: now, LastActive: now,
+	}))
+
+	chatID := uuid.New().String()
+	require.NoError(t, repo.CreateChat(ctx, &db.Chat{
+		ID: chatID, ProjectID: projectID, UserID: userID,
+		CreatedAt: now, UpdatedAt: now, LastActive: now,
+	}))
+	return chatID
+}
+
+// The core regression: an LLM failure must surface as an activity error, NOT a
+// silent success carrying the user's own text. This is the exact shape of the
+// brotli decode failure that hid in production.
+func TestGenerateTitle_LLMFailureReturnsErrorInsteadOfSilentFallback(t *testing.T) {
+	repo := setupTestRepo(t)
+	chatID := seedTitleChat(t, repo)
+
+	driver := &failingTitleDriver{
+		err: errors.New("error parsing response json: invalid character '\\x03' looking for beginning of value"),
+	}
+	activity := &GenerateTitleActivity{repo: repo, driverResolver: failingTitleResolver(driver)}
+
+	firstMessage := "creating titles of chats is broken, it's just using my text"
+	_, err := activity.Execute(context.Background(), GenerateTitleInput{
+		ChatID:       chatID,
+		FirstMessage: firstMessage,
+	})
+
+	require.Error(t, err, "an LLM failure must fail the activity so Temporal retries")
+	assert.Contains(t, err.Error(), "invalid character")
+
+	// Nothing may be persisted on a failed attempt — a retry must still see an
+	// untitled chat, since the activity returns early once a title exists.
+	chat, getErr := repo.GetChat(context.Background(), chatID)
+	require.NoError(t, getErr)
+	assert.Empty(t, chat.Title, "a failed attempt must not persist a title")
+	assert.NotEqual(t, firstMessage, chat.Title)
+}
+
+// The fallback still exists, but only when the caller asks for it explicitly.
+func TestGenerateTitle_UseFallbackWritesTruncatedFirstMessage(t *testing.T) {
+	repo := setupTestRepo(t)
+	chatID := seedTitleChat(t, repo)
+
+	// The driver must never be consulted on the fallback path.
+	driver := &failingTitleDriver{err: errors.New("must not be called")}
+	activity := &GenerateTitleActivity{repo: repo, driverResolver: failingTitleResolver(driver)}
+
+	out, err := activity.Execute(context.Background(), GenerateTitleInput{
+		ChatID:       chatID,
+		FirstMessage: "creating titles of chats is broken",
+		UseFallback:  true,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "creating titles of chats is broken", out.Title)
+	assert.Zero(t, driver.calls, "fallback must not call the LLM")
+
+	chat, getErr := repo.GetChat(context.Background(), chatID)
+	require.NoError(t, getErr)
+	assert.Equal(t, "creating titles of chats is broken", chat.Title)
+}
+
+// A model that returns only whitespace must fail rather than persist an empty
+// title: the activity returns early when a title is set, so an empty one would
+// leave the chat permanently untitled.
+func TestGenerateTitle_EmptyGeneratedTitleIsAnError(t *testing.T) {
+	repo := setupTestRepo(t)
+	chatID := seedTitleChat(t, repo)
+
+	d := &titleDriver{resp: setTitleCall(`{"title":"   "}`)}
+	var opts llm.DriverOptions
+	activity := &GenerateTitleActivity{repo: repo, driverResolver: titleResolver(d, &opts)}
+
+	_, err := activity.Execute(context.Background(), GenerateTitleInput{
+		ChatID:       chatID,
+		FirstMessage: "some first message",
+	})
+
+	require.Error(t, err, "a blank title must not be persisted")
+
+	chat, getErr := repo.GetChat(context.Background(), chatID)
+	require.NoError(t, getErr)
+	assert.Empty(t, chat.Title)
+}
+
+// An already-titled chat short-circuits before any LLM call, so a retry or a
+// duplicate workflow never overwrites a good title.
+func TestGenerateTitle_AlreadyTitledChatSkipsLLM(t *testing.T) {
+	repo := setupTestRepo(t)
+	ctx := context.Background()
+	chatID := seedTitleChat(t, repo)
+
+	chat, err := repo.GetChat(ctx, chatID)
+	require.NoError(t, err)
+	chat.Title = "Existing Title"
+	require.NoError(t, repo.UpdateChat(ctx, chat))
+
+	driver := &failingTitleDriver{err: errors.New("must not be called")}
+	activity := &GenerateTitleActivity{repo: repo, driverResolver: failingTitleResolver(driver)}
+
+	out, err := activity.Execute(ctx, GenerateTitleInput{
+		ChatID:       chatID,
+		FirstMessage: "some first message",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "Existing Title", out.Title)
+	assert.Zero(t, driver.calls)
+}

--- a/internal/workflow/runtime/activities/handlers/generate_title_payload_test.go
+++ b/internal/workflow/runtime/activities/handlers/generate_title_payload_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Reliant Labs
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/converter"
+)
+
+// GenerateTitleWorkflow builds its activity input as a map[string]interface{}
+// (that is what CreateChat sends), while the activity receives the typed
+// GenerateTitleInput. Temporal's payload converter bridges the two, so the
+// fallback flag only works if the JSON tag matches the map key exactly.
+//
+// A mocked activity cannot catch a mismatch here — it would silently decode to
+// false, the fallback would quietly re-run the failing LLM path, and a chat
+// would be left untitled. This test crosses that seam for real.
+func TestGenerateTitleInput_FallbackFlagSurvivesPayloadConversion(t *testing.T) {
+	dc := converter.GetDefaultDataConverter()
+
+	workflowInput := map[string]interface{}{
+		"chat_id":       "chat-123",
+		"first_message": "creating titles of chats is broken",
+		"use_fallback":  true,
+	}
+
+	payload, err := dc.ToPayload(workflowInput)
+	require.NoError(t, err)
+
+	var decoded GenerateTitleInput
+	require.NoError(t, dc.FromPayload(payload, &decoded))
+
+	assert.Equal(t, "chat-123", decoded.ChatID)
+	assert.Equal(t, "creating titles of chats is broken", decoded.FirstMessage)
+	assert.True(t, decoded.UseFallback,
+		`use_fallback must decode to UseFallback; check the json tag on GenerateTitleInput`)
+}
+
+// The normal path omits the key entirely, which must mean "call the LLM".
+func TestGenerateTitleInput_DefaultsToLLMPath(t *testing.T) {
+	dc := converter.GetDefaultDataConverter()
+
+	payload, err := dc.ToPayload(map[string]interface{}{
+		"chat_id":       "chat-123",
+		"first_message": "some message",
+	})
+	require.NoError(t, err)
+
+	var decoded GenerateTitleInput
+	require.NoError(t, dc.FromPayload(payload, &decoded))
+
+	assert.False(t, decoded.UseFallback, "absent use_fallback must mean the LLM path")
+}


### PR DESCRIPTION
Lands the real work that had been sitting uncommitted in the shared checkout, plus a lockfile fix.

## The fixes

**`fix(db)` — carry `display_style` on live message updates.** This is the "params have changed" system message appearing in chat despite being written hidden: the live update path dropped `display_style`, so the client never learned the message was meant to be hidden.

**`fix(llm)` — decode compressed claude-code responses.** The driver advertised brotli in its `Accept-Encoding` and then never decoded it, so non-streaming calls failed with `invalid character '\x03'` — a JSON parser being handed compressed bytes.

**`fix(workflow)` — retry title generation instead of silently falling back.** Failures were swallowed into a default title rather than retried.

**`fix(electron)` — sync the lockfile.** `npm ci` fails on `main` today: the lockfile is missing `electron-builder-squirrel-windows@26.0.11`, `electron-winstaller@5.4.0` and 11 transitive deps. Additive only — 197 lines added, nothing removed or downgraded.

Plus two investigation documents recording the prod endpoint/CORS incident.

## What was deliberately NOT taken

The shared checkout is at v1.7.1 while `main` is at v1.7.4, so many of its files are **older** than main, not newer. Every dirty file was diffed against `origin/main` rather than trusted. Three would have been outright regressions:

| File | Would have done |
|---|---|
| `electron/package.json` | reverted 1.7.4 → 1.7.1 |
| `.github/workflows/release.yml` | dropped the `shell: bash` Windows fixes |
| `go.sum` / `go.work.sum` | downgraded forge v0.1.2 → v0.1.1 |

A further **47 files were already identical to main** — including several that looked new (`daemon_nonint_test.go`, `oauth_nonint_test.go`, `publisher_test.go`, the three web test files, `daemon-contract.js`, and all of `.github/actions/`, `.github/scripts/`, `.github/release-config.env`). Those landed in earlier PRs today.

## Verification

```
go build ./...                    exit 0
go test ./internal/... ./cmd/...  exit 0, ok=108 FAIL=0
web: tsc -b                       exit 0
web: vitest run                   270 files / 1974 tests passed
electron: npm test                125 pass / 0 fail
electron: npm ci                  exit 0 (was failing before the lockfile fix)
```

## Worth knowing: the new DB tests skip without a database

The four new DB tests require `DATABASE_URL`; without it the suite reports green while verifying nothing. They were run against the repo's own dev Postgres (isolated per-package DB, no real data touched) and all pass — **and the fix was reverted to confirm they actually fail without it**:

```
--- FAIL: TestSaveMessageToThread_UpdateCarriesDisplayStyle
    SaveMessageToThread emitted a live update with no display_style
--- FAIL: TestEnrichMessageUpdate_CarriesDisplayStyle
--- FAIL: TestSaveMessageToThread_UpdateCarriesVisibleDisplayStyle
```

That is the difference between a test that passes and a test that proves something. CI will only exercise them if it sets `DATABASE_URL` — worth addressing separately.
