### PR TITLE
chore: release v1.7.5

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -13,6 +13,14 @@ Regenerate with: make generate-changelog
 
 Track what's new in each Reliant release.
 
+<Update label="v1.7.5" description="August 20, 2026">
+### Three fixes to things that misbehaved quietly
+
+- **The "Some of your params have changed" message stays hidden** Messages that exist only to give the model context are marked hidden and filtered out of the transcript. When one of those arrived as a live update rather than on a page load, the hidden marking was dropped along the way, so the message appeared in your chat until you reloaded — at which point it vanished, which made it look random. The marking now travels with live updates, so a hidden message is hidden the first time and stays that way.
+- **Non-streaming Claude Code requests no longer fail with a decoding error** The Claude Code driver told the server it could accept brotli-compressed responses, but never actually decompressed them. Every non-streaming call therefore tried to read compressed bytes as JSON and failed with `invalid character '\x03' looking for beginning of value`. The driver now only advertises the compression formats it can genuinely handle, and decompresses the response before reading it.
+- **Chat titles retry instead of silently falling back to your first message** If the model call that names a chat failed, the failure was swallowed and the chat was titled with a truncated copy of whatever you typed first. There was no retry and nothing in the logs, so a provider outage looked exactly like normal operation. The title request is now retried three times with backoff, and only falls back to your first message after those genuinely fail — and that fallback is recorded rather than invisible. Titles that come back empty are also rejected now, instead of being saved permanently.
+</Update>
+
 <Update label="v1.7.4" description="August 20, 2026">
 ### Picks up the forge scaffolding fix
 

--- a/docs/data/releases/v1.7.5.yaml
+++ b/docs/data/releases/v1.7.5.yaml
@@ -1,0 +1,11 @@
+version: "v1.7.5"
+date: "2026-08-20"
+title: "Three fixes to things that misbehaved quietly"
+summary: "A stray system message no longer appears in your transcript, non-streaming Claude Code requests no longer fail outright, and chat titles are generated properly instead of quietly settling for the first line of your message. All three were failures you could see but not explain."
+items:
+  - title: "The \"Some of your params have changed\" message stays hidden"
+    description: "Messages that exist only to give the model context are marked hidden and filtered out of the transcript. When one of those arrived as a live update rather than on a page load, the hidden marking was dropped along the way, so the message appeared in your chat until you reloaded — at which point it vanished, which made it look random. The marking now travels with live updates, so a hidden message is hidden the first time and stays that way."
+  - title: "Non-streaming Claude Code requests no longer fail with a decoding error"
+    description: "The Claude Code driver told the server it could accept brotli-compressed responses, but never actually decompressed them. Every non-streaming call therefore tried to read compressed bytes as JSON and failed with `invalid character '\\x03' looking for beginning of value`. The driver now only advertises the compression formats it can genuinely handle, and decompresses the response before reading it."
+  - title: "Chat titles retry instead of silently falling back to your first message"
+    description: "If the model call that names a chat failed, the failure was swallowed and the chat was titled with a truncated copy of whatever you typed first. There was no retry and nothing in the logs, so a provider outage looked exactly like normal operation. The title request is now retried three times with backoff, and only falls back to your first message after those genuinely fail — and that fallback is recorded rather than invisible. Titles that come back empty are also rejected now, instead of being saved permanently."

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reliant",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "AI-powered coding assistant with intelligent agents for professional software development",
   "author": "Reliant Labs <support@reliantlabs.io>",
   "homepage": "https://reliantlabs.io",


### PR DESCRIPTION
Cuts the v1.7.5 patch release: bumps the Electron app version and adds release notes for everything merged since v1.7.4.

## Changes
- `electron/package.json` 1.7.4 → 1.7.5 (the single version source)
- `docs/data/releases/v1.7.5.yaml` — new release notes
- `docs/changelog.mdx` — regenerated via `make generate-changelog`

## What is in the release
Three user-visible fixes from #193:
- **display_style on live updates** — a hidden, LLM-context-only system message ("Some of your params have changed") rendered in the transcript until reload
- **brotli decode for claude-code** — every non-streaming call failed with `invalid character '\x03' looking for beginning of value`
- **title-generation retry** — LLM failures were swallowed and every chat silently got the truncated-first-message fallback

The electron lockfile sync and docs from #193 are also carried, but are not user-facing and are deliberately not listed in the notes.

No changelog email is sent by this release — the `notify-changelog` job was removed in #181 and this PR does not reintroduce it.
