### PR TITLE
fix(docker): build in a glibc toolchain so the arm64 image can exec

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -99,6 +99,21 @@ jobs:
           cache-from: type=gha,scope=reliant
           cache-to: type=gha,scope=reliant,mode=max
 
+      # Reject an image whose binary asks for a loader the image does not
+      # ship. `docker build` cannot catch this: the build succeeds, the
+      # manifest is a valid linux/<arch>, and only exec fails — with
+      # "no such file or directory" naming the BINARY, not the missing
+      # interpreter. It crashlooped three prod deployments after the arm64
+      # leg was built in a musl toolchain against a glibc runtime base.
+      #
+      # Runs BEFORE the prod mirror below, so a bad image is never copied
+      # into the registry prod deploys from.
+      - name: Verify image interpreters
+        run: |
+          curl -sSL "https://github.com/google/go-containerregistry/releases/download/v0.20.2/go-containerregistry_Linux_x86_64.tar.gz" \
+            | tar -xz -C /usr/local/bin crane
+          ./scripts/check-image-interp.sh "${{ env.GAR_NONPROD }}/reliant@${{ steps.build.outputs.digest }}" amd64 arm64
+
       # ── Prod GAR mirror ──────────────────────────────────────────────
       # Prod GAR (reliant-labs-475814) is a DIFFERENT GCP project from the
       # nonprod one used above, so it needs the prod WIF identity. Finish

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,32 @@
 # deploy time: `user: root` in compose or securityContext in k8s.
 
 # ── Build ────────────────────────────────────────────────────────────────────
-# golang:1.26.2-alpine — pinned by digest, pulled via the GCP Artifact Registry
-# pull-through cache (dodges Docker Hub's per-IP rate limit).
-FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/reliant-nonprod-490701/dockerhub/library/golang@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
+# golang:1.26.2-BOOKWORM (glibc), pinned by digest, pulled via the GCP Artifact
+# Registry pull-through cache (dodges Docker Hub's per-IP rate limit).
+#
+# The builder's libc is load-bearing, not incidental. CGO_ENABLED=0 does NOT
+# make this binary static: the forge module pulls kcl-lang.io ->
+# ebitengine/purego, which emits cgo_import_dynamic directives, so the binary
+# is dynamically linked and Go stamps a PT_INTERP chosen from the BUILDER's
+# libc — per target arch.
+#
+# On the previous alpine (musl) builder that produced:
+#   GOARCH=amd64 -> /lib64/ld-linux-x86-64.so.2   (glibc — worked by luck)
+#   GOARCH=arm64 -> /lib/ld-musl-aarch64.so.1     (musl  — BROKEN)
+# and the debian runtime below ships no musl loader, so the arm64 image died
+# with `exec /usr/local/bin/reliant: no such file or directory` — an error
+# naming the BINARY even though the binary is present, because the kernel is
+# reporting the missing INTERPRETER. That crashlooped reliant-api-server,
+# reliant-temporal-worker and daemon-gateway in prod.
+#
+# A glibc builder makes both arches agree with the runtime base. Verified:
+# arm64 now stamps /lib/ld-linux-aarch64.so.1, which the runtime provides at
+# /usr/lib/aarch64-linux-gnu/. scripts/check-image-interp.sh enforces this in
+# CI, because a build-only check cannot see it — the image builds fine and
+# only fails at exec.
+FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/reliant-nonprod-490701/dockerhub/library/golang@sha256:47ce5636e9936b2c5cbf708925578ef386b4f8872aec74a67bd13a627d242b19 AS builder
 ARG TARGETARCH
-RUN apk add --no-cache git
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 # go.work (gitignored, machine-local) bridges this build to the sibling
 # ../forge checkout for local development. That checkout is absent from the

--- a/scripts/check-image-interp.sh
+++ b/scripts/check-image-interp.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Assert every architecture of a built image carries an ELF interpreter the
+# image can actually satisfy.
+#
+# THE BUG THIS CATCHES. The binary is dynamically linked despite
+# CGO_ENABLED=0: the forge module pulls kcl-lang.io -> ebitengine/purego,
+# which emits cgo_import_dynamic directives. Go then picks the interpreter
+# path from the BUILDER's libc. Build in an alpine (musl) toolchain and
+# cross-compile, and the arm64 leg asks for
+#
+#     /lib/ld-musl-aarch64.so.1
+#
+# while the debian runtime ships only glibc's ld-linux. exec then fails with
+#
+#     exec /usr/local/bin/reliant: no such file or directory
+#
+# which names the BINARY even though the binary is present — the kernel is
+# reporting the missing INTERPRETER. That crashlooped three prod deployments.
+#
+# WHY A BUILD-ONLY CHECK MISSES IT. `docker build` succeeds, the image pushes,
+# the manifest is a valid linux/arm64, and `crane config` reports the right
+# platform. Nothing is wrong until something tries to RUN it. The amd64 leg
+# happens to be fine, so a single-arch smoke test passes too.
+#
+# Usage: check-image-interp.sh <image-ref> [arch ...]   (default: amd64 arm64)
+set -euo pipefail
+
+IMAGE="${1:?usage: check-image-interp.sh <image-ref> [arch ...]}"
+shift || true
+ARCHES=("$@")
+[ ${#ARCHES[@]} -eq 0 ] && ARCHES=(amd64 arm64)
+
+command -v crane >/dev/null || { echo "crane is required" >&2; exit 2; }
+
+fail=0
+for arch in "${ARCHES[@]}"; do
+  work="$(mktemp -d)"
+  trap 'rm -rf "$work"' EXIT
+
+  # Distinguish "this arch genuinely isn't published" from "we could not read
+  # the registry at all". Collapsing the two into a silent SKIP is how a guard
+  # ends up green against an image it never actually inspected — including on
+  # an auth failure, which is the common CI misconfiguration.
+  if ! crane manifest "$IMAGE" >/dev/null 2>"$work/err"; then
+    echo "  ${arch}: FAIL — cannot read $IMAGE: $(tr -d '\n' < "$work/err")" >&2
+    fail=1; rm -rf "$work"; trap - EXIT; continue
+  fi
+
+  if ! crane export --platform "linux/${arch}" "$IMAGE" - 2>/dev/null \
+      | tar -xO usr/local/bin/reliant > "$work/bin" 2>/dev/null || [ ! -s "$work/bin" ]; then
+    echo "  ${arch}: SKIP (no linux/${arch} published for this image)"
+    rm -rf "$work"; trap - EXIT; continue
+  fi
+
+  # Read PT_INTERP from the program headers rather than grepping strings: a Go
+  # binary embeds several loader paths as data, and only the header says which
+  # one the kernel will actually use.
+  interp="$(python3 - "$work/bin" <<'PY'
+import struct,sys
+d=open(sys.argv[1],'rb').read(65536)
+if d[:4]!=b'\x7fELF': print("NOT-ELF"); raise SystemExit
+e='<' if d[5]==1 else '>'
+ph=struct.unpack_from(e+'Q',d,0x20)[0]; es=struct.unpack_from(e+'H',d,0x36)[0]; n=struct.unpack_from(e+'H',d,0x38)[0]
+for i in range(n):
+    o=ph+i*es
+    if struct.unpack_from(e+'I',d,o)[0]==3:
+        off=struct.unpack_from(e+'Q',d,o+0x08)[0]; sz=struct.unpack_from(e+'Q',d,o+0x20)[0]
+        print(d[off:off+sz].rstrip(b'\x00').decode()); raise SystemExit
+print("STATIC")
+PY
+)"
+
+  case "$interp" in
+    STATIC)
+      echo "  ${arch}: OK (static, no interpreter needed)" ;;
+    *ld-musl*)
+      echo "  ${arch}: FAIL — wants ${interp}, but the runtime base is debian (glibc)." >&2
+      echo "           Build in a glibc toolchain (golang:*-bookworm), not alpine." >&2
+      fail=1 ;;
+    *)
+      # Dynamic and non-musl: the loader must exist in the image, or exec dies
+      # with a misleading "no such file or directory" naming the binary.
+      if crane export --platform "linux/${arch}" "$IMAGE" - 2>/dev/null \
+          | tar -tf - 2>/dev/null | grep -qF "${interp#/}"; then
+        echo "  ${arch}: OK (${interp} present in image)"
+      else
+        echo "  ${arch}: FAIL — wants ${interp}, which is NOT in the image." >&2
+        fail=1
+      fi ;;
+  esac
+
+  rm -rf "$work"; trap - EXIT
+done
+
+exit "$fail"


### PR DESCRIPTION
fix(docker): build in a glibc toolchain so the arm64 image can exec

The image built by CI crashlooped in prod:

    exec /usr/local/bin/reliant: no such file or directory

with the binary present at exactly that path. The error names the BINARY,
but the kernel is reporting the missing INTERPRETER.

CGO_ENABLED=0 does not make this binary static. The forge module pulls
kcl-lang.io -> ebitengine/purego, which emits cgo_import_dynamic
directives, so the binary is dynamically linked and Go stamps a PT_INTERP
chosen from the BUILDER's libc — separately per target arch. On the alpine
(musl) builder, cross-compiling produced:

    GOARCH=amd64 -> /lib64/ld-linux-x86-64.so.2   glibc, worked by luck
    GOARCH=arm64 -> /lib/ld-musl-aarch64.so.1     musl,  BROKEN

The runtime base is debian and ships no musl loader, so the arm64 image
could never exec. Reproduced locally with the same multi-platform buildx
invocation CI uses, and confirmed by reading PT_INTERP from the program
headers of the published images:

    prod's working image  /lib64/ld-linux-x86-64.so.2
    the CI-built image    /lib/ld-musl-x86_64.so.1

Building in golang:1.26.2-bookworm makes both arches agree with the
runtime. Verified by rebuilding: arm64 now stamps
/lib/ld-linux-aarch64.so.1, which the runtime provides at
/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1.

The builder stays pinned by digest and behind the Artifact Registry
pull-through cache, as before — only the base changes.

scripts/check-image-interp.sh enforces the invariant in CI, per arch,
against the pushed digest and BEFORE the prod mirror, so a bad image is
never copied into the registry prod deploys from. A build-only check
cannot catch this class: the build succeeds, the manifest is a valid
linux/<arch>, `crane config` reports the right platform, and nothing is
wrong until something tries to run it. The script reads PT_INTERP from the
program headers rather than grepping strings, because a Go binary embeds
several loader paths as data and only the header says which one the kernel
will use. It also fails loudly when it cannot READ the image, rather than
skipping — a guard that silently passes on an auth error is worse than no
guard.

Detection logic verified against three real binaries: prod's working image
PASSES, and both the CI-built prod mirror and its nonprod amd64 child FAIL.

---

**This is the bug that crashlooped three prod deployments during today's deploy** (reliant-api-server, reliant-temporal-worker, daemon-gateway). Prod was rolled back to the last-good digest and is healthy; those three are still pinned to it until this lands and a clean image is built.