### PR TITLE
fix(web): recognize the packaged app:// origin, and fail PKCE loudly

### DIFF
--- a/web/src/api/grpc-client.ts
+++ b/web/src/api/grpc-client.ts
@@ -27,7 +27,11 @@ import { DaemonTokenService } from "../gen/reliant/v1/daemon_token_pb";
 import { QuestionService } from "../gen/reliant/v1/question_pb";
 import { ConnectorService } from "../gen/reliant/v1/connector_pb";
 import { logger } from "../lib/logger";
-import { buildLocalhostUrl, isSameOriginTransport } from "../lib/protocol";
+import {
+  buildLocalhostUrl,
+  isPackagedRendererOrigin,
+  isSameOriginTransport,
+} from "../lib/protocol";
 import {
   buildInterceptors,
   setCurrentBaseURL,
@@ -62,9 +66,10 @@ const getGRPCBaseURL = (): string | null => {
     }
   }
 
-  // If we're in a file:// protocol (Electron but config not loaded yet),
-  // we need to wait for the config - return null to indicate not ready
-  if (typeof window !== "undefined" && window.location.protocol === "file:") {
+  // Packaged desktop app whose config has not been injected yet: return null to
+  // indicate not-ready rather than falling through to the browser defaults
+  // below, which would dial a localhost port nothing is listening on.
+  if (isPackagedRendererOrigin()) {
     logger.warn(
       "[gRPC Client] Electron detected but backend config not yet available"
     );

--- a/web/src/api/grpc-unauth.ts
+++ b/web/src/api/grpc-unauth.ts
@@ -23,7 +23,11 @@ import {
   StartOAuthSignInRequestSchema,
   SystemService,
 } from "../gen/reliant/v1/system_pb";
-import { buildLocalhostUrl, isSameOriginTransport } from "../lib/protocol";
+import {
+  buildLocalhostUrl,
+  isPackagedRendererOrigin,
+  isSameOriginTransport,
+} from "../lib/protocol";
 import { buildInterceptors } from "./transport";
 
 // Minimal local logger. Avoids depending on `@/lib/logger` to keep the
@@ -54,9 +58,8 @@ const getGRPCBaseURL = (): string | null => {
     }
   }
 
-  // If we're in a file:// protocol (Electron but config not loaded yet),
-  // return null to indicate not ready
-  if (typeof window !== "undefined" && window.location.protocol === "file:") {
+  // Packaged desktop app whose config has not been injected yet: not ready.
+  if (isPackagedRendererOrigin()) {
     return null;
   }
 

--- a/web/src/lib/__tests__/oauth-insecure-context.test.ts
+++ b/web/src/lib/__tests__/oauth-insecure-context.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/api/settings-grpc", () => ({
+  settingsGrpc: {
+    completeCodexOAuth: vi.fn(),
+    completeClaudeOAuth: vi.fn(),
+  },
+}));
+
+vi.mock("@/api/daemon-grpc", () => ({
+  startOAuthViaDaemon: vi.fn(),
+}));
+
+vi.mock("@/lib/oauth-local", () => ({
+  startOAuthViaLocalServer: vi.fn(),
+}));
+
+import { startOAuthViaDaemon } from "@/api/daemon-grpc";
+import { runCodexOAuthFlow } from "@/lib/codex-oauth";
+import { runClaudeOAuthFlow } from "@/lib/claude-oauth";
+
+/**
+ * PKCE needs SHA-256, which lives on `crypto.subtle`. That object only exists
+ * in a SECURE CONTEXT — an https:// page, or http:// on localhost/127.0.0.1.
+ * Reach the app over plain http:// on a LAN IP or a tunnel host (the mobile
+ * surface and the ngrok/cloudflared hosts `vite.config.ts` allow-lists are
+ * exactly that shape) and `crypto.subtle` is `undefined`.
+ *
+ * Before this fix the flow read `crypto.subtle.digest` unguarded and died with
+ * "Cannot read properties of undefined (reading 'digest')" — a TypeError that
+ * names neither the cause nor the remedy, thrown out of the flow rather than
+ * returned as a result the UI knows how to display.
+ */
+
+const originalCrypto = globalThis.crypto;
+
+/** A non-secure context: crypto exists, crypto.subtle does not. */
+const stubInsecureContext = () => {
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    writable: true,
+    value: {
+      getRandomValues: (values: Uint8Array) => {
+        for (let i = 0; i < values.length; i += 1) values[i] = (i * 31) % 256;
+        return values;
+      },
+      // subtle intentionally absent — this is what a non-secure origin gives you.
+    } as unknown as Crypto,
+  });
+};
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    writable: true,
+    value: originalCrypto,
+  });
+  vi.clearAllMocks();
+});
+
+describe.each([
+  ["Codex", runCodexOAuthFlow],
+  ["Claude", runClaudeOAuthFlow],
+])("%s OAuth on a non-secure origin", (_label, runFlow) => {
+  it("returns a failed result instead of throwing a TypeError", async () => {
+    stubInsecureContext();
+
+    // Must not reject: the UI hooks render `result.message`.
+    const result = await runFlow();
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("reports pkce_generation_failed with an actionable message", async () => {
+    stubInsecureContext();
+
+    const result = await runFlow();
+
+    if (result.ok) throw new Error("expected the flow to fail");
+    expect(result.errorCode).toBe("pkce_generation_failed");
+    // The message must name the cause (insecure origin) and the remedy
+    // (HTTPS/localhost) rather than leaking "reading 'digest'".
+    expect(result.message).toMatch(/secure context|HTTPS/i);
+    expect(result.message).not.toMatch(/digest/);
+  });
+
+  it("never starts the browser round trip it cannot complete", async () => {
+    stubInsecureContext();
+
+    await runFlow();
+
+    // Without a code challenge there is nothing to authorize against; opening
+    // a browser window here would strand the user on a dead flow.
+    expect(startOAuthViaDaemon).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/__tests__/packagedOrigin.test.ts
+++ b/web/src/lib/__tests__/packagedOrigin.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * PR #173 moved the packaged renderer from `file://` to `app://bundle` so the
+ * root-absolute asset paths in the Vite bundle resolve. It changed only files
+ * under `electron/`, so every `window.location.protocol === "file:"` test in
+ * `web/src` — each one a stand-in for "is this the packaged desktop app" —
+ * silently stopped matching the packaged app.
+ *
+ * These tests pin the packaged-app behaviour to the ORIGIN the packaged app
+ * actually has, so a future scheme change fails here instead of in the field.
+ */
+
+type TestWindow = Window & {
+  electronAPI?: unknown
+  RELIANT_CONFIG?: Record<string, unknown>
+}
+
+const setOrigin = (origin: string, protocol: string) => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, origin, protocol, href: `${origin}/` },
+  })
+}
+
+/** The packaged desktop app as it actually runs since v1.7.0. */
+const runAsPackagedElectron = () => {
+  ;(window as TestWindow).electronAPI = {}
+  setOrigin('app://bundle', 'app:')
+}
+
+afterEach(() => {
+  delete (window as TestWindow).electronAPI
+  delete (window as TestWindow).RELIANT_CONFIG
+  vi.unstubAllEnvs()
+  vi.resetModules()
+})
+
+describe('getAppURL under the packaged app:// origin', () => {
+  it('does not hand app://bundle to an identity provider as a redirect target', async () => {
+    const { getAppURL } = await import('@/lib/constants')
+    runAsPackagedElectron()
+
+    // `app://bundle/auth/callback` is reachable only from inside this
+    // renderer. A provider redirect there goes nowhere.
+    expect(getAppURL()).toBe('https://app.reliantlabs.io')
+  })
+})
+
+describe('isConfigReady under the packaged app:// origin', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('reports not-ready until RELIANT_CONFIG has actually been injected', async () => {
+    const { isConfigReady } = await import('@/lib/configReady')
+    runAsPackagedElectron()
+
+    // preload.js injects RELIANT_CONFIG asynchronously via postMessage. Before
+    // it lands the packaged app has no backend URL, so it is NOT ready.
+    expect(isConfigReady()).toBe(false)
+  })
+
+  it('reports ready once RELIANT_CONFIG is present', async () => {
+    const { isConfigReady } = await import('@/lib/configReady')
+    runAsPackagedElectron()
+    ;(window as TestWindow).RELIANT_CONFIG = { grpcUrl: 'http://127.0.0.1:9090' }
+
+    expect(isConfigReady()).toBe(true)
+  })
+})
+
+describe('waitForConfig under the packaged app:// origin', () => {
+  it('waits for the async RELIANT_CONFIG injection instead of returning immediately', async () => {
+    vi.resetModules()
+    const { waitForConfig } = await import('@/lib/configReady')
+    runAsPackagedElectron()
+
+    let settled = false
+    const pending = waitForConfig(2000).then(() => {
+      settled = true
+    })
+
+    // Nothing injected yet: the packaged app must still be waiting.
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    ;(window as TestWindow).RELIANT_CONFIG = { grpcUrl: 'http://127.0.0.1:9090' }
+    window.postMessage(
+      { type: 'reliant-config-ready', config: { grpcUrl: 'http://127.0.0.1:9090' } },
+      '*',
+    )
+
+    await pending
+    expect(settled).toBe(true)
+  })
+})
+
+describe('transport selection under the packaged app:// origin', () => {
+  it('never treats the packaged renderer as a same-origin (Vite-proxy) surface', async () => {
+    const { isSameOriginTransport } = await import('@/lib/protocol')
+    runAsPackagedElectron()
+
+    // There is no dev-server proxy inside the packaged app. A same-origin RPC
+    // would resolve to app://bundle/reliant.v1.* and hit the SPA's index.html.
+    expect(isSameOriginTransport()).toBe(false)
+  })
+})

--- a/web/src/lib/claude-oauth.ts
+++ b/web/src/lib/claude-oauth.ts
@@ -2,6 +2,13 @@ import * as Sentry from '@sentry/react'
 import { settingsGrpc } from '@/api/settings-grpc'
 import { startOAuthViaDaemon } from '@/api/daemon-grpc'
 import { startOAuthViaLocalServer } from '@/lib/oauth-local'
+import {
+  InsecureContextError,
+  base64UrlEncode,
+  generateCodeChallenge,
+  generateCodeVerifier,
+  randomBytes,
+} from '@/lib/pkce'
 
 const CLAUDE_OAUTH_AUTHORIZE_URL = 'https://claude.ai/oauth/authorize'
 const CLAUDE_OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e'
@@ -42,37 +49,30 @@ const errorResult = (errorCode: ClaudeOAuthErrorCode, message: string): ClaudeOA
   message,
 })
 
-const base64UrlEncode = (bytes: Uint8Array): string => {
-  let binary = ''
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte)
-  }
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
-}
-
-const randomBytes = (length: number): Uint8Array => {
-  const values = new Uint8Array(length)
-  crypto.getRandomValues(values)
-  return values
-}
-
-const generateCodeVerifier = (): string => base64UrlEncode(randomBytes(64))
-
-const generateCodeChallenge = async (codeVerifier: string): Promise<string> => {
-  const encoded = new TextEncoder().encode(codeVerifier)
-  const digest = await crypto.subtle.digest('SHA-256', encoded)
-  return base64UrlEncode(new Uint8Array(digest))
-}
-
 export async function runClaudeOAuthFlow(options: ClaudeOAuthOptions = {}): Promise<ClaudeOAuthResult> {
   const statePrefix = options.statePrefix ?? CLAUDE_OAUTH_STATE_PREFIX
   const authorizeUrl = options.authorizeUrl ?? CLAUDE_OAUTH_AUTHORIZE_URL
   const clientId = options.clientId ?? CLAUDE_OAUTH_CLIENT_ID
   const scope = options.scope ?? CLAUDE_OAUTH_DEFAULT_SCOPE
 
-  // Generate PKCE
-  const codeVerifier = generateCodeVerifier()
-  const codeChallenge = await generateCodeChallenge(codeVerifier)
+  // Generate PKCE. This runs BEFORE the browser round trip and must not throw:
+  // on a non-secure origin crypto.subtle is undefined, and the raw TypeError
+  // ("reading 'digest'") escaped the flow entirely instead of reaching the UI.
+  let codeVerifier: string
+  let codeChallenge: string
+  try {
+    codeVerifier = generateCodeVerifier()
+    codeChallenge = await generateCodeChallenge(codeVerifier)
+  } catch (error) {
+    const message =
+      error instanceof InsecureContextError
+        ? error.message
+        : 'Could not generate the PKCE challenge required to sign in.'
+    Sentry.captureException(error, {
+      tags: { component: 'oauth', provider: 'claude', stage: 'pkce' },
+    })
+    return errorResult('pkce_generation_failed', message)
+  }
 
   // Generate state
   const state = statePrefix + base64UrlEncode(randomBytes(24))

--- a/web/src/lib/codex-oauth.ts
+++ b/web/src/lib/codex-oauth.ts
@@ -2,6 +2,13 @@ import * as Sentry from '@sentry/react'
 import { settingsGrpc } from '@/api/settings-grpc'
 import { startOAuthViaDaemon } from '@/api/daemon-grpc'
 import { startOAuthViaLocalServer } from '@/lib/oauth-local'
+import {
+  InsecureContextError,
+  base64UrlEncode,
+  generateCodeChallenge,
+  generateCodeVerifier,
+  randomBytes,
+} from '@/lib/pkce'
 
 const CODEX_OAUTH_AUTHORIZE_URL = 'https://auth.openai.com/oauth/authorize'
 const CODEX_OAUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann'
@@ -48,37 +55,30 @@ const errorResult = (errorCode: CodexOAuthErrorCode, message: string): CodexOAut
   message,
 })
 
-const base64UrlEncode = (bytes: Uint8Array): string => {
-  let binary = ''
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte)
-  }
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
-}
-
-const randomBytes = (length: number): Uint8Array => {
-  const values = new Uint8Array(length)
-  crypto.getRandomValues(values)
-  return values
-}
-
-const generateCodeVerifier = (): string => base64UrlEncode(randomBytes(64))
-
-const generateCodeChallenge = async (codeVerifier: string): Promise<string> => {
-  const encoded = new TextEncoder().encode(codeVerifier)
-  const digest = await crypto.subtle.digest('SHA-256', encoded)
-  return base64UrlEncode(new Uint8Array(digest))
-}
-
 export async function runCodexOAuthFlow(options: CodexOAuthOptions = {}): Promise<CodexOAuthResult> {
   const statePrefix = options.statePrefix ?? CODEX_OAUTH_STATE_PREFIX
   const authorizeUrl = options.authorizeUrl ?? CODEX_OAUTH_AUTHORIZE_URL
   const clientId = options.clientId ?? CODEX_OAUTH_CLIENT_ID
   const scope = options.scope ?? CODEX_OAUTH_DEFAULT_SCOPE
 
-  // Generate PKCE
-  const codeVerifier = generateCodeVerifier()
-  const codeChallenge = await generateCodeChallenge(codeVerifier)
+  // Generate PKCE. This runs BEFORE the browser round trip and must not throw:
+  // on a non-secure origin crypto.subtle is undefined, and the raw TypeError
+  // ("reading 'digest'") escaped the flow entirely instead of reaching the UI.
+  let codeVerifier: string
+  let codeChallenge: string
+  try {
+    codeVerifier = generateCodeVerifier()
+    codeChallenge = await generateCodeChallenge(codeVerifier)
+  } catch (error) {
+    const message =
+      error instanceof InsecureContextError
+        ? error.message
+        : 'Could not generate the PKCE challenge required to sign in.'
+    Sentry.captureException(error, {
+      tags: { component: 'oauth', provider: 'codex', stage: 'pkce' },
+    })
+    return errorResult('pkce_generation_failed', message)
+  }
 
   // Generate state
   const state = statePrefix + base64UrlEncode(randomBytes(24))

--- a/web/src/lib/configReady.ts
+++ b/web/src/lib/configReady.ts
@@ -2,6 +2,7 @@
 // This is needed in Electron where the config is injected asynchronously
 
 import { logger } from "./logger";
+import { isPackagedRendererOrigin } from "./protocol";
 
 // Default timeout for waiting for config
 const DEFAULT_TIMEOUT_MS = 5000;
@@ -12,13 +13,15 @@ const POLL_INTERVAL_MS = 100;
  */
 export const isConfigReady = (): boolean => {
   if (typeof window === "undefined") return false;
-  
-  // In development browser mode, config is always "ready" (uses env vars or defaults)
-  if (window.location.protocol !== "file:") {
+
+  // In browser mode (dev server or hosted web), config is always "ready" —
+  // it comes from build-time env vars, not from preload.js.
+  if (!isPackagedRendererOrigin()) {
     return true;
   }
-  
-  // In Electron (file:// protocol), check for RELIANT_CONFIG
+
+  // In the packaged desktop app, preload.js injects RELIANT_CONFIG
+  // asynchronously; until it lands there is no backend URL to dial.
   return !!window.RELIANT_CONFIG?.grpcUrl;
 };
 
@@ -28,8 +31,8 @@ export const isConfigReady = (): boolean => {
  * @returns Promise that resolves when config is ready or rejects on timeout
  */
 export const waitForConfig = async (timeoutMs = DEFAULT_TIMEOUT_MS): Promise<void> => {
-  // If not in Electron, config is immediately available
-  if (typeof window === "undefined" || window.location.protocol !== "file:") {
+  // Outside the packaged app, config is immediately available.
+  if (typeof window === "undefined" || !isPackagedRendererOrigin()) {
     return;
   }
   

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -5,6 +5,8 @@
  * and documentation.
  */
 
+import { isPackagedRendererOrigin } from "./protocol";
+
 // ============================================================================
 // Environment Detection
 // ============================================================================
@@ -25,9 +27,9 @@ export const getIsDev = (): boolean => {
       }
 
       // Fallback during very early bootstrap before RELIANT_CONFIG is injected:
-      // - file:// means packaged app => production behavior
+      // - the packaged renderer's own scheme means packaged app => production
       // - http(s) in local Electron dev => allow dev behavior
-      if (window.location.protocol === "file:") {
+      if (isPackagedRendererOrigin()) {
         return false;
       }
 
@@ -59,15 +61,19 @@ const DEFAULT_APP_URL = "https://app.reliantlabs.io";
 
 /**
  * True for an origin that only means something on the machine that produced it.
- * A loopback or file:// origin is never a valid public redirect target: handing
- * one to an identity provider sends the user's browser to a port on their own
- * machine that either isn't listening or belongs to an unrelated process.
+ * A loopback origin, or the packaged renderer's own scheme, is never a valid
+ * public redirect target: handing one to an identity provider sends the user's
+ * browser to a port on their own machine that either isn't listening or belongs
+ * to an unrelated process — or, for `app://bundle`, to a scheme that exists
+ * only inside this Electron process and that no browser can resolve at all.
  */
 const isLocalOrigin = (origin: string): boolean => {
   if (!origin || origin === "null") return true;
   try {
     const { protocol, hostname } = new URL(origin);
-    if (protocol === "file:") return true;
+    // `app:` is the packaged renderer's scheme, `file:` its pre-v1.7.0
+    // predecessor. Neither is reachable from outside this process.
+    if (protocol === "file:" || protocol === "app:") return true;
     return (
       hostname === "localhost" ||
       hostname === "127.0.0.1" ||

--- a/web/src/lib/pkce.ts
+++ b/web/src/lib/pkce.ts
@@ -1,0 +1,64 @@
+/**
+ * PKCE primitives shared by the provider OAuth flows (Claude, Codex).
+ *
+ * The S256 code challenge is a SHA-256 of the verifier, and SHA-256 in a
+ * browser lives on `crypto.subtle` — which exists only in a SECURE CONTEXT.
+ * An https:// page has one; so does http:// on localhost or 127.0.0.1. Plain
+ * http:// on a LAN IP or a tunnel host does NOT, and there `crypto.subtle` is
+ * `undefined`.
+ *
+ * Reading through it unguarded produced "Cannot read properties of undefined
+ * (reading 'digest')" — a TypeError that names neither the cause nor the fix,
+ * thrown out of the flow instead of returned as a result the UI can render.
+ *
+ * We deliberately do NOT ship a pure-JS SHA-256 fallback. It would make the
+ * PKCE handshake itself work, but the flow would still be running on an origin
+ * where every token it is about to obtain travels in clear text, and where the
+ * browser withholds the rest of the secure-context APIs. Papering over that
+ * would convert a loud, fixable misconfiguration into a silent one that hands
+ * out credentials over plaintext. The remedy is to serve the app over HTTPS or
+ * reach it on localhost, so that is what the error says.
+ */
+
+/** Raised when PKCE cannot run because the page is not a secure context. */
+export class InsecureContextError extends Error {
+  constructor() {
+    super(
+      "This page is not running in a secure context, so the browser does not " +
+        "provide the SHA-256 needed to sign in. Open the app over HTTPS, or on " +
+        "localhost, and try again.",
+    );
+    this.name = "InsecureContextError";
+  }
+}
+
+export const base64UrlEncode = (bytes: Uint8Array): string => {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+};
+
+export const randomBytes = (length: number): Uint8Array => {
+  const values = new Uint8Array(length);
+  crypto.getRandomValues(values);
+  return values;
+};
+
+export const generateCodeVerifier = (): string => base64UrlEncode(randomBytes(64));
+
+/**
+ * SHA-256 the verifier into an S256 code challenge.
+ *
+ * @throws {InsecureContextError} when `crypto.subtle` is unavailable.
+ */
+export const generateCodeChallenge = async (codeVerifier: string): Promise<string> => {
+  if (typeof crypto === "undefined" || !crypto.subtle) {
+    throw new InsecureContextError();
+  }
+
+  const encoded = new TextEncoder().encode(codeVerifier);
+  const digest = await crypto.subtle.digest("SHA-256", encoded);
+  return base64UrlEncode(new Uint8Array(digest));
+};

--- a/web/src/lib/protocol.ts
+++ b/web/src/lib/protocol.ts
@@ -42,6 +42,39 @@ export const buildLocalhostUrl = (port: string | number): string => {
 };
 
 /**
+ * The scheme the packaged desktop renderer is served from.
+ *
+ * `app://bundle` (see electron/src/app-protocol.js). Packaged builds used
+ * `file://` up to and including v1.6.3; `loadFile()` gave the page a `file://`
+ * origin, where the bundle's root-absolute asset paths resolved against the
+ * FILESYSTEM root and nothing loaded. v1.7.0 moved to a real origin.
+ */
+const PACKAGED_SCHEMES = ["app:", "file:"] as const;
+
+/**
+ * True when this renderer is the PACKAGED desktop app rather than a browser or
+ * a Vite dev server.
+ *
+ * This is the single discriminator for "no dev-server proxy, and the backend
+ * URL arrives asynchronously from preload.js". It exists because that question
+ * was previously asked as `window.location.protocol === "file:"` in seven
+ * different places. When the packaged renderer moved from `file://` to
+ * `app://bundle`, every one of those checks silently flipped to its
+ * browser-shaped branch — the packaged app started reporting that its config
+ * was ready before preload had injected any, and handed `app://bundle` to
+ * identity providers as an OAuth redirect target.
+ *
+ * Both schemes are matched so the historical `file://` build keeps working, and
+ * so the next scheme change is one edit here rather than another silent drift.
+ */
+export const isPackagedRendererOrigin = (): boolean => {
+  if (typeof window === "undefined") return false;
+  return (PACKAGED_SCHEMES as readonly string[]).includes(
+    window.location.protocol,
+  );
+};
+
+/**
  * Whether Connect transports should use a SAME-ORIGIN (relative) baseUrl so the
  * Vite dev-server proxy fans every RPC out to its backend (`/reliant.v1.*` →
  * reliant-api, `/controlplane.v1.*` → admin-server). This is the SINGLE root
@@ -50,12 +83,12 @@ export const buildLocalhostUrl = (port: string | number): string => {
  * does the host routing — no absolute cross-origin backend URLs, no per-port
  * CORS bookkeeping, no random-electron-port allow-listing.
  *
- * Packaged Electron is the ONLY exception: it loads the bundle from `file://`
- * and there is no dev-server proxy, so it must dial the local daemon at the
- * absolute `window.RELIANT_CONFIG.grpcUrl`. The `file://` check is the same
- * discriminator `lib/configReady.ts` already uses to decide whether to block on
+ * Packaged Electron is the ONLY exception: it serves the bundle from its own
+ * scheme (`app://bundle`) and there is no dev-server proxy, so it must dial the
+ * local daemon at the absolute `window.RELIANT_CONFIG.grpcUrl`. That is the
+ * same discriminator `lib/configReady.ts` uses to decide whether to block on
  * the async RELIANT_CONFIG injection — so the whole renderer stays consistent:
- * http-served ⇒ browser-like (same-origin proxy); file:// ⇒ packaged daemon.
+ * http-served ⇒ browser-like (same-origin proxy); packaged ⇒ packaged daemon.
  */
 export const isSameOriginTransport = (): boolean => {
   if (typeof window === "undefined") return false;
@@ -66,6 +99,6 @@ export const isSameOriginTransport = (): boolean => {
   // same-origin RPC hits the SPA's own index.html → "unsupported content type
   // text/html" and the app hangs. Prod builds must dial the absolute per-env
   // backend URLs (VITE_API_URL / VITE_CONTROL_PLANE_API_URL). Packaged Electron
-  // (file://, a prod build) is excluded by both checks and uses RELIANT_CONFIG.
-  return import.meta.env.DEV && window.location.protocol !== "file:";
+  // (a prod build) is excluded by both checks and uses RELIANT_CONFIG.
+  return import.meta.env.DEV && !isPackagedRendererOrigin();
 };

--- a/web/src/store/shortcutsStore.ts
+++ b/web/src/store/shortcutsStore.ts
@@ -17,6 +17,7 @@
 import { create } from "zustand";
 import { api } from "../api/client";
 import { logger } from "../lib/logger";
+import { isPackagedRendererOrigin } from "../lib/protocol";
 import { parseBinding } from "../lib/keyboard/chord";
 import { detectPlatform } from "../lib/keyboard/platform";
 import { getReservation, type Reservation } from "../lib/keyboard/reserved";
@@ -183,10 +184,7 @@ export const useShortcutsStore = create<ShortcutsState>()((set, get) => ({
     try {
       set({ isLoading: true });
 
-      if (
-        typeof window !== "undefined" &&
-        window.location.protocol === "file:"
-      ) {
+      if (isPackagedRendererOrigin()) {
         // Electron: the gRPC endpoint is injected after the page loads.
         const maxWaitTime = 5000;
         const startTime = Date.now();


### PR DESCRIPTION
Fixes two user-reported Electron auth bugs. Both are renderer-side; no `electron/` files change.

## Bug 1 — "Sign in with GitHub" → black screen, no console/network errors

**Root cause: PR #173 (`487fb19a`, shipped in v1.7.0) moved the packaged renderer from `file://` to `app://bundle` but touched only `electron/` files.** Every `window.location.protocol === "file:"` check in `web/src` — each a stand-in for *"is this the packaged desktop app"* — silently flipped to its browser-shaped branch. Seven sites, all wrong in the packaged app since v1.7.0:

| Site | Consequence under `app://bundle` |
|---|---|
| `configReady.isConfigReady` | Reports **ready** before preload.js injected `RELIANT_CONFIG` |
| `configReady.waitForConfig` | Returns **immediately** instead of awaiting the async injection |
| `grpc-client` / `grpc-unauth` | Not-ready guard stops firing; falls through to the browser default and dials a localhost port nothing is listening on |
| `constants.getIsDev` | Packaged app takes the **dev** branch |
| `constants.isLocalOrigin` | `app://bundle` is neither loopback nor `file:`, so `getAppURL()` returns `app://bundle` and OAuth redirects point at a scheme that exists only inside this process |
| `shortcutsStore` | Skips its wait-for-config loop |

`isLocalOrigin` is the sharpest: the function exists specifically to stop a local origin being handed to an identity provider, and `app://bundle` walks straight past it.

**Fix:** one helper, `isPackagedRendererOrigin()`, matching both `app:` and the historical `file:`, replacing all seven ad-hoc comparisons. The next scheme change is a one-line edit instead of another silent drift.

## Bug 2 — `Cannot read properties of undefined (reading 'digest')`

PKCE's S256 challenge needs SHA-256 from `crypto.subtle`, which exists **only in a secure context**. Both provider flows read through it unguarded *and outside their `try` block*, so on a non-secure origin the raw `TypeError` escaped the flow entirely rather than reaching the UI — and the flow would open a browser round trip it could never complete.

**This is not the packaged app.** Verified empirically in a real Electron 39.2.7 harness registering the scheme exactly as `app-protocol.js` does:

```json
{"origin":"app://bundle","isSecureContext":true,"hasSubtle":true,"localStorageWorks":true}
```

`file://` is a secure context too, so neither packaged origin can produce this. The reachable case is a plain-`http://` LAN or tunnel origin — `vite.config.ts` allow-lists ngrok/cloudflared hosts precisely so the OAuth consent screen works through a tunnel, and the mobile surface calls these same hooks.

**Fix:** shared `lib/pkce.ts` raising a typed `InsecureContextError` that names the cause and the remedy; both flows now return the already-declared-but-unused `pkce_generation_failed` result instead of throwing.

**No pure-JS SHA-256 fallback**, deliberately. It would make the handshake succeed while the tokens it obtains still travel in clear text on that origin, converting a loud, fixable misconfiguration into a silent one that hands out credentials over plaintext.

## Tests — fail before, pass after

- `packagedOrigin.test.ts` — **4 of 5 failed** before, incl. `expected 'app://bundle' to be 'https://app.reliantlabs.io'` and `isConfigReady()` returning `true` with no config injected.
- `oauth-insecure-context.test.ts` — **6 failed** before with the user's verbatim error, `TypeError: Cannot read properties of undefined (reading 'digest')`.

Full gate green: **272 files / 1985 tests**, `tsc --noEmit` clean, ESLint clean on all changed files, and the electron suite (`app-protocol` + `navigation-policy`, 19 tests) still passes.

## Notes

- **The preprod-Supabase lead is dead.** Shipped v1.7.5 `build-config.js` has the prod project (`dash.reliantlabs.io`); `umoxnokojetwkrmttfqj` appears in zero shipped assets. The user's trace was a dev/local build.
- **Bug 1 and bug 3 do NOT share a root cause.** `configReady` never stalls — it returns immediately, and even on timeout `main.tsx` and `Root.tsx` render anyway. A missing config value cannot hang the post-auth render. Bug 3 (`VITE_CONTROL_PLANE_API_URL`) remains the sibling agent's, independent of this.
- Scoped to files I own; no overlap with the release-config/KCL work in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)