### PR TITLE
fix(chat): keep the spawn cancel button after a page refresh

### DIFF
--- a/internal/db/postgres/generated/querier.go
+++ b/internal/db/postgres/generated/querier.go
@@ -459,6 +459,28 @@ type Querier interface {
 	// issued", so workflow_created_at is omitted rather than selected and left
 	// to crash the first time a caller lists mid-dispatch-race.
 	ListSpawnChildrenForThread(ctx context.Context, threadID sql.NullString) ([]ListSpawnChildrenForThreadRow, error)
+	// The spawn tool call behind each child thread in one chat, for the reconnect
+	// snapshot: it is what the background-work pill's cancel button addresses, and
+	// threads has no spawned_by_tool_call_id column to read it from.
+	//
+	// w.thread (not tc.child_workflow_id) is the join key into the thread, for the
+	// same reason ListSpawnChildrenForThread uses it: for a RESUMED spawn,
+	// child_workflow_id names the workflow executing THIS call — a fresh id each
+	// resumption — while w.thread is the pre-existing thread being resumed, which
+	// is the thread the UI actually shows.
+	//
+	// A resumed spawn yields SEVERAL rows for one child thread (one per
+	// resumption, observed up to 6). requested_at ASC is load-bearing: the caller
+	// folds these into a map, so ascending order leaves the most recent call as
+	// the surviving value — which is the one still executing and therefore the one
+	// a cancel must address.
+	//
+	// Deliberately narrow. The snapshot needs ~1 row per spawn, and a busy chat
+	// holds ~10k tool calls whose input jsonb is large; selecting tool_calls.* and
+	// filtering in Go would haul all of that over the wire on every page load.
+	// Measured on the busiest real chat: 60 rows in 1.9ms via
+	// idx_tool_calls_child_workflow_id, against 10,622 tool calls.
+	ListSpawnToolCallIDsByChildThread(ctx context.Context, chatID string) ([]ListSpawnToolCallIDsByChildThreadRow, error)
 	// The async-spawn counterpart to ListStrandedSpawnToolCalls above (spec:
 	// async-spawn-and-agent-messaging.md, §7.1). A background=true spawn
 	// (dispatchSpawnBackground/workflow.go) writes tool_calls.status = 6

--- a/internal/db/postgres/generated/tool_calls.sql.go
+++ b/internal/db/postgres/generated/tool_calls.sql.go
@@ -144,6 +144,66 @@ func (q *Queries) ListSpawnChildrenForThread(ctx context.Context, threadID sql.N
 	return items, nil
 }
 
+const listSpawnToolCallIDsByChildThread = `-- name: ListSpawnToolCallIDsByChildThread :many
+SELECT
+    w.thread AS child_thread_id,
+    tc.id AS tool_call_id
+FROM tool_calls tc
+JOIN workflows w ON w.id = tc.child_workflow_id
+WHERE tc.chat_id = $1
+  AND tc.child_workflow_id IS NOT NULL
+ORDER BY tc.requested_at ASC
+`
+
+type ListSpawnToolCallIDsByChildThreadRow struct {
+	ChildThreadID string `json:"child_thread_id"`
+	ToolCallID    string `json:"tool_call_id"`
+}
+
+// The spawn tool call behind each child thread in one chat, for the reconnect
+// snapshot: it is what the background-work pill's cancel button addresses, and
+// threads has no spawned_by_tool_call_id column to read it from.
+//
+// w.thread (not tc.child_workflow_id) is the join key into the thread, for the
+// same reason ListSpawnChildrenForThread uses it: for a RESUMED spawn,
+// child_workflow_id names the workflow executing THIS call — a fresh id each
+// resumption — while w.thread is the pre-existing thread being resumed, which
+// is the thread the UI actually shows.
+//
+// A resumed spawn yields SEVERAL rows for one child thread (one per
+// resumption, observed up to 6). requested_at ASC is load-bearing: the caller
+// folds these into a map, so ascending order leaves the most recent call as
+// the surviving value — which is the one still executing and therefore the one
+// a cancel must address.
+//
+// Deliberately narrow. The snapshot needs ~1 row per spawn, and a busy chat
+// holds ~10k tool calls whose input jsonb is large; selecting tool_calls.* and
+// filtering in Go would haul all of that over the wire on every page load.
+// Measured on the busiest real chat: 60 rows in 1.9ms via
+// idx_tool_calls_child_workflow_id, against 10,622 tool calls.
+func (q *Queries) ListSpawnToolCallIDsByChildThread(ctx context.Context, chatID string) ([]ListSpawnToolCallIDsByChildThreadRow, error) {
+	rows, err := q.db.QueryContext(ctx, listSpawnToolCallIDsByChildThread, chatID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListSpawnToolCallIDsByChildThreadRow{}
+	for rows.Next() {
+		var i ListSpawnToolCallIDsByChildThreadRow
+		if err := rows.Scan(&i.ChildThreadID, &i.ToolCallID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listStrandedBackgroundSpawnToolCalls = `-- name: ListStrandedBackgroundSpawnToolCalls :many
 SELECT tc.id AS tool_call_id,
        tc.chat_id,

--- a/internal/db/postgres/queries/tool_calls.sql
+++ b/internal/db/postgres/queries/tool_calls.sql
@@ -45,6 +45,37 @@ SELECT * FROM tool_calls
 WHERE chat_id = $1
 ORDER BY requested_at ASC;
 
+-- name: ListSpawnToolCallIDsByChildThread :many
+-- The spawn tool call behind each child thread in one chat, for the reconnect
+-- snapshot: it is what the background-work pill's cancel button addresses, and
+-- threads has no spawned_by_tool_call_id column to read it from.
+--
+-- w.thread (not tc.child_workflow_id) is the join key into the thread, for the
+-- same reason ListSpawnChildrenForThread uses it: for a RESUMED spawn,
+-- child_workflow_id names the workflow executing THIS call — a fresh id each
+-- resumption — while w.thread is the pre-existing thread being resumed, which
+-- is the thread the UI actually shows.
+--
+-- A resumed spawn yields SEVERAL rows for one child thread (one per
+-- resumption, observed up to 6). requested_at ASC is load-bearing: the caller
+-- folds these into a map, so ascending order leaves the most recent call as
+-- the surviving value — which is the one still executing and therefore the one
+-- a cancel must address.
+--
+-- Deliberately narrow. The snapshot needs ~1 row per spawn, and a busy chat
+-- holds ~10k tool calls whose input jsonb is large; selecting tool_calls.* and
+-- filtering in Go would haul all of that over the wire on every page load.
+-- Measured on the busiest real chat: 60 rows in 1.9ms via
+-- idx_tool_calls_child_workflow_id, against 10,622 tool calls.
+SELECT
+    w.thread AS child_thread_id,
+    tc.id AS tool_call_id
+FROM tool_calls tc
+JOIN workflows w ON w.id = tc.child_workflow_id
+WHERE tc.chat_id = $1
+  AND tc.child_workflow_id IS NOT NULL
+ORDER BY tc.requested_at ASC;
+
 -- name: ListToolCallsByMessageIDs :many
 SELECT * FROM tool_calls
 WHERE message_id IN (sqlc.slice('message_ids'))

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -183,6 +183,11 @@ type Repository interface {
 	// this cannot return another thread's children), joined to each child's
 	// live workflow/thread state. Backs spawn_status's listing mode.
 	ListSpawnChildren(ctx context.Context, threadID string) ([]*SpawnChild, error)
+	// SpawnToolCallIDsByChildThread maps child thread id -> the spawn tool
+	// call that started it, for one chat. threads has no
+	// spawned_by_tool_call_id column, so the reconnect snapshot recovers the
+	// cancel button's target through this join rather than reading a field.
+	SpawnToolCallIDsByChildThread(ctx context.Context, chatID string) (map[string]string, error)
 
 	// Plans
 	CreatePlan(ctx context.Context, plan *Plan) error

--- a/internal/db/repository_spawn_list.go
+++ b/internal/db/repository_spawn_list.go
@@ -27,6 +27,41 @@ type SpawnChild struct {
 	ThreadTitle       *string
 }
 
+// SpawnToolCallIDsByChildThread maps child thread id -> the spawn tool call
+// that started it, for one chat.
+//
+// The reconnect snapshot needs this because threads has no
+// spawned_by_tool_call_id column: the field only ever rides the live update
+// payload, so a client that reloads sees none and the background-work pill
+// loses its cancel button. tool_calls.child_workflow_id -> workflows.thread is
+// the durable link the spawn path already writes.
+func (r *Repo) SpawnToolCallIDsByChildThread(ctx context.Context, chatID string) (map[string]string, error) {
+	if chatID == "" {
+		return nil, fmt.Errorf("chat ID cannot be empty")
+	}
+	if r.DB == nil {
+		return nil, fmt.Errorf("repository has no database connection")
+	}
+
+	rows, err := pgdb.New(r.DB.DB(ctx)).ListSpawnToolCallIDsByChildThread(ctx, chatID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list spawn tool call ids: %w", err)
+	}
+
+	// Rows arrive requested_at ASC, and a resumed spawn contributes one row
+	// per resumption for the same thread. Overwriting therefore leaves the
+	// most recent call as the value — the one still executing, and the one a
+	// cancel must address.
+	byThread := make(map[string]string, len(rows))
+	for _, row := range rows {
+		if row.ChildThreadID == "" || row.ToolCallID == "" {
+			continue
+		}
+		byThread[row.ChildThreadID] = row.ToolCallID
+	}
+	return byThread, nil
+}
+
 // ListSpawnChildren returns every spawn call issued BY threadID, in request
 // order. threadID must be the CALLER's own thread — tool_calls.thread_id is
 // always the parent's, so this cannot return another thread's children by

--- a/internal/grpc/services/streaming.go
+++ b/internal/grpc/services/streaming.go
@@ -749,6 +749,10 @@ type threadSnapshotMetadata struct {
 	originNodeID string
 	status       int32
 	completedAt  *time.Time
+	// spawnedByToolCallID is the spawn tool call that started this thread,
+	// recovered from tool_calls.child_workflow_id rather than from the
+	// update payload. It is what the cancel button addresses.
+	spawnedByToolCallID string
 }
 
 // threadMetadata maps thread id -> authoritative thread-table metadata for one chat.
@@ -782,7 +786,46 @@ func (s *StreamingService) threadMetadata(ctx context.Context, chatID string) ma
 		entry.completedAt = row.CompletedAt
 		metadata[row.ID] = entry
 	}
+
+	if len(metadata) == 0 {
+		return metadata
+	}
+
+	for threadID, toolCallID := range s.spawnToolCallIDsByThread(ctx, chatID) {
+		entry, ok := metadata[threadID]
+		if !ok {
+			continue
+		}
+		entry.spawnedByToolCallID = toolCallID
+		metadata[threadID] = entry
+	}
+
 	return metadata
+}
+
+// spawnToolCallIDsByThread maps spawn child thread id -> the tool call that
+// started it, for one chat.
+//
+// The link is tool_calls.child_workflow_id -> workflows.id -> workflows.thread,
+// written by the spawn path at dispatch and already trusted by
+// cancelChildWorkflowForToolCall (which cancels through exactly this join) and
+// by ListSpawnChildrenForThread. Nothing new has to be persisted; the durable
+// fact was always there, it just never reached the snapshot payload.
+//
+// The join runs in SQL rather than in Go: this is the page-load path, and a
+// busy chat holds ~10k tool calls with large input jsonb against ~60 spawns.
+//
+// Returns an empty map on error, matching threadMetadata: reconciliation is an
+// enhancement of the stored payload, so losing it degrades the snapshot to what
+// it was before rather than failing the whole initial sync.
+func (s *StreamingService) spawnToolCallIDsByThread(ctx context.Context, chatID string) map[string]string {
+	byThread, err := s.database.SpawnToolCallIDsByChildThread(ctx, chatID)
+	if err != nil {
+		logging.Warn(LOG_PREFIX_STREAM_CHAT+" Failed to resolve spawn tool call ids for cancel reconciliation",
+			"error", err, "chatID", chatID[:8])
+		return map[string]string{}
+	}
+	return byThread
 }
 
 // withThreadMetadata fills missing identity fields from the threads table.
@@ -840,6 +883,19 @@ func withThreadMetadata(data json.RawMessage, metadata map[string]threadSnapshot
 	if entry.originNodeID != "" {
 		if originNodeID, ok := payload["origin_node_id"].(string); !ok || originNodeID == "" {
 			payload["origin_node_id"] = entry.originNodeID
+			changed = true
+		}
+	}
+	// Without this the ■ button vanishes on reload. Two thread updates are
+	// written per spawn microseconds apart — workflow_status states the tool
+	// call id, thread_status's lifecycle row omits it — and per-entity dedup
+	// keeps only the newer, id-less row. The live stream hides the gap by
+	// carrying the field forward across updates; the snapshot has no history
+	// to carry forward from, so the reloading client sees no id and
+	// BackgroundWorkPill's truthiness guard drops the cancel affordance.
+	if entry.spawnedByToolCallID != "" {
+		if toolCallID, ok := payload["spawned_by_tool_call_id"].(string); !ok || toolCallID == "" {
+			payload["spawned_by_tool_call_id"] = entry.spawnedByToolCallID
 			changed = true
 		}
 	}

--- a/internal/grpc/services/streaming_snapshot_spawn_cancel_test.go
+++ b/internal/grpc/services/streaming_snapshot_spawn_cancel_test.go
@@ -1,0 +1,280 @@
+// Copyright (c) 2025 Reliant Labs
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	reliantv1 "github.com/reliant-labs/reliant/gen/reliant/v1"
+	"github.com/reliant-labs/reliant/internal/auth"
+	"github.com/reliant-labs/reliant/internal/db"
+	"github.com/reliant-labs/reliant/internal/db/core"
+	"github.com/stretchr/testify/require"
+)
+
+// The snapshot must carry a spawn's originating tool call id, so the cancel
+// button survives a reload.
+//
+// This is the same failure shape as thread `origin` (see
+// streaming_snapshot_thread_origin_test.go), on a different field, and it is
+// the one the user hit: "only 1 cancel button on the spawn pills in the UI",
+// then "looks like it populates the button when it happens, but not on a
+// refresh".
+//
+// Two thread updates are written per spawn, microseconds apart:
+//
+//	workflow_status.emitThreadUpdate  — carries spawned_by_tool_call_id
+//	thread_status.emitThreadUpdate    — lifecycle only, OMITS it
+//
+// On the live stream that is invisible: mergeActiveThreads carries the field
+// forward from the earlier record. But the reconnect snapshot
+// (GetLatestNonMessageUpdatesPerEntity) keeps only the NEWEST row per entity —
+// which is the lifecycle row that omits it — and hands it to a client with no
+// history to carry forward from. spawn.toolCallId goes undefined, and
+// BackgroundWorkPill's `{spawn.toolCallId && ...}` guard drops the ■ button.
+//
+// The user therefore keeps the button on spawns created in the current page
+// session and loses it on every spawn that has survived a refresh — exactly the
+// long-running agents they most want to stop.
+//
+// tool_calls.child_workflow_id -> workflows.id -> workflows.thread is the
+// durable link, already written by the spawn path, and the same join
+// ListSpawnChildrenForThread and cancelChildWorkflowForToolCall already trust.
+// Verified against live chat data: both stranded spawn threads recovered their
+// toolu_* id through it.
+func TestChatSnapshot_ThreadUpdateCarriesSpawnedByToolCallID(t *testing.T) {
+	repo, cleanup := db.SetupTestDB(t)
+	defer cleanup()
+
+	ctx := context.WithValue(context.Background(), auth.UserIDContextKey, "test-user")
+	now := time.Now().UTC()
+
+	chatID := uuid.New().String()
+	mainThreadID := chatID
+	spawnThreadID := uuid.New().String()
+	spawnWorkflowID := uuid.New().String()
+	toolCallID := "toolu_01PHSCqg3WxYCkTzWY6v3Xwd"
+
+	require.NoError(t, repo.CreateChat(ctx, &db.Chat{
+		ID: chatID, Title: "spawns", ProjectID: "test-project", UserID: "test-user",
+		CreatedAt: now, UpdatedAt: now, LastActive: now,
+	}))
+	_, err := repo.CreateThread(ctx, &db.Thread{ID: mainThreadID, ChatID: chatID, CreatedAt: now})
+	require.NoError(t, err)
+	spawnTitle := "electron config via forge KCL"
+	_, err = repo.CreateThread(ctx, &db.Thread{
+		ID: spawnThreadID, ChatID: chatID, ParentThreadID: &mainThreadID,
+		WorkflowID: &spawnWorkflowID, Title: &spawnTitle,
+		Origin: db.ThreadOriginSpawn, CreatedAt: now,
+	})
+	require.NoError(t, err)
+
+	// The durable link the spawn path writes: the parent's spawn tool call
+	// names the child workflow, and the child workflow names the thread.
+	require.NoError(t, repo.CreateWorkflow(ctx, &db.Workflow{
+		ID: spawnWorkflowID, ChatID: chatID, WorkflowName: "builtin://agent",
+		Thread: spawnThreadID, CreatedAt: now,
+	}))
+	require.NoError(t, repo.UpsertToolCall(ctx, &db.ToolCall{
+		ID: toolCallID, ChatID: chatID, ThreadID: &mainThreadID,
+		ToolName: "spawn", ChildWorkflowID: &spawnWorkflowID,
+		Status:      core.ToolCallStatusExecuting,
+		RequestedAt: now, CreatedAt: now, UpdatedAt: now,
+	}))
+
+	// The lifecycle row that WINS per-entity dedup. Correct in every respect
+	// except that it never restates spawned_by_tool_call_id — exactly what
+	// thread_status.emitThreadUpdate writes today.
+	lifecycle, err := json.Marshal(map[string]any{
+		"update_type":  "thread",
+		"id":           spawnWorkflowID,
+		"chat_id":      chatID,
+		"thread":       spawnThreadID,
+		"workflow_id":  spawnWorkflowID,
+		"origin":       db.ThreadOriginSpawn,
+		"status":       "running",
+		"thread_title": spawnTitle,
+	})
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateChatUpdate(ctx, chatID, db.UpdateTypeThread, spawnWorkflowID, string(lifecycle)))
+
+	snapshot, _, err := NewStreamingService(repo, nil, nil, nil).buildChatSnapshot(ctx, chatID)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	for _, u := range snapshot.OtherUpdates {
+		if u.UpdateType != reliantv1.ChatUpdateType_CHAT_UPDATE_TYPE_THREAD {
+			continue
+		}
+		var candidate map[string]any
+		require.NoError(t, json.Unmarshal([]byte(u.DataJson), &candidate))
+		if candidate["thread"] == spawnThreadID {
+			payload = candidate
+		}
+	}
+	require.NotNil(t, payload, "snapshot must carry the spawn thread's update")
+
+	require.Equal(t, toolCallID, payload["spawned_by_tool_call_id"],
+		"a reloading client sees this row alone; without the tool call id the "+
+			"background-work pill renders no cancel button and a long-running "+
+			"agent becomes unstoppable from the UI")
+}
+
+// A RESUMED spawn issues several tool calls against ONE child thread, and the
+// snapshot must offer the newest — the call still executing is the only one a
+// cancel can stop; an earlier, already-completed call would be a no-op button.
+//
+// Not hypothetical: in live chat data one thread had 6 tool calls against it.
+// The ordering that makes this come out right (requested_at ASC, folded into a
+// map so the last write wins) lives in SQL, where it is easy to drop by
+// accident, so it is pinned here.
+func TestChatSnapshot_ResumedSpawnUsesNewestToolCallID(t *testing.T) {
+	repo, cleanup := db.SetupTestDB(t)
+	defer cleanup()
+
+	ctx := context.WithValue(context.Background(), auth.UserIDContextKey, "test-user")
+	now := time.Now().UTC()
+
+	chatID := uuid.New().String()
+	mainThreadID := chatID
+	spawnThreadID := uuid.New().String()
+
+	require.NoError(t, repo.CreateChat(ctx, &db.Chat{
+		ID: chatID, Title: "resumed spawn", ProjectID: "test-project", UserID: "test-user",
+		CreatedAt: now, UpdatedAt: now, LastActive: now,
+	}))
+	_, err := repo.CreateThread(ctx, &db.Thread{ID: mainThreadID, ChatID: chatID, CreatedAt: now})
+	require.NoError(t, err)
+
+	firstWorkflowID := uuid.New().String()
+	_, err = repo.CreateThread(ctx, &db.Thread{
+		ID: spawnThreadID, ChatID: chatID, ParentThreadID: &mainThreadID,
+		WorkflowID: &firstWorkflowID, Origin: db.ThreadOriginSpawn, CreatedAt: now,
+	})
+	require.NoError(t, err)
+
+	// Each resumption is a NEW workflow id against the SAME thread — which is
+	// why workflows.thread, not child_workflow_id, is the join key.
+	oldToolCallID := "toolu_first_dispatch"
+	newToolCallID := "toolu_latest_resumption"
+	for _, dispatch := range []struct {
+		workflowID string
+		toolCallID string
+		at         time.Time
+	}{
+		{firstWorkflowID, oldToolCallID, now.Add(-2 * time.Hour)},
+		{uuid.New().String(), newToolCallID, now.Add(-1 * time.Minute)},
+	} {
+		require.NoError(t, repo.CreateWorkflow(ctx, &db.Workflow{
+			ID: dispatch.workflowID, ChatID: chatID, WorkflowName: "builtin://agent",
+			Thread: spawnThreadID, CreatedAt: dispatch.at,
+		}))
+		require.NoError(t, repo.UpsertToolCall(ctx, &db.ToolCall{
+			ID: dispatch.toolCallID, ChatID: chatID, ThreadID: &mainThreadID,
+			ToolName: "spawn", ChildWorkflowID: &dispatch.workflowID,
+			Status:      core.ToolCallStatusExecuting,
+			RequestedAt: dispatch.at, CreatedAt: dispatch.at, UpdatedAt: dispatch.at,
+		}))
+	}
+
+	lifecycle, err := json.Marshal(map[string]any{
+		"update_type": "thread",
+		"id":          firstWorkflowID,
+		"chat_id":     chatID,
+		"thread":      spawnThreadID,
+		"origin":      db.ThreadOriginSpawn,
+		"status":      "running",
+	})
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateChatUpdate(ctx, chatID, db.UpdateTypeThread, firstWorkflowID, string(lifecycle)))
+
+	snapshot, _, err := NewStreamingService(repo, nil, nil, nil).buildChatSnapshot(ctx, chatID)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	for _, u := range snapshot.OtherUpdates {
+		if u.UpdateType != reliantv1.ChatUpdateType_CHAT_UPDATE_TYPE_THREAD {
+			continue
+		}
+		var candidate map[string]any
+		require.NoError(t, json.Unmarshal([]byte(u.DataJson), &candidate))
+		if candidate["thread"] == spawnThreadID {
+			payload = candidate
+		}
+	}
+	require.NotNil(t, payload, "snapshot must carry the resumed spawn's thread update")
+
+	require.Equal(t, newToolCallID, payload["spawned_by_tool_call_id"],
+		"a resumed spawn must offer the newest tool call — cancelling the "+
+			"superseded one would leave the agent running while the UI "+
+			"reported it stopped")
+}
+
+// Reconciliation fills a gap; it never overwrites what an emitter stated.
+func TestChatSnapshot_ThreadUpdateKeepsStoredSpawnedByToolCallID(t *testing.T) {
+	repo, cleanup := db.SetupTestDB(t)
+	defer cleanup()
+
+	ctx := context.WithValue(context.Background(), auth.UserIDContextKey, "test-user")
+	now := time.Now().UTC()
+
+	chatID := uuid.New().String()
+	mainThreadID := chatID
+	spawnThreadID := uuid.New().String()
+	spawnWorkflowID := uuid.New().String()
+	statedToolCallID := "toolu_stated_by_emitter"
+	joinToolCallID := "toolu_from_the_join"
+
+	require.NoError(t, repo.CreateChat(ctx, &db.Chat{
+		ID: chatID, Title: "spawns", ProjectID: "test-project", UserID: "test-user",
+		CreatedAt: now, UpdatedAt: now, LastActive: now,
+	}))
+	_, err := repo.CreateThread(ctx, &db.Thread{ID: mainThreadID, ChatID: chatID, CreatedAt: now})
+	require.NoError(t, err)
+	_, err = repo.CreateThread(ctx, &db.Thread{
+		ID: spawnThreadID, ChatID: chatID, ParentThreadID: &mainThreadID,
+		WorkflowID: &spawnWorkflowID, Origin: db.ThreadOriginSpawn, CreatedAt: now,
+	})
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateWorkflow(ctx, &db.Workflow{
+		ID: spawnWorkflowID, ChatID: chatID, WorkflowName: "builtin://agent",
+		Thread: spawnThreadID, CreatedAt: now,
+	}))
+	require.NoError(t, repo.UpsertToolCall(ctx, &db.ToolCall{
+		ID: joinToolCallID, ChatID: chatID, ThreadID: &mainThreadID,
+		ToolName: "spawn", ChildWorkflowID: &spawnWorkflowID,
+		Status:      core.ToolCallStatusExecuting,
+		RequestedAt: now, CreatedAt: now, UpdatedAt: now,
+	}))
+
+	stated, err := json.Marshal(map[string]any{
+		"update_type":             "thread",
+		"id":                      spawnWorkflowID,
+		"chat_id":                 chatID,
+		"thread":                  spawnThreadID,
+		"workflow_id":             spawnWorkflowID,
+		"origin":                  db.ThreadOriginSpawn,
+		"status":                  "running",
+		"spawned_by_tool_call_id": statedToolCallID,
+	})
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateChatUpdate(ctx, chatID, db.UpdateTypeThread, spawnWorkflowID, string(stated)))
+
+	snapshot, _, err := NewStreamingService(repo, nil, nil, nil).buildChatSnapshot(ctx, chatID)
+	require.NoError(t, err)
+
+	for _, u := range snapshot.OtherUpdates {
+		if u.UpdateType != reliantv1.ChatUpdateType_CHAT_UPDATE_TYPE_THREAD {
+			continue
+		}
+		var candidate map[string]any
+		require.NoError(t, json.Unmarshal([]byte(u.DataJson), &candidate))
+		if candidate["thread"] == spawnThreadID {
+			require.Equal(t, statedToolCallID, candidate["spawned_by_tool_call_id"],
+				"reconciliation must not overwrite a tool call id the emitter stated")
+		}
+	}
+}

--- a/internal/grpc/services/streaming_subscribe_race_test.go
+++ b/internal/grpc/services/streaming_subscribe_race_test.go
@@ -94,6 +94,12 @@ func (r *snapshotGateRepo) ListThreadsByConversation(context.Context, string) ([
 	return nil, nil
 }
 
+// A spawn's cancel button needs the tool call that started it, which the
+// snapshot recovers via tool_calls.child_workflow_id -> workflows.thread.
+func (r *snapshotGateRepo) SpawnToolCallIDsByChildThread(context.Context, string) (map[string]string, error) {
+	return nil, nil
+}
+
 func (r *snapshotGateRepo) ListContentBlocksForMessages(context.Context, []string) ([]*db.MessageContentBlock, error) {
 	return nil, nil
 }

--- a/web/src/components/Chat/BackgroundWorkPill.tsx
+++ b/web/src/components/Chat/BackgroundWorkPill.tsx
@@ -114,18 +114,28 @@ function SpawnRow({
       </span>
       <span className="ml-auto flex flex-shrink-0 items-center gap-1.5">
         <Elapsed startedAt={spawn.startedAt} />
-        {spawn.toolCallId && (
-          <button
-            type="button"
-            onClick={handleCancel}
-            aria-label={`Cancel background agent ${spawn.title}`}
-            disabled={isCancelling}
-            className="rounded p-0.5 transition-colors hover:bg-muted disabled:opacity-60"
-            title="Cancel background agent"
-          >
-            <Square className={cn("h-3.5 w-3.5", isCancelling ? "animate-pulse text-warning" : "text-destructive")} />
-          </button>
-        )}
+        {/*
+          Always rendered, never silently absent. cancelToolCall is the only
+          route that stops a spawn, so a row without a tool call id genuinely
+          cannot be cancelled — but hiding the control made a long-running
+          agent look like it had no stop button at all, which is how this was
+          reported. A disabled control that says why is honest; a live one that
+          no-ops would be worse than either.
+        */}
+        <button
+          type="button"
+          onClick={handleCancel}
+          aria-label={`Cancel background agent ${spawn.title}`}
+          disabled={isCancelling || !spawn.toolCallId}
+          className="rounded p-0.5 transition-colors hover:bg-muted disabled:opacity-60"
+          title={
+            spawn.toolCallId
+              ? "Cancel background agent"
+              : "This agent cannot be cancelled from here — it is still starting up, or its originating tool call is not yet recorded"
+          }
+        >
+          <Square className={cn("h-3.5 w-3.5", isCancelling ? "animate-pulse text-warning" : "text-destructive")} />
+        </button>
       </span>
     </div>
   );

--- a/web/src/components/Chat/__tests__/BackgroundWorkPill.test.tsx
+++ b/web/src/components/Chat/__tests__/BackgroundWorkPill.test.tsx
@@ -148,6 +148,36 @@ describe("BackgroundWorkPill", () => {
     expect(screen.getByLabelText("Cancel background agent researcher")).toBeTruthy();
   });
 
+  // The reload case. The backend now recovers spawned_by_tool_call_id for the
+  // snapshot (tool_calls.child_workflow_id -> workflows.thread), but a row can
+  // still arrive without one — a spawn caught mid-dispatch, before
+  // child_workflow_id is written. Previously the ■ button was rendered behind
+  // a bare `{spawn.toolCallId && ...}` truthiness guard, so those spawns showed
+  // NO stop control at all and simply looked uncancellable.
+  //
+  // Silently vanishing is the worst option: the spawns most likely to lack an
+  // id are long-running ones, which are exactly the ones a user wants to stop.
+  // Rendering a live button that no-ops would be worse still. So the control
+  // stays visible and is explicitly disabled, saying why.
+  it("keeps a visible but disabled stop control for a spawn with no tool call id", () => {
+    useThreadActivityStore
+      .getState()
+      .setThreads(CHAT_ID, [thread({ thread: "thread-42" })]);
+    const cancelToolCall = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({ cancelToolCall });
+
+    renderPill();
+
+    fireEvent.click(screen.getByTestId("background-work-pill"));
+
+    const stop = screen.getByLabelText("Cancel background agent researcher");
+    expect(stop).toBeDisabled();
+    expect(stop.getAttribute("title")).toContain("cannot be cancelled");
+
+    fireEvent.click(stop);
+    expect(cancelToolCall).not.toHaveBeenCalled();
+  });
+
   it("cancels the originating tool call without selecting the spawn row", () => {
     useThreadActivityStore.getState().setThreads(CHAT_ID, [
       thread({


### PR DESCRIPTION
## The bug

Reported as *"only 1 cancel button on the spawn pills in the UI"*, then narrowed by the decisive follow-up: *"looks like it populates the button when it happens, but not on a refresh."*

So this is a **live-path vs rehydration-path** bug. The button is present when the spawn is created live and vanishes after reload — meaning the long-running agents a user most wants to stop are exactly the ones they cannot.

## Root cause

**The `threads` table has no `spawned_by_tool_call_id` column.** Confirmed against the live database:

```
id  chat_id  parent_thread_id  workflow_id  created_at  title
origin  origin_node_id  status  completed_at  fork_at_message_id
```

The field only ever rides the live update payload. Two thread updates are written per spawn, microseconds apart:

- `workflow_status.emitThreadUpdate` — carries `spawned_by_tool_call_id`
- `thread_status.emitThreadUpdate` — lifecycle only, **omits it**

On the live stream that gap is invisible, because `mergeActiveThreads` explicitly carries the field forward (`update.spawned_by_tool_call_id || prev.spawned_by_tool_call_id`). The reconnect snapshot keeps only the **newest** row per entity — the lifecycle row that omits it — and hands it to a client with no history to carry forward from. `spawn.toolCallId` is `undefined`, and the `{spawn.toolCallId && ...}` guard in `BackgroundWorkPill` drops the button.

## The fix

Recover the id from the link the spawn path **already writes**: `tool_calls.child_workflow_id` → `workflows.thread`, the same join `cancelChildWorkflowForToolCall` already cancels through.

Chosen over adding a `threads` column because it needs **no migration** and, since it reads rows that already exist, **spawns already running get their button back on the next reload**. A migration would fix only newly created spawns and leave every existing one broken.

Verified against live data: **974 of 974** spawn tool calls have `child_workflow_id`, and all 974 join cleanly. `workflows.thread` covers 974 vs 950 for `threads.workflow_id`, which is why it is the join key.

### Details that are load-bearing

- **The join runs in SQL, not Go.** This is the page-load hot path, and the busiest real chat holds **10,622 tool calls** with large `input` jsonb against **60 spawns**. `EXPLAIN ANALYZE`: 60 rows in **1.9ms** via `idx_tool_calls_child_workflow_id`. Loading all tool calls to filter in memory would have been a real regression.
- **`workflows.thread`, not `child_workflow_id`, is the join key** — for a resumed spawn, `child_workflow_id` names the workflow executing *this* call (a fresh id per resumption) while `workflows.thread` is the pre-existing thread the UI shows.
- **`requested_at ASC` folded into a map leaves the newest call winning.** Real data shows resumed spawns produce up to **6** tool calls against one thread; cancelling a superseded one would leave the agent running while the UI reported it stopped.
- **Reconciliation only fills a gap** — it never overwrites an id an emitter stated.

## UX

A row can still legitimately arrive without an id (a spawn caught mid-dispatch, before `child_workflow_id` is written). Rather than vanishing, the control stays visible and is **explicitly disabled with a reason**. A silently absent button is the worst failure mode here; a live button that no-ops would be worse still.

## Test evidence

The refresh case is covered specifically — a test exercising only the live path would have passed against this bug all along.

**Fail before** (`streaming.go` reverted to `origin/main`, tests kept):

```
--- FAIL: TestChatSnapshot_ThreadUpdateCarriesSpawnedByToolCallID
    Error: Not equal:
      expected: string("toolu_01PHSCqg3WxYCkTzWY6v3Xwd")
      actual  : <nil>(<nil>)
```

```
x BackgroundWorkPill > keeps a visible but disabled stop control for a spawn with no tool call id
  Tests  1 failed | 13 passed (14)
```

**Pass after:** `internal/grpc/services` and `internal/db` both `ok`; frontend **339 tests / 54 files** all passing.

**Mutation-checked:** flipping the query to `requested_at DESC` fails `TestChatSnapshot_ResumedSpawnUsesNewestToolCallID` with `actual: "toolu_first_dispatch"`, proving the ordering is genuinely load-bearing and not incidentally correct.

`go build ./...`, `go vet`, and `gofmt` are clean. sqlc regenerated via `make sqlc`; the generated diff is purely additive.

## Not verified

Not exercised against a running UI in a browser — the evidence here is the automated tests plus the live-database queries. The `:5434` database was read-only throughout.
