### PR TITLE
feat(viewer): open files outside the workspace in the desktop app

### DIFF
--- a/internal/filepreview/access.go
+++ b/internal/filepreview/access.go
@@ -9,7 +9,35 @@ import (
 	"github.com/reliant-labs/reliant/internal/db"
 )
 
+// ErrPathOutsideBase is returned when a RELATIVE path climbs out of its base
+// directory. That is always a traversal attempt and is always refused.
 var ErrPathOutsideBase = errors.New("requested path is outside base directory")
+
+// ErrAbsolutePathOutsideBase is returned when an ABSOLUTE path names a location
+// outside the workspace and the caller is not permitted to read host files.
+//
+// It is deliberately distinct from ErrPathOutsideBase. The two describe
+// different acts: a relative path escaping its base is a traversal, while an
+// absolute path is a location the user named outright. Callers surface them
+// with different messages, so collapsing them into one sentinel would make the
+// UI unable to explain which happened.
+var ErrAbsolutePathOutsideBase = errors.New("absolute path is outside the workspace")
+
+// PathScope selects how an absolute requested path is treated.
+type PathScope int
+
+const (
+	// ScopeBaseOnly confines the request to the base directory. An absolute
+	// path outside it is refused. This is the default and is what every
+	// mutating operation uses.
+	ScopeBaseOnly PathScope = iota
+
+	// ScopeAllowAbsolute additionally permits an absolute path that names a
+	// location outside the base. It is granted only to read-only viewer
+	// operations, and only where the filesystem being read belongs to the
+	// requesting user (see the callers in internal/grpc/services).
+	ScopeAllowAbsolute
+)
 
 // ResolveBasePath resolves the correct base path for file operations.
 // Returns the worktree path if worktree_id or chat_id is provided, otherwise returns project path.
@@ -40,22 +68,69 @@ func ResolveBasePath(ctx context.Context, repo db.Repository, projectID string, 
 	return project.Path, nil
 }
 
-// ValidatePath performs security checks to ensure path is within the base directory.
+// ValidatePath resolves requestedPath against basePath and enforces the
+// confinement rule for the base scope. It is equivalent to
+// ValidatePathScoped(basePath, requestedPath, ScopeBaseOnly).
 func ValidatePath(basePath, requestedPath string) (string, error) {
-	fullPath := filepath.Join(basePath, requestedPath)
+	return ValidatePathScoped(basePath, requestedPath, ScopeBaseOnly)
+}
 
-	absFullPath, err := filepath.Abs(fullPath)
-	if err != nil {
-		return "", err
-	}
+// ValidatePathScoped resolves requestedPath against basePath under scope.
+//
+// Relative paths are joined onto the base and must stay beneath it. A relative
+// path that climbs out is refused with ErrPathOutsideBase under EVERY scope —
+// traversal is never permitted, because a relative path is interpreted against
+// a base the user did not choose, so escaping it can only be an attempt to
+// reach something the base was meant to exclude.
+//
+// Absolute paths are NOT joined onto the base. Joining them was the previous
+// behaviour and it was wrong in both directions: an absolute path already
+// inside the workspace was concatenated onto the base a second time
+// (/w + /w/src/a.go -> /w/w/src/a.go, a file that does not exist), and an
+// absolute path outside it was silently rewritten to a different file under the
+// base (/w + /etc/passwd -> /w/etc/passwd) instead of being either honoured or
+// refused. An absolute path is now taken to mean the location it names:
+//
+//   - inside the base: always allowed, under either scope.
+//   - outside the base: allowed only under ScopeAllowAbsolute, otherwise
+//     refused with ErrAbsolutePathOutsideBase.
+func ValidatePathScoped(basePath, requestedPath string, scope PathScope) (string, error) {
 	absBasePath, err := filepath.Abs(basePath)
 	if err != nil {
 		return "", err
 	}
 
-	if absFullPath != absBasePath && !strings.HasPrefix(absFullPath, absBasePath+string(filepath.Separator)) {
-		return "", ErrPathOutsideBase
+	// "" and "/" both mean "the workspace root itself" in this API, not the
+	// filesystem root. FileSystemProxyService encodes the same contract
+	// (see resolvePath in fs_proxy.go), and the file tree relies on it: it
+	// defaults an unset path to "/" to list the top of the workspace.
+	if requestedPath == "" || requestedPath == "/" {
+		return absBasePath, nil
 	}
 
+	if filepath.IsAbs(requestedPath) {
+		absRequested := filepath.Clean(requestedPath)
+		if withinBase(absRequested, absBasePath) {
+			return absRequested, nil
+		}
+		if scope == ScopeAllowAbsolute {
+			return absRequested, nil
+		}
+		return "", ErrAbsolutePathOutsideBase
+	}
+
+	absFullPath, err := filepath.Abs(filepath.Join(absBasePath, requestedPath))
+	if err != nil {
+		return "", err
+	}
+	if !withinBase(absFullPath, absBasePath) {
+		return "", ErrPathOutsideBase
+	}
 	return absFullPath, nil
+}
+
+// withinBase reports whether path is base itself or a descendant of it. The
+// separator guards against /projects/app matching /projects/app-secrets.
+func withinBase(path, base string) bool {
+	return path == base || strings.HasPrefix(path, base+string(filepath.Separator))
 }

--- a/internal/filepreview/access_test.go
+++ b/internal/filepreview/access_test.go
@@ -27,3 +27,53 @@ func TestValidatePathRejectsTraversal(t *testing.T) {
 		t.Fatalf("error = %v, want %v", err, ErrPathOutsideBase)
 	}
 }
+
+// An absolute path that already points inside the base must resolve to itself.
+// filepath.Join would concatenate it onto the base a second time, producing a
+// path that does not exist and, for a write, creating a file in the wrong place.
+func TestValidatePathAllowsAbsoluteInsideBase(t *testing.T) {
+	base := filepath.Join(string(filepath.Separator), "tmp", "workspace")
+	want := filepath.Join(base, "src", "main.go")
+
+	got, err := ValidatePath(base, want)
+	if err != nil {
+		t.Fatalf("ValidatePath returned error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("ValidatePath = %q, want %q", got, want)
+	}
+}
+
+// "" and "/" address the workspace root, not the filesystem root. The file
+// tree depends on this: it defaults an unset path to "/" to list the top of the
+// workspace, so treating "/" as an absolute path outside the base breaks it.
+func TestValidatePathTreatsRootAsBase(t *testing.T) {
+	base := filepath.Join(string(filepath.Separator), "tmp", "workspace")
+
+	for _, requested := range []string{"", "/"} {
+		got, err := ValidatePath(base, requested)
+		if err != nil {
+			t.Fatalf("ValidatePath(%q) returned error: %v", requested, err)
+		}
+		if got != base {
+			t.Fatalf("ValidatePath(%q) = %q, want %q", requested, got, base)
+		}
+	}
+}
+
+// An absolute path outside the base must be refused outright. Silently rebasing
+// it onto the base is the worst of the three options: it neither honours the
+// request nor refuses it, and for a write it lands somewhere the caller never
+// named.
+func TestValidatePathRejectsAbsoluteOutsideBase(t *testing.T) {
+	base := filepath.Join(string(filepath.Separator), "tmp", "workspace")
+	outside := filepath.Join(string(filepath.Separator), "etc", "passwd")
+
+	got, err := ValidatePath(base, outside)
+	if err == nil {
+		t.Fatalf("expected absolute path outside base to be rejected, got %q", got)
+	}
+	if err != ErrAbsolutePathOutsideBase {
+		t.Fatalf("error = %v, want %v", err, ErrAbsolutePathOutsideBase)
+	}
+}

--- a/internal/grpc/services/filesystem.go
+++ b/internal/grpc/services/filesystem.go
@@ -70,11 +70,39 @@ func (s *FileSystemService) resolveBasePath(ctx context.Context, projectID strin
 	return basePath, nil
 }
 
-// validatePath performs security checks to ensure path is within base directory
+// validatePath confines a request to the base directory. Every mutating
+// operation uses it: a write, delete, copy or rename is only ever performed
+// inside the workspace the request named.
 func (s *FileSystemService) validatePath(basePath, requestedPath string) (string, error) {
-	absFullPath, err := filepreview.ValidatePath(basePath, requestedPath)
+	return s.validatePathScoped(basePath, requestedPath, filepreview.ScopeBaseOnly)
+}
+
+// validateReadPath is validatePath for read-only viewer operations.
+//
+// It additionally allows an ABSOLUTE path outside the workspace, so that a user
+// who clicks an absolute path the assistant mentioned actually sees the file
+// instead of a dead tooltip. Relative traversal is still refused here exactly as
+// it is everywhere else.
+//
+// This is sound only because of where this type runs. FileSystemService is the
+// direct-filesystem implementation, and it is mounted ONLY when the server has
+// no daemon router (internal/grpc/server.go) — i.e. desktop/monolith, where the
+// process is on the user's own machine and serves that one user. The user
+// already has a shell and a file manager on that machine, so reading a file
+// they explicitly named grants them nothing they did not already have.
+//
+// In hosted multi-tenant deployments a router is always present, so the
+// FileSystemProxyService is mounted instead and this method is never reached.
+// That service keeps every path confined to the workspace; see fs_proxy.go.
+func (s *FileSystemService) validateReadPath(basePath, requestedPath string) (string, error) {
+	return s.validatePathScoped(basePath, requestedPath, filepreview.ScopeAllowAbsolute)
+}
+
+func (s *FileSystemService) validatePathScoped(basePath, requestedPath string, scope filepreview.PathScope) (string, error) {
+	absFullPath, err := filepreview.ValidatePathScoped(basePath, requestedPath, scope)
 	if err != nil {
-		if err == filepreview.ErrPathOutsideBase {
+		switch err {
+		case filepreview.ErrPathOutsideBase, filepreview.ErrAbsolutePathOutsideBase:
 			return "", connect.NewError(connect.CodePermissionDenied, err)
 		}
 		return "", connect.NewError(connect.CodeInvalidArgument, err)
@@ -284,8 +312,9 @@ func (s *FileSystemService) GetFileContent(
 		return nil, connect.NewError(connect.CodeNotFound, err)
 	}
 
-	// Validate path
-	absFullPath, err := s.validatePath(basePath, requestedPath)
+	// Read-only: an absolute path outside the workspace is allowed here so a
+	// user can open a file they explicitly named. See validateReadPath.
+	absFullPath, err := s.validateReadPath(basePath, requestedPath)
 	if err != nil {
 		return nil, err
 	}
@@ -386,8 +415,8 @@ func (s *FileSystemService) GetFileMetadata(
 		return nil, connect.NewError(connect.CodeNotFound, err)
 	}
 
-	// Validate path
-	absFullPath, err := s.validatePath(basePath, requestedPath)
+	// Read-only: see validateReadPath.
+	absFullPath, err := s.validateReadPath(basePath, requestedPath)
 	if err != nil {
 		return nil, err
 	}
@@ -438,7 +467,8 @@ func (s *FileSystemService) GetFilePreviewInfo(
 		return nil, connect.NewError(connect.CodeNotFound, err)
 	}
 
-	absFullPath, err := s.validatePath(basePath, requestedPath)
+	// Read-only: see validateReadPath.
+	absFullPath, err := s.validateReadPath(basePath, requestedPath)
 	if err != nil {
 		return nil, err
 	}
@@ -494,7 +524,8 @@ func (s *FileSystemService) GetFilePreview(
 		return nil, connect.NewError(connect.CodeNotFound, err)
 	}
 
-	absFullPath, err := s.validatePath(basePath, requestedPath)
+	// Read-only: see validateReadPath.
+	absFullPath, err := s.validateReadPath(basePath, requestedPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/grpc/services/filesystem_test.go
+++ b/internal/grpc/services/filesystem_test.go
@@ -38,6 +38,78 @@ func setupTestFileSystemService(t *testing.T) (*FileSystemService, string) {
 	return NewFileSystemService(repo), projectPath
 }
 
+// A file outside the workspace, named by absolute path, opens. This is the
+// user-facing point of the change: clicking an absolute path the assistant
+// mentioned shows the file instead of a dead "cannot be opened" tooltip.
+func TestFileSystemService_GetFileContent_AllowsAbsolutePathOutsideWorkspace(t *testing.T) {
+	svc, _ := setupTestFileSystemService(t)
+
+	outside := filepath.Join(t.TempDir(), "notes.md")
+	require.NoError(t, os.WriteFile(outside, []byte("# outside the workspace\n"), 0644))
+
+	resp, err := svc.GetFileContent(context.Background(), connect.NewRequest(&reliantv1.GetFileContentRequest{
+		ProjectId: "test-project",
+		Path:      outside,
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Contains(t, resp.Msg.Content, "outside the workspace")
+}
+
+// Relative traversal stays refused on the read path. Widening absolute paths
+// must not widen this: a relative path is interpreted against a base the user
+// did not choose, so climbing out of it is still a traversal attempt.
+func TestFileSystemService_GetFileContent_StillRejectsRelativeTraversal(t *testing.T) {
+	svc, projectPath := setupTestFileSystemService(t)
+
+	secret := filepath.Join(filepath.Dir(projectPath), "secret.txt")
+	require.NoError(t, os.WriteFile(secret, []byte("top secret"), 0644))
+
+	_, err := svc.GetFileContent(context.Background(), connect.NewRequest(&reliantv1.GetFileContentRequest{
+		ProjectId: "test-project",
+		Path:      "../secret.txt",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}
+
+// Writes stay confined even for an absolute path. Reading a file the user
+// named is a different act from writing one: a write outside the workspace was
+// never requested and is refused.
+func TestFileSystemService_SaveFileContent_RejectsAbsolutePathOutsideWorkspace(t *testing.T) {
+	svc, _ := setupTestFileSystemService(t)
+
+	outside := filepath.Join(t.TempDir(), "should-not-be-written.txt")
+
+	_, err := svc.SaveFileContent(context.Background(), connect.NewRequest(&reliantv1.SaveFileContentRequest{
+		ProjectId: "test-project",
+		Path:      outside,
+		Content:   "nope",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+
+	_, statErr := os.Stat(outside)
+	assert.True(t, os.IsNotExist(statErr), "file outside the workspace must not have been created")
+}
+
+// An absolute path that already points INSIDE the workspace resolves to itself.
+// The previous implementation joined it onto the base a second time, producing
+// /workspace/workspace/src/... and a spurious NotFound.
+func TestFileSystemService_GetFileContent_AbsolutePathInsideWorkspaceIsNotDoubled(t *testing.T) {
+	svc, projectPath := setupTestFileSystemService(t)
+
+	inside := filepath.Join(projectPath, "main.go")
+	require.NoError(t, os.WriteFile(inside, []byte("package main\n"), 0644))
+
+	resp, err := svc.GetFileContent(context.Background(), connect.NewRequest(&reliantv1.GetFileContentRequest{
+		ProjectId: "test-project",
+		Path:      inside,
+	}))
+	require.NoError(t, err)
+	assert.Contains(t, resp.Msg.Content, "package main")
+}
+
 func TestFileSystemService_GetFileContent_AllowsRawPDFContent(t *testing.T) {
 	svc, projectPath := setupTestFileSystemService(t)
 

--- a/web/src/lib/__tests__/fileOpener.test.ts
+++ b/web/src/lib/__tests__/fileOpener.test.ts
@@ -45,6 +45,16 @@ vi.mock('../../store/viewerStore', () => ({
   },
 }));
 
+// Whether files outside the workspace can be opened depends on the runtime:
+// only the desktop backend will serve them. Default to the browser (the more
+// restrictive case) so a test must opt in to desktop behaviour.
+let mockIsElectron = false;
+
+vi.mock('../constants', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../constants')>()),
+  isElectron: () => mockIsElectron,
+}));
+
 // Import after mocks are set up
 import { classifyPath } from '../fileOpener';
 import type { ParsedFilePath } from '../filePath';
@@ -85,6 +95,7 @@ describe('classifyPath', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsElectron = false;
     
     // Default mock state
     mockWorktreeState = {
@@ -154,6 +165,10 @@ describe('classifyPath', () => {
       expect(result.isClickable).toBe(true);
     });
 
+    // An external path is still classified 'external' — that drives the muted
+    // styling. Whether it is CLICKABLE now depends on the runtime, because
+    // only the desktop backend will serve a file outside the workspace. Both
+    // cases are covered in the 'external paths' block below.
     it('should classify completely external path as "external"', () => {
       const parsed: ParsedFilePath = {
         fullPath: '/etc/passwd',
@@ -165,7 +180,6 @@ describe('classifyPath', () => {
       
       expect(result.classification).toBe('external');
       expect(result.targetWorktreeId).toBeNull();
-      expect(result.isClickable).toBe(false);
       expect(result.tooltipMessage).toContain('outside');
     });
 
@@ -201,6 +215,55 @@ describe('classifyPath', () => {
     });
   });
 
+  // The user-facing point of this change: a path the assistant mentioned that
+  // lives outside the workspace should open rather than show a dead tooltip.
+  // It can only do that where the backend will serve it.
+  describe('external paths', () => {
+    const outsidePath: ParsedFilePath = {
+      fullPath: '/home/user/notes/todo.md',
+      path: '/home/user/notes/todo.md',
+      isAbsolute: true,
+    };
+
+    it('is clickable in the desktop app, where the backend can read host files', () => {
+      mockIsElectron = true;
+
+      const result = classifyPath(outsidePath);
+
+      expect(result.classification).toBe('external');
+      expect(result.isClickable).toBe(true);
+      expect(result.tooltipMessage).toContain('/home/user/notes/todo.md');
+      expect(result.tooltipMessage).toContain('read-only');
+    });
+
+    it('is not clickable in the browser, and the tooltip says why and what to do', () => {
+      mockIsElectron = false;
+
+      const result = classifyPath(outsidePath);
+
+      expect(result.classification).toBe('external');
+      expect(result.isClickable).toBe(false);
+      // Not just "cannot be opened": name the reason and the way forward.
+      expect(result.tooltipMessage).toContain('outside this workspace');
+      expect(result.tooltipMessage).toContain('desktop app');
+    });
+
+    it('explains an unresolvable relative path rather than calling it external', () => {
+      mockIsElectron = true;
+      mockWorktreeState = { worktrees: [], currentWorktree: null };
+
+      const result = classifyPath({
+        fullPath: 'src/index.ts',
+        path: 'src/index.ts',
+        isAbsolute: false,
+      });
+
+      expect(result.isClickable).toBe(false);
+      expect(result.tooltipMessage).toContain('relative');
+      expect(result.tooltipMessage).toContain('no workspace open');
+    });
+  });
+
   describe('relative paths', () => {
     it('should resolve relative path with valid worktree context', () => {
       const parsed: ParsedFilePath = {
@@ -233,7 +296,11 @@ describe('classifyPath', () => {
       
       expect(result.classification).toBe('external');
       expect(result.isClickable).toBe(false);
-      expect(result.tooltipMessage).toContain('no workspace context');
+      // Wording changed deliberately: the tooltip now names the reason
+      // (a relative path with nothing to resolve it against) instead of the
+      // internal phrase "no workspace context".
+      expect(result.tooltipMessage).toContain('relative');
+      expect(result.tooltipMessage).toContain('no workspace open');
     });
 
     it('should use first active worktree when contextWorktreeId is undefined', () => {

--- a/web/src/lib/fileOpener.ts
+++ b/web/src/lib/fileOpener.ts
@@ -6,6 +6,7 @@ import { useMemo } from 'react';
 import { useWorktreeStore, type Worktree } from '../store/worktreeStore';
 import { useViewerStore } from '../store/viewerStore';
 import { useProjectStore } from '../store/projectStore';
+import { isElectron } from './constants';
 import { logger } from './logger';
 import type { ParsedFilePath } from './filePath';
 import type { FileNode } from '../components/FileBrowser';
@@ -25,14 +26,133 @@ export interface PathClassificationResult {
 }
 
 /**
+ * Whether the backend will serve a file that lives outside the workspace.
+ *
+ * Only the desktop app will. There the server runs on the user's own machine
+ * and serves that one user, so reading a file they explicitly named grants
+ * them nothing they did not already have with a shell or Finder — the
+ * read-only viewer RPCs accept an absolute host path
+ * (internal/grpc/services/filesystem.go, validateReadPath).
+ *
+ * A hosted deployment routes filesystem requests through a daemon
+ * (FileSystemProxyService), which keeps every path confined to the workspace.
+ * Marking such a link clickable there would render a button that looks live
+ * and then fails with PermissionDenied, which is worse than saying up front
+ * that it cannot be opened.
+ */
+function canOpenFilesOutsideWorkspace(): boolean {
+  return isElectron();
+}
+
+/** The store state classification needs, so the core stays pure and testable. */
+interface ClassificationContext {
+  activeWorktrees: Worktree[];
+  currentWorktreeId?: string;
+  projectPath?: string;
+}
+
+/**
  * Classify a file path to determine how it should be displayed and handled.
- * Runs at render time for visual styling.
- * 
+ *
+ * This is the single implementation. The hook and the non-hook wrapper below
+ * both delegate here; they differ only in how they read the stores. They were
+ * previously two hand-maintained copies that had already drifted apart (one
+ * checked the worktree root with a second `if`, the other with an `||`), so
+ * any future fix had to be applied twice to take effect.
+ *
  * Classifications:
  * - 'current': Path is in the current/context worktree
  * - 'other-worktree': Path is in a different active worktree
  * - 'project-only': Path is in the project but no worktree match
- * - 'external': Path is outside the project (non-clickable)
+ * - 'external': Path is outside the project
+ */
+function classifyPathWithContext(
+  parsedPath: ParsedFilePath | null,
+  contextWorktreeId: string | undefined,
+  { activeWorktrees, currentWorktreeId, projectPath }: ClassificationContext
+): PathClassificationResult {
+  const unopenable = (tooltipMessage: string): PathClassificationResult => ({
+    classification: 'external',
+    targetWorktreeId: null,
+    matchedWorktree: null,
+    isClickable: false,
+    tooltipMessage,
+  });
+
+  if (!parsedPath) {
+    return unopenable('Invalid file path');
+  }
+
+  const effectiveWorktreeId = contextWorktreeId || currentWorktreeId;
+  const contextWorktree = effectiveWorktreeId
+    ? activeWorktrees.find(w => w.id === effectiveWorktreeId)
+    : activeWorktrees[0]; // Fallback to first active worktree
+
+  // Resolve path to absolute if relative
+  let absolutePath = parsedPath.path;
+  if (!parsedPath.isAbsolute) {
+    if (!contextWorktree?.path) {
+      return unopenable(
+        'Cannot open this file: the path is relative and there is no workspace open to resolve it against.'
+      );
+    }
+    absolutePath = `${contextWorktree.path}/${absolutePath.replace(/^\.\//, '')}`;
+  }
+
+  // Sort by path length descending to match the most specific worktree first
+  const sortedWorktrees = [...activeWorktrees].sort(
+    (a, b) => (b.path?.length || 0) - (a.path?.length || 0)
+  );
+
+  const isWithin = (base: string | undefined): boolean =>
+    !!base && (absolutePath === base || absolutePath.startsWith(base + '/'));
+
+  for (const worktree of sortedWorktrees) {
+    if (isWithin(worktree.path)) {
+      const isCurrent = worktree.id === effectiveWorktreeId;
+      return {
+        classification: isCurrent ? 'current' : 'other-worktree',
+        targetWorktreeId: worktree.id,
+        matchedWorktree: worktree,
+        isClickable: true,
+        tooltipMessage: isCurrent
+          ? `Click to open ${parsedPath.path}`
+          : `Opens in ${worktree.name} workspace`,
+      };
+    }
+  }
+
+  if (isWithin(projectPath)) {
+    return {
+      classification: 'project-only',
+      targetWorktreeId: null,
+      matchedWorktree: null,
+      isClickable: true,
+      tooltipMessage: `Click to open ${parsedPath.path}`,
+    };
+  }
+
+  // Outside the project entirely. The desktop app can still read it, so the
+  // link stays live there; a hosted deployment cannot, and says why rather
+  // than offering a button that would fail on click.
+  if (canOpenFilesOutsideWorkspace()) {
+    return {
+      classification: 'external',
+      targetWorktreeId: null,
+      matchedWorktree: null,
+      isClickable: true,
+      tooltipMessage: `Click to open ${parsedPath.path} (outside this workspace, read-only)`,
+    };
+  }
+
+  return unopenable(
+    `Cannot open ${parsedPath.path}: it is outside this workspace, and files on the host are ` +
+      `only readable in the desktop app. Open it in a project or workspace that contains it.`
+  );
+}
+
+/**
+ * Hook version of path classification. Runs at render time for visual styling.
  */
 export function usePathClassification(
   parsedPath: ParsedFilePath | null,
@@ -48,106 +168,15 @@ export function usePathClassification(
     [allWorktrees]
   );
 
-  return useMemo(() => {
-    // No path = external
-    if (!parsedPath) {
-      return {
-        classification: 'external' as const,
-        targetWorktreeId: null,
-        matchedWorktree: null,
-        isClickable: false,
-        tooltipMessage: 'Invalid file path',
-      };
-    }
-
-    // Determine the effective worktree for context
-    const effectiveWorktreeId = contextWorktreeId || currentWorktree?.id;
-    const contextWorktree = effectiveWorktreeId
-      ? activeWorktrees.find(w => w.id === effectiveWorktreeId)
-      : activeWorktrees[0]; // Fallback to first active worktree
-
-    // Resolve path to absolute if relative
-    let absolutePath = parsedPath.path;
-    if (!parsedPath.isAbsolute) {
-      if (contextWorktree?.path) {
-        const cleanPath = absolutePath.replace(/^\.\//, '');
-        absolutePath = `${contextWorktree.path}/${cleanPath}`;
-      } else {
-        // Cannot resolve relative path without worktree context
-        return {
-          classification: 'external' as const,
-          targetWorktreeId: null,
-          matchedWorktree: null,
-          isClickable: false,
-          tooltipMessage: 'Cannot resolve path - no workspace context',
-        };
-      }
-    }
-
-    // Check if path matches any active worktree
-    // Sort by path length descending to match most specific worktree first
-    const sortedWorktrees = [...activeWorktrees].sort(
-      (a, b) => (b.path?.length || 0) - (a.path?.length || 0)
-    );
-
-    for (const worktree of sortedWorktrees) {
-      if (worktree.path && absolutePath.startsWith(worktree.path + '/')) {
-        const isCurrent = worktree.id === effectiveWorktreeId;
-        return {
-          classification: isCurrent ? 'current' : 'other-worktree',
-          targetWorktreeId: worktree.id,
-          matchedWorktree: worktree,
-          isClickable: true,
-          tooltipMessage: isCurrent
-            ? `Click to open ${parsedPath.path}`
-            : `Opens in ${worktree.name} workspace`,
-        };
-      }
-      // Also check exact match (for the worktree root itself)
-      if (worktree.path && absolutePath === worktree.path) {
-        const isCurrent = worktree.id === effectiveWorktreeId;
-        return {
-          classification: isCurrent ? 'current' : 'other-worktree',
-          targetWorktreeId: worktree.id,
-          matchedWorktree: worktree,
-          isClickable: true,
-          tooltipMessage: isCurrent
-            ? `Click to open ${parsedPath.path}`
-            : `Opens in ${worktree.name} workspace`,
-        };
-      }
-    }
-
-    // Check if path is within project (backend fallback allows this)
-    if (projectPath && absolutePath.startsWith(projectPath + '/')) {
-      return {
-        classification: 'project-only' as const,
-        targetWorktreeId: null,
-        matchedWorktree: null,
-        isClickable: true,
-        tooltipMessage: `Click to open ${parsedPath.path}`,
-      };
-    }
-    // Also check exact match for project root
-    if (projectPath && absolutePath === projectPath) {
-      return {
-        classification: 'project-only' as const,
-        targetWorktreeId: null,
-        matchedWorktree: null,
-        isClickable: true,
-        tooltipMessage: `Click to open ${parsedPath.path}`,
-      };
-    }
-
-    // Path is completely external
-    return {
-      classification: 'external' as const,
-      targetWorktreeId: null,
-      matchedWorktree: null,
-      isClickable: false,
-      tooltipMessage: 'This file is outside the current workspace and cannot be opened',
-    };
-  }, [parsedPath, contextWorktreeId, currentWorktree?.id, activeWorktrees, projectPath]);
+  return useMemo(
+    () =>
+      classifyPathWithContext(parsedPath, contextWorktreeId, {
+        activeWorktrees,
+        currentWorktreeId: currentWorktree?.id,
+        projectPath,
+      }),
+    [parsedPath, contextWorktreeId, currentWorktree?.id, activeWorktrees, projectPath]
+  );
 }
 
 /**
@@ -160,87 +189,12 @@ export function classifyPath(
 ): PathClassificationResult {
   const worktreeState = useWorktreeStore.getState();
   const projectState = useProjectStore.getState();
-  
-  const allWorktrees = worktreeState.worktrees;
-  const currentWorktree = worktreeState.currentWorktree;
-  const projectPath = projectState.currentProject?.path;
-  
-  // Filter out archived worktrees
-  const activeWorktrees = allWorktrees.filter(w => !w.deleted_at);
 
-  // No path = external
-  if (!parsedPath) {
-    return {
-      classification: 'external',
-      targetWorktreeId: null,
-      matchedWorktree: null,
-      isClickable: false,
-      tooltipMessage: 'Invalid file path',
-    };
-  }
-
-  // Determine the effective worktree for context
-  const effectiveWorktreeId = contextWorktreeId || currentWorktree?.id;
-  const contextWorktree = effectiveWorktreeId
-    ? activeWorktrees.find(w => w.id === effectiveWorktreeId)
-    : activeWorktrees[0];
-
-  // Resolve path to absolute if relative
-  let absolutePath = parsedPath.path;
-  if (!parsedPath.isAbsolute) {
-    if (contextWorktree?.path) {
-      const cleanPath = absolutePath.replace(/^\.\//, '');
-      absolutePath = `${contextWorktree.path}/${cleanPath}`;
-    } else {
-      return {
-        classification: 'external',
-        targetWorktreeId: null,
-        matchedWorktree: null,
-        isClickable: false,
-        tooltipMessage: 'Cannot resolve path - no workspace context',
-      };
-    }
-  }
-
-  // Check if path matches any active worktree
-  const sortedWorktrees = [...activeWorktrees].sort(
-    (a, b) => (b.path?.length || 0) - (a.path?.length || 0)
-  );
-
-  for (const worktree of sortedWorktrees) {
-    if (worktree.path && (absolutePath.startsWith(worktree.path + '/') || absolutePath === worktree.path)) {
-      const isCurrent = worktree.id === effectiveWorktreeId;
-      return {
-        classification: isCurrent ? 'current' : 'other-worktree',
-        targetWorktreeId: worktree.id,
-        matchedWorktree: worktree,
-        isClickable: true,
-        tooltipMessage: isCurrent
-          ? `Click to open ${parsedPath.path}`
-          : `Opens in ${worktree.name} workspace`,
-      };
-    }
-  }
-
-  // Check if path is within project
-  if (projectPath && (absolutePath.startsWith(projectPath + '/') || absolutePath === projectPath)) {
-    return {
-      classification: 'project-only',
-      targetWorktreeId: null,
-      matchedWorktree: null,
-      isClickable: true,
-      tooltipMessage: `Click to open ${parsedPath.path}`,
-    };
-  }
-
-  // Path is completely external
-  return {
-    classification: 'external',
-    targetWorktreeId: null,
-    matchedWorktree: null,
-    isClickable: false,
-    tooltipMessage: 'This file is outside the current workspace and cannot be opened',
-  };
+  return classifyPathWithContext(parsedPath, contextWorktreeId, {
+    activeWorktrees: worktreeState.worktrees.filter(w => !w.deleted_at),
+    currentWorktreeId: worktreeState.currentWorktree?.id,
+    projectPath: projectState.currentProject?.path,
+  });
 }
 
 // ============================================================================


### PR DESCRIPTION
> "also annoying when i see 'this file is outside the current workspace ...' can we just allow opening the file regardless?"

Clicking an absolute path the assistant mentioned showed a dead tooltip. It now opens, read-only, wherever the backend can actually serve it.

**Please overrule the local-vs-hosted split if you'd rather have the simple version** (allow everything in Electron, leave hosted alone) — the reasoning is spelled out below so it's easy to reject. I was asked which you'd prefer and you hadn't answered, so I used judgment.

## The check wasn't doing what its name said

Worth flagging on its own, because it changes what "the security model" even means here. `ValidatePath` joined the requested path onto the base unconditionally, so an absolute path was **never rejected — it was silently rebased**:

```
/workspace + /etc/passwd          -> /workspace/etc/passwd
/workspace + /workspace/src/a.go  -> /workspace/workspace/src/a.go
```

Neither is right. The first reads a *different file* than the caller named — and on a write, creates one somewhere they never asked for. The second made an absolute in-workspace path spuriously `NotFound`. The only thing genuinely refused was relative traversal (`../secret`).

So there was less of a "path-traversal defence" to preserve than it appeared, and one latent write bug.

## The model

Two acts that were conflated, now separated:

- **A relative path escaping its base is a traversal.** Still refused, under every scope. A relative path is interpreted against a base the user didn't choose, so climbing out can only be an attempt to reach what the base was meant to exclude. `TestValidatePathRejectsTraversal` is **unchanged and still passes** — I did not weaken it.
- **An absolute path is a location the user named outright.** It resolves to itself, and is permitted outside the base only under the new `ScopeAllowAbsolute`.

`ScopeAllowAbsolute` is granted to the four **read-only** viewer RPCs (`GetFileContent`, `GetFileMetadata`, `GetFilePreviewInfo`, `GetFilePreview`). Every mutating op — save, create, delete, copy, replace — stays confined, because a write outside the workspace was never requested. That asymmetry is the core of it: reading a file you pointed at is not the same act as writing one.

## Local vs hosted — yes, they differ, and it's implemented

**They differ, and the difference is enforced by which service is mounted**, not by a flag I invented:

- `FileSystemService` (this change) is mounted **only when there is no daemon router** — desktop/monolith, where the process runs on the user's own machine and serves that one user. Reading a file they explicitly named grants them nothing they don't already have with a shell or Finder.
- Hosted multi-tenant **always** has a router, so `FileSystemProxyService` is mounted instead and this code path is never reached. Paths stay confined to the workspace there.

The frontend mirrors this rather than guessing: an external link is clickable only in Electron. In a browser it stays non-clickable, because a live-looking button that fails with `PermissionDenied` on click is strictly worse than today's honest tooltip.

Third-party connector callers (ChatGPT/Claude driving a cloud daemon) are **unaffected** — they're bound by `internal/daemonpolicy`, a separate kernel-enforced (`os.Root`) boundary this change doesn't touch.

## What now opens, what deliberately doesn't

| | Before | After |
|---|---|---|
| Absolute path outside workspace, desktop | dead tooltip | **opens, read-only** |
| Absolute path already inside workspace | spurious `NotFound` (double-joined) | **opens** |
| Absolute path outside workspace, hosted browser | dead tooltip | still refused, tooltip now says why + what to do |
| Relative traversal (`../secret`) | refused | **still refused** |
| Any *write* outside the workspace | silently rebased into workspace | **refused** |

Tooltips that still refuse name the reason and the way forward instead of "cannot be opened".

## Also

Collapses the two hand-maintained copies of the classification logic in `fileOpener.ts` into one. They had **already drifted** — one checked the worktree root with a second `if`, the other with an `||` — so any fix had to be applied twice to take effect.

## Fail-before / pass-after

Each new test was run against the old implementation first:

- `filepreview` — 3 fail before (failure output literally shows `/tmp/workspace/tmp/workspace/src/main.go` and the rebased `/tmp/workspace/etc/passwd`), pass after.
- `services` — 3 of 4 fail before, pass after.
- `fileOpener` — 4 fail before, pass after.

Full suites green: `go test -count=1` across `filepreview`, `grpc/...`, `toolexec/...`, `daemonpolicy`; **1977 web tests** (1974 baseline + 3 new). `go vet`, `golangci-lint` (0 issues), `tsc --noEmit`, and ESLint all clean.

### One regression I caught and fixed

Relaxing absolute paths initially broke `GetFileTree`: it defaults an unset path to `"/"`, which my first cut treated as "filesystem root, outside the base" and refused. `""`/`"/"` are now explicitly the **workspace root** — the same contract `fs_proxy.go` already encodes — with a regression test pinning it.

### Unverified

No runtime click-through in a packaged Electron build; verification is the automated suites plus the service-level tests that exercise the real RPCs against a real filesystem. The hosted refusal path is covered by the frontend tests rather than a live multi-tenant deployment.
