### PR TITLE
fix(agent): stop pending_inbox lying, and let an assistant-tailed thread yield

### DIFF
--- a/internal/workflow/builtin/agent.yaml
+++ b/internal/workflow/builtin/agent.yaml
@@ -132,6 +132,19 @@ nodes:
     # the response is not in that turn; without this the loop would exit on a
     # thread holding an undelivered message. Looping once more routes back
     # through call_llm, which delivers it.
+    #
+    # pending_inbox means exactly one thing: a real queued message exists, and
+    # the next call_llm will deliver it — so re-entering ends history with a
+    # USER message, which is the only reason another turn is safe to take. It
+    # is set from an actual mailbox probe and nothing else.
+    #
+    # It used to also be set from "the stream was interrupted", and that is
+    # what bricked chats. A text-only turn with no tool calls is COMPLETE and
+    # must yield to the user; when an interrupt set this true with an empty
+    # mailbox, the loop re-entered anyway, the drain delivered nothing, history
+    # still ended with the assistant message, and every retry reproduced it —
+    # permanently. Keep this term truthful: if the mailbox is empty, the loop
+    # must exit and yield.
     while: (outputs.tool_calls != null && size(outputs.tool_calls) > 0) || outputs.has_feedback == true || outputs.pending_inbox == true
     inline:
       outputs:

--- a/internal/workflow/runtime/activities/handlers/call_llm.go
+++ b/internal/workflow/runtime/activities/handlers/call_llm.go
@@ -245,7 +245,36 @@ func (a *CallLLMActivity) executeCore(ctx context.Context, rtx RuntimeContext, a
 	//
 	// Cheap: one indexed SELECT against the partial index on queued rows, once
 	// per LLM call — negligible next to the call itself.
-	output.PendingInbox = output.GetPendingInbox() || a.hasQueuedAgentMessages(ctx, thread)
+	//
+	// This is now the SOLE source of pending_inbox. It used to be ORed with a
+	// value streamLLMResponse set from streamInterrupted, and that OR is what
+	// made the flag unfalsifiable: once an interrupt set it true, an empty
+	// mailbox could not clear it, so the loop re-entered CallLLM forever on a
+	// thread with nothing to deliver. The flag now means what the loop reads it
+	// to mean — "a real queued message exists and the next turn will deliver
+	// it" — so re-entering ends history with a USER message, and an empty
+	// mailbox exits the loop and yields to the user.
+	//
+	// The probe runs on a context detached from cancellation. An interrupted
+	// turn arrives here with ctx already dead, and the whole point of the
+	// interrupt path is to take one more turn to deliver what the interrupt was
+	// issued for — a probe that returned false merely because the context was
+	// cancelled would strand exactly the message the user just sent. Bounded so
+	// a dead pool cannot hold the unwind open.
+	//
+	// The residual race is a message queued microseconds AFTER this SELECT.
+	// That window cannot be closed here — any check has an after. It is closed
+	// on the other side instead, and was already: the enqueue rings the
+	// doorbell signal (notifyAgentMessageQueued) which wakes a parked thread,
+	// an idle thread's queue is absorbed by the user's next send, and a row
+	// that outlives every turn is marked undeliverable by the reconciler's
+	// resolveOrphanedAgentMessages rather than sitting queued forever. A
+	// missed-by-a-microsecond message is therefore late, never lost — whereas
+	// the old "assume yes" answer traded that for a chat that could not
+	// advance at all.
+	probeCtx, cancelProbe := context.WithTimeout(context.WithoutCancel(ctx), pendingInboxProbeTimeout)
+	output.PendingInbox = a.hasQueuedAgentMessages(probeCtx, thread)
+	cancelProbe()
 
 	logger.Info("[CallLLM] Completed",
 		"chatID", rtx.ChatID,
@@ -327,6 +356,11 @@ func (a *CallLLMActivity) persistInterruptedTurn(
 // interruptedTurnWriteTimeout bounds the detached write of an interrupted
 // turn's partial. Short: one insert on a live pool, with the caller unwinding.
 const interruptedTurnWriteTimeout = 5 * time.Second
+
+// pendingInboxProbeTimeout bounds the detached mailbox probe that decides
+// whether the agent loop takes another turn. Short: one indexed SELECT, and on
+// the interrupt path the caller is already unwinding.
+const pendingInboxProbeTimeout = 5 * time.Second
 
 // hasQueuedAgentMessages reports whether thread's mailbox holds undelivered
 // messages right now.
@@ -908,15 +942,48 @@ func (a *CallLLMActivity) streamLLMResponse(ctx context.Context, chat *db.Chat, 
 		"toolNames", toolNameDebug,
 	)
 
-	// Defense-in-depth: verify conversation ends with user/tool message.
-	// This catches thread routing mismatches before they hit the API.
+	// An assistant-tailed history means this turn has nothing to send.
+	//
+	// The mailbox drain ran before the history read, so by this point every
+	// queued message is already folded in. If the last message is STILL the
+	// assistant's, there is no new input to respond to — the previous turn
+	// already had the last word. That is a complete turn, not a failure.
+	//
+	// This used to return an error, and that error is what bricked chats. The
+	// retry ladder re-runs CallLLM, the tail is unchanged, and it fails
+	// identically every time: the thread can never advance again, and no user
+	// action recovers it. Yielding instead ends the turn cleanly — the agent
+	// loop sees no tool calls and no pending inbox, exits, and hands control
+	// back to the user, whose next message becomes the new tail. A thread
+	// already carrying this shape heals on its next turn.
+	//
+	// Logged at ERROR because reaching here is still a bug upstream (see
+	// below for the real causes); it must stay greppable rather than being
+	// silently absorbed. What changes is that the chat survives it.
 	if len(history) > 0 {
 		lastMsg := history[len(history)-1]
 		if lastMsg.Role == message.Assistant {
-			return nil, fmt.Errorf(
-				"conversation history ends with assistant message after all transformations (chat=%s, thread=%s, last_msg_id=%s, msg_count=%d) — this usually means the user message was saved to a different thread than CallLLM reads from",
-				chat.ID, thread, lastMsg.ID, len(history),
+			activity.GetLogger(ctx).Error(
+				"[CallLLM] History ends with an assistant message after the mailbox drain — "+
+					"yielding the turn instead of calling the provider. Causes, in order of "+
+					"likelihood: the previous turn produced text with no tool calls and the loop "+
+					"re-entered anyway (a pending_inbox that did not correspond to a real queued "+
+					"message); an interrupted turn persisted a partial assistant message and the "+
+					"mailbox it expected to drain was empty; or, rarely, the user message was "+
+					"written to a different thread than this one.",
+				"chatID", chat.ID,
+				"thread", thread,
+				"lastMsgID", lastMsg.ID,
+				"msgCount", len(history),
 			)
+			return &reliantv1.CallLLMOutput{
+				Message: &reliantv1.MessageOutput{Role: "assistant", Text: ""},
+				// No tool calls and (set by the caller from a real mailbox
+				// probe) no pending inbox: both agent loops exit on this.
+				CompactionThreshold: effectiveCompactionThreshold,
+				Model:               resolvedModelID,
+				MessageId:           streamState.messageID,
+			}, nil
 		}
 	}
 
@@ -1108,7 +1175,28 @@ streamLoop:
 			Role: "assistant",
 			Text: responseText,
 		},
-		PendingInbox:        streamInterrupted,
+		// Deliberately NOT set from streamInterrupted.
+		//
+		// It used to be, and that is the bug that wedged chats. An interrupt
+		// wants one more mailbox-draining turn, but "was interrupted" is not
+		// evidence that anything is queued: interrupting with an empty mailbox
+		// set this true, the loop re-entered CallLLM, the drain delivered
+		// nothing, and history still ended with the partial assistant message.
+		//
+		// pending_inbox now means exactly one thing — a real queued message
+		// exists and the next turn will deliver it — so re-entering CallLLM
+		// genuinely ends history with a USER message. executeCore sets it from
+		// the mailbox probe. The interrupt case is not lost: an interrupt is
+		// only ever issued against a thread that has something queued (see
+		// specs/thread-interrupt.md — the UI offers it only from the queued
+		// strip), so the probe finds that row and returns the same true.
+		//
+		// Interrupt's OWN wake-up does not depend on this flag either: the
+		// enqueue rings the doorbell signal (notifyAgentMessageQueued), and a
+		// row that outlives every turn is swept by the reconciler's
+		// resolveOrphanedAgentMessages. See the probe in executeCore for the
+		// residual microsecond race and why it is closed there, not here.
+		PendingInbox:        false,
 		CompactionThreshold: effectiveCompactionThreshold,
 		Model:               resolvedModelID,
 		MessageId:           streamState.messageID,

--- a/internal/workflow/runtime/activities/handlers/call_llm_pending_inbox_test.go
+++ b/internal/workflow/runtime/activities/handlers/call_llm_pending_inbox_test.go
@@ -1,0 +1,329 @@
+// Copyright (c) 2025 Reliant Labs
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	reliantv1 "github.com/reliant-labs/reliant/gen/reliant/v1"
+	"github.com/reliant-labs/reliant/internal/db"
+	"github.com/reliant-labs/reliant/internal/models/message"
+	"github.com/reliant-labs/reliant/internal/ptr"
+)
+
+// THE WEDGE (chat 2b4c8c20, thread 8c48ab59, 48 identical failures)
+//
+// A text-only assistant turn — text, no tool calls — is a COMPLETE turn. The
+// agent loop must exit and yield to the user. Instead it re-entered call_llm
+// because pending_inbox was true, and pending_inbox was set from
+// `streamInterrupted` rather than from any mailbox check:
+//
+//	PendingInbox: streamInterrupted,        // call_llm.go, before this change
+//
+// With an empty mailbox the drain delivered nothing, history still ended with
+// that assistant message, the end-of-history guard returned an error, and the
+// retry ladder reproduced it forever. Verified against the live database: the
+// wedged thread's mailbox held exactly one row at status=2 (already delivered)
+// and the sibling wedged thread's mailbox was completely empty — pending_inbox
+// was lying in both cases.
+//
+// These tests pin both halves of the fix:
+//
+//   - PREVENTION: pending_inbox means "a real queued message exists and the
+//     next turn will deliver it", so re-entering call_llm genuinely ends
+//     history with a USER message. Empty mailbox ⇒ false ⇒ the loop exits.
+//   - RECOVERY: a thread whose tail is ALREADY a text-only assistant message
+//     yields cleanly instead of erroring, so it can resume on its next turn.
+//     The pre-existing blockless recovery only handled the ZERO-content-block
+//     shape, which is exactly why this case slipped through.
+
+// PREVENTION. The probe is the sole source of truth, and an empty mailbox must
+// report false — otherwise the loop re-enters on a thread with nothing to
+// deliver, which is the wedge.
+func TestPendingInbox_EmptyMailboxReportsFalse(t *testing.T) {
+	f := setupDurableStatusFixture(t)
+	defer f.h.Cleanup()
+
+	activityInstance := NewCallLLMActivity(f.h.Repo(), nil, nil, &staticConfigProvider{}, nil, nil)
+
+	var pending bool
+	runInActivity(t, f.h, func(actCtx context.Context) error {
+		pending = activityInstance.hasQueuedAgentMessages(actCtx, f.chatID)
+		return nil
+	})
+
+	assert.False(t, pending,
+		"an empty mailbox must report no pending inbox — reporting true is what "+
+			"made the agent loop re-enter call_llm forever on a thread with nothing to deliver")
+}
+
+// A delivered row is not a pending one. The wedged thread's mailbox held
+// exactly this: one row at status=2. If that counted as pending, the loop would
+// re-enter on a message the model has already seen.
+func TestPendingInbox_DeliveredRowIsNotPending(t *testing.T) {
+	f := setupDurableStatusFixture(t)
+	defer f.h.Cleanup()
+	ctx := context.Background()
+
+	queueHumanMessage(t, f.h.Repo(), f.chatID, f.chatID, "already read this")
+
+	activityInstance := NewCallLLMActivity(f.h.Repo(), nil, nil, &staticConfigProvider{}, nil, nil)
+
+	// Deliver it, exactly as a turn's drain would.
+	runInActivity(t, f.h, func(actCtx context.Context) error {
+		activityInstance.drainAgentMailbox(actCtx, f.chatID, f.chatID)
+		return nil
+	})
+	queued, err := f.h.Repo().ListQueuedAgentMessagesForThread(ctx, f.chatID)
+	require.NoError(t, err)
+	require.Empty(t, queued, "precondition: the drain must have claimed the row")
+
+	var pending bool
+	runInActivity(t, f.h, func(actCtx context.Context) error {
+		pending = activityInstance.hasQueuedAgentMessages(actCtx, f.chatID)
+		return nil
+	})
+
+	assert.False(t, pending,
+		"a row already delivered must not count as a pending inbox — this is the exact "+
+			"state of the wedged thread's mailbox (one row, status=2)")
+}
+
+// The other half of the invariant: a REAL queued message must still report
+// true. The fix must not buy wedge-immunity by stranding messages — that is the
+// regression the pending_inbox term was introduced to prevent.
+func TestPendingInbox_RealQueuedMessageReportsTrue(t *testing.T) {
+	f := setupDurableStatusFixture(t)
+	defer f.h.Cleanup()
+
+	queueHumanMessage(t, f.h.Repo(), f.chatID, f.chatID, "actually, check the migration first")
+
+	activityInstance := NewCallLLMActivity(f.h.Repo(), nil, nil, &staticConfigProvider{}, nil, nil)
+
+	var pending bool
+	runInActivity(t, f.h, func(actCtx context.Context) error {
+		pending = activityInstance.hasQueuedAgentMessages(actCtx, f.chatID)
+		return nil
+	})
+
+	assert.True(t, pending,
+		"a genuinely queued message must earn another turn, or it is stranded — "+
+			"call_llm is the only deliverer")
+}
+
+// THE INTERRUPT RACE, resolved.
+//
+// An interrupted turn reaches the probe with its context ALREADY CANCELLED
+// (verified in the incident logs: the same cancellation that killed the stream
+// also failed an unrelated settings read with "context canceled"). So the probe
+// must run detached, or it would answer false for the very message the
+// interrupt was issued to deliver — trading the wedge for a stranded message.
+//
+// This is the test that distinguishes a correct fix from one that merely stops
+// the looping: with a live queued message and a dead context, the answer must
+// still be true.
+func TestPendingInbox_SurvivesCancelledContext(t *testing.T) {
+	f := setupDurableStatusFixture(t)
+	defer f.h.Cleanup()
+
+	queueHumanMessage(t, f.h.Repo(), f.chatID, f.chatID, "stop, this changes things")
+
+	activityInstance := NewCallLLMActivity(f.h.Repo(), nil, nil, &staticConfigProvider{}, nil, nil)
+
+	var pending bool
+	runInActivity(t, f.h, func(actCtx context.Context) error {
+		cancelled, cancel := context.WithCancel(actCtx)
+		cancel() // exactly the state an interrupted turn arrives in
+
+		probeCtx, cancelProbe := context.WithTimeout(
+			context.WithoutCancel(cancelled), 5*time.Second)
+		defer cancelProbe()
+		pending = activityInstance.hasQueuedAgentMessages(probeCtx, f.chatID)
+		return nil
+	})
+
+	assert.True(t, pending,
+		"an interrupted turn's probe must survive its own cancellation — otherwise the "+
+			"message the user interrupted to send is stranded, which is the regression "+
+			"the pending_inbox term exists to prevent")
+}
+
+// RECOVERY. The wedged tail shape: an assistant message with ONE text block and
+// no tool calls. It is NOT blockless, so dropBlocklessAssistantMessages leaves
+// it alone — correctly, since discarding it would destroy real model output the
+// user already read.
+//
+// That means recovery cannot come from filtering. It has to come from call_llm
+// treating an assistant tail as a completed turn and yielding, which is what
+// the guard now does.
+func TestRecovery_TextOnlyAssistantTailIsNotBlockless(t *testing.T) {
+	msgs := []message.Message{
+		userWithText("u1", "go ahead"),
+		assistantWithText("a1", "While that runs, let me review my full diff and check lint/typecheck."),
+	}
+
+	kept, dropped := dropBlocklessAssistantMessages(msgs)
+
+	require.Equal(t, 0, dropped,
+		"a text-only assistant message carries real output and must never be dropped")
+	require.Len(t, kept, 2)
+	assert.Equal(t, message.Assistant, kept[len(kept)-1].Role,
+		"the history still ends with the assistant message — so recovery must come from "+
+			"call_llm yielding on that tail, not from filtering it away")
+}
+
+// saveTextOnlyAssistantMessage writes the wedged tail shape: an ASSISTANT
+// message with exactly one text content block and no tool calls. Mirrors
+// CreateTestUserMessageWithText, which is how the sibling half of the
+// conversation is written.
+func saveTextOnlyAssistantMessage(t *testing.T, h *IdempotencyTestHelper, chatID, threadID, text string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	msgID := uuid.New().String()
+	ordinal, err := h.Repo().GetNextOrdinal(ctx, threadID)
+	require.NoError(t, err)
+	seq, err := h.Repo().GetNextSeq(ctx, chatID, threadID)
+	require.NoError(t, err)
+
+	require.NoError(t, h.Repo().CreateMessage(ctx, &db.Message{
+		ID:              msgID,
+		ChatID:          chatID,
+		Role:            reliantv1.MessageRole_MESSAGE_ROLE_ASSISTANT,
+		Ordinal:         ordinal,
+		Seq:             seq,
+		ThreadID:        threadID,
+		ContextWindowID: chatID + ":" + threadID + ":0",
+		CreatedAt:       time.Now().UTC(),
+		UpdatedAt:       time.Now().UTC(),
+	}))
+
+	require.NoError(t, h.Repo().CreateContentBlock(ctx, &db.MessageContentBlock{
+		ID:        uuid.New().String(),
+		MessageID: msgID,
+		BlockType: reliantv1.ContentBlockType_CONTENT_BLOCK_TYPE_TEXT,
+		Position:  0,
+		Content:   ptr.Of(text),
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}))
+
+	return msgID
+}
+
+// RECOVERY, end to end. A thread whose tail is a text-only assistant message
+// with an empty mailbox must yield instead of erroring.
+//
+// Before the fix this returned:
+//
+//	failed to stream LLM response: conversation history ends with assistant
+//	message after all transformations (...)
+//
+// which the retry ladder reproduced forever — the chat could never advance
+// again without hand-editing the database. Now the turn ends cleanly with no
+// tool calls and no pending inbox, so the agent loop's while-condition is false
+// on every term and it exits, yielding to the user. The user's next message
+// becomes the new tail and the thread is live again.
+func TestRecovery_AssistantTailYieldsInsteadOfWedging(t *testing.T) {
+	resolver := mockLLMDriverResolver()
+
+	h := NewIdempotencyTestHelper(t)
+	defer h.Cleanup()
+
+	ctx := context.Background()
+	project := h.CreateTestProject(ctx, "project-"+uuid.NewString(), "user-"+uuid.NewString())
+	chat := h.CreateTestChat(ctx, "chat-"+uuid.NewString(), project.ID, project.UserID)
+
+	// Reproduce the wedged tail: a user turn, then a text-only assistant reply
+	// with no tool calls — and nothing queued behind it.
+	h.CreateTestUserMessage(ctx, chat.ID, chat.ID)
+	saveTextOnlyAssistantMessage(t, h, chat.ID, chat.ID,
+		"While that runs, let me review my full diff and check lint/typecheck.")
+
+	queued, err := h.Repo().ListQueuedAgentMessagesForThread(ctx, chat.ID)
+	require.NoError(t, err)
+	require.Empty(t, queued, "precondition: the wedged thread's mailbox is empty")
+
+	activityInstance := NewCallLLMActivity(h.Repo(), nil, nil, &staticConfigProvider{}, resolver, nil)
+
+	var output CallLLMOutput
+	err = h.ExecuteActivity(activityInstance.Execute,
+		callLLMInput(chat.ID, chat.ID, "mock-model"), &output)
+
+	require.NoError(t, err,
+		"a thread whose tail is a text-only assistant message must YIELD, not error — "+
+			"erroring is what wedged chat 2b4c8c20 permanently")
+
+	// Every term of the agent loop's while-condition must be false, or the loop
+	// re-enters and the wedge is merely relocated.
+	assert.Empty(t, output.ToolCalls,
+		"a yielded turn requests no tools, so the loop's tool_calls term is false")
+	assert.False(t, output.PendingInbox,
+		"the mailbox is empty, so pending_inbox must be false and the loop must exit")
+}
+
+// SCOPING — THE MAIN REGRESSION RISK.
+//
+// A text-only assistant tail is the NORMAL, HEALTHY resting state of a finished
+// turn awaiting the user. Measured across the live database: 1,200 threads have
+// that tail and only 2 were wedged. So the shape alone is emphatically NOT the
+// defect, and any repair that keys off it would fire on ~1,198 healthy idle
+// threads.
+//
+// This fix does not key off the shape. The distinguishing condition is the
+// COMBINATION — a text-only assistant tail AND the loop re-entering call_llm
+// AND an empty mailbox — i.e. pending_inbox claimed a delivery and the drain
+// delivered nothing. Both halves key off exactly that:
+//
+//   - Prevention removes the false claim at the source (pending_inbox now comes
+//     only from a real mailbox probe), so the loop never re-enters on an empty
+//     mailbox in the first place.
+//   - Recovery lives INSIDE call_llm, on the path taken only when something has
+//     ALREADY re-entered with an assistant tail. An idle thread is not running
+//     call_llm at all — nothing executes this code for it.
+//
+// This test pins the healthy case: an idle thread's history is untouched by the
+// repair pass, so it neither gains a turn nor loses its last message.
+func TestScoping_HealthyIdleTextOnlyTailIsUntouched(t *testing.T) {
+	tail := "Done — the migration is applied and the tests pass."
+	msgs := []message.Message{
+		userWithText("u1", "apply the migration"),
+		assistantWithText("a1", tail),
+	}
+
+	kept, dropped := dropBlocklessAssistantMessages(msgs)
+
+	require.Equal(t, 0, dropped,
+		"the resting state of 1,198 healthy idle threads must not be treated as damage")
+	require.Len(t, kept, 2, "an idle thread's history must survive the repair pass intact")
+	assert.Equal(t, tail, kept[1].Content().String(),
+		"the assistant's final answer is what the user is reading — it must not be rewritten")
+}
+
+// The same scoping fact, stated on the flag the agent loop actually reads.
+//
+// An idle thread with a text-only tail and an empty mailbox reports
+// pending_inbox=false, so every term of the while-condition is false and the
+// loop stays exited. Nothing about this fix pushes such a thread into an extra
+// turn — the flag is the only lever that could, and it reads false.
+func TestScoping_IdleThreadWithEmptyMailboxEarnsNoExtraTurn(t *testing.T) {
+	f := setupDurableStatusFixture(t)
+	defer f.h.Cleanup()
+
+	activityInstance := NewCallLLMActivity(f.h.Repo(), nil, nil, &staticConfigProvider{}, nil, nil)
+
+	var pending bool
+	runInActivity(t, f.h, func(actCtx context.Context) error {
+		pending = activityInstance.hasQueuedAgentMessages(actCtx, f.chatID)
+		return nil
+	})
+
+	assert.False(t, pending,
+		"an idle thread with nothing queued must earn no extra turn — pending_inbox is "+
+			"the only term that could grant one, and it must read false")
+}

--- a/specs/thread-interrupt.md
+++ b/specs/thread-interrupt.md
@@ -147,6 +147,35 @@ re-checks the mailbox (one indexed SELECT) and reports whether anything landed.
 Both agent loops OR it into their `while`, so the loop takes one more turn, and
 that turn's drain delivers the message.
 
+**`pending_inbox` must stay truthful — it means "a real queued message exists
+and the next turn WILL deliver it", and nothing else.** That is what makes
+another turn safe to take: re-entering `call_llm` ends history with a USER
+message. It is set from the mailbox probe alone.
+
+It was briefly also set from `streamInterrupted`, and that wedged chats
+permanently. A text-only assistant turn has no tool calls, so the turn is
+COMPLETE and the loop must exit and yield; when an interrupt set this flag with
+an EMPTY mailbox, the loop re-entered anyway, the drain delivered nothing,
+history still ended with the assistant message, and the end-of-history guard
+failed the turn — identically on every retry, forever. Measured on live data:
+chat `2b4c8c20` / thread `8c48ab59`, 48 identical failures, mailbox holding one
+already-delivered row.
+
+The interrupt path loses nothing by this. An interrupt is only ever issued
+against a thread that already has something queued (the UI offers the button
+only from the queued strip), so the probe finds that row and returns true
+anyway. The probe runs on a context detached from cancellation, because an
+interrupted turn reaches it with its context already dead and would otherwise
+answer false for the very message the interrupt was issued to deliver.
+
+The residual race — a message queued microseconds AFTER the probe — is not
+closed here and cannot be; every check has an "after". It is closed on the
+enqueue side, and already was: `notifyAgentMessageQueued` rings the doorbell,
+`SendMessage` absorbs an idle thread's queue on the user's next turn, and
+`resolveOrphanedAgentMessages` marks anything that outlives every turn. Such a
+message is late, never lost — whereas assuming "yes" bought that at the price of
+a chat that could not advance at all.
+
 - `agent.yaml`: `... || outputs.pending_inbox == true`
 - `structured-agent.yaml`: added INSIDE the `max_turns` conjunction — a queued
   message earns another turn, it must not buy unbounded ones.


### PR DESCRIPTION
## The wedge

A text-only assistant turn — text, no tool calls — is a **complete** turn: the agent loop should exit and yield to the user. Instead the loop re-entered `call_llm` because `pending_inbox` was true, and `pending_inbox` was set from `streamInterrupted` rather than from any mailbox check:

```go
PendingInbox: streamInterrupted,   // call_llm.go:1111, before this change
```

With an empty mailbox the drain delivered nothing, history still ended with the assistant message, the guard at `call_llm.go:917` failed the turn, and the retry ladder reproduced it forever. **The chat became permanently unrecoverable.**

Verified independently against the live database (read-only):

| fact | evidence |
|---|---|
| 48 identical failures | all on `chat=2b4c8c20…`, `thread=8c48ab59…` |
| the tail | assistant, **one text block, no `tool_use`** |
| its mailbox | exactly **one row at status=2** (already delivered) |
| the cancelled turn | `toolCalls=0 … pendingInbox=true` in the worker log |

`pending_inbox` was lying.

## Prevention

`pending_inbox` now means exactly one thing — **a real queued message exists and the next turn will deliver it** — so re-entering `call_llm` genuinely ends history with a USER message. It comes from the mailbox probe alone; the `||` that made it unfalsifiable is gone (once an interrupt set it true, an empty mailbox could not clear it).

## How the interrupt race is resolved

The interrupt path deliberately runs "one more mailbox-draining turn" so a message sent *during* streaming isn't stranded. That is preserved, and nothing is re-stranded:

1. **An interrupt is only ever issued against a thread that already has something queued** — the UI offers the button only from the queued strip. So the probe finds that row and returns `true` anyway. `streamInterrupted` was a *proxy* for "something is queued"; the probe is the real thing.
2. **The probe runs detached from cancellation.** An interrupted turn reaches it with `ctx` already dead (confirmed in the incident log: the same cancellation failed an unrelated settings read with `context canceled`). A context-bound probe would answer `false` for the very message the interrupt was issued to deliver — trading the wedge for a stranded message. Pinned by `TestPendingInbox_SurvivesCancelledContext`.
3. **The residual microsecond race is closed on the enqueue side, and already was** — `notifyAgentMessageQueued` rings the doorbell, `SendMessage` absorbs an idle queue on the next send, and the reconciler's `resolveOrphanedAgentMessages` marks anything that outlives every turn. Such a message is **late, never lost** — whereas assuming "yes" bought that at the price of a chat that could not advance at all.

## Recovery

An assistant tail *after the drain* now yields a completed turn instead of erroring, so a thread already carrying that shape heals on its next turn. It still logs at ERROR — reaching it remains an upstream bug — but the chat survives it.

## Scoping — the main regression risk

A text-only assistant tail is the **normal resting state of an idle thread**. Independently measured on live data: **1,201** threads have that tail, and only **2** are on a RUNNING thread (both with **zero** pending mailbox rows — exactly the two known wedges).

**Neither half of this fix keys off that shape.** Prevention removes the false claim at its source; recovery lives *inside* `call_llm`, which an idle thread never executes. **Behaviour for a normal idle thread is unchanged** — pinned by `TestScoping_HealthyIdleTextOnlyTailIsUntouched` and `TestScoping_IdleThreadWithEmptyMailboxEarnsNoExtraTurn`.

## Misleading error text

The old message claimed *"this usually means the user message was saved to a different thread than CallLLM reads from"* — flatly wrong for this cause, and it sent the last debugger down a false trail. It now names the real conditions in likelihood order.

## Evidence

`TestRecovery_AssistantTailYieldsInsteadOfWedging` **fails against the old code** with the exact production error, and passes after. Full `./internal/workflow/...`, `./internal/threads/...`, `./internal/grpc/...`, `./internal/db/...` suites pass; `go build ./...` clean.

🚫 **Do not merge** — opened for review.