### PR TITLE
chore: release v1.7.7

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -13,6 +13,13 @@ Regenerate with: make generate-changelog
 
 Track what's new in each Reliant release.
 
+<Update label="v1.7.7" description="August 22, 2026">
+### Deployment plumbing, and a desktop build that runs everywhere it claims to
+
+- **The published container image runs on every architecture it advertises** The image is built for both Intel and ARM, but the ARM build was linked against system libraries the image does not contain. Starting it failed with a message naming the program as missing — even though the program was there — because it was really the loader that was absent. The build now uses a toolchain that matches the image, and a check in the release pipeline reads the compiled program's own requirements and refuses to publish an image that cannot start. That check exists because nothing before it could tell: the build succeeds, the image looks correct, and only running it fails.
+- **Releases reach production without manual steps** The deployment pipeline had never once completed. It advanced through environments in order, but asking it for a single environment caused it to skip the ones before — and skipping those skipped the one you asked for. Production sat behind an environment whose cluster no longer exists, so it could never be reached at all. Deployments were being applied by hand as a result. It now deploys the environment you ask for, and pins every component to the exact build recorded for that release rather than assuming one label fits components built in different places.
+</Update>
+
 <Update label="v1.7.6" description="August 21, 2026">
 ### Sign-in works again, and a stuck chat can no longer strand itself
 

--- a/docs/data/releases/v1.7.7.yaml
+++ b/docs/data/releases/v1.7.7.yaml
@@ -1,0 +1,9 @@
+version: "v1.7.7"
+date: "2026-08-22"
+title: "Deployment plumbing, and a desktop build that runs everywhere it claims to"
+summary: "A maintenance release. The desktop app is now built against the right system libraries on every architecture it ships for, and the machinery that gets a release into production stopped needing a person to nudge it by hand."
+items:
+  - title: "The published container image runs on every architecture it advertises"
+    description: "The image is built for both Intel and ARM, but the ARM build was linked against system libraries the image does not contain. Starting it failed with a message naming the program as missing — even though the program was there — because it was really the loader that was absent. The build now uses a toolchain that matches the image, and a check in the release pipeline reads the compiled program's own requirements and refuses to publish an image that cannot start. That check exists because nothing before it could tell: the build succeeds, the image looks correct, and only running it fails."
+  - title: "Releases reach production without manual steps"
+    description: "The deployment pipeline had never once completed. It advanced through environments in order, but asking it for a single environment caused it to skip the ones before — and skipping those skipped the one you asked for. Production sat behind an environment whose cluster no longer exists, so it could never be reached at all. Deployments were being applied by hand as a result. It now deploys the environment you ask for, and pins every component to the exact build recorded for that release rather than assuming one label fits components built in different places."

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reliant",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "AI-powered coding assistant with intelligent agents for professional software development",
   "author": "Reliant Labs <support@reliantlabs.io>",
   "homepage": "https://reliantlabs.io",

--- a/go.mod
+++ b/go.mod
@@ -28,8 +28,8 @@ require (
 	github.com/pdfcpu/pdfcpu v0.13.0
 	github.com/pressly/goose/v3 v3.25.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/reliant-labs/forge v0.1.3
-	github.com/reliant-labs/forge/pkg v0.1.3
+	github.com/reliant-labs/forge v0.1.4
+	github.com/reliant-labs/forge/pkg v0.1.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/sqlc-dev/pqtype v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -537,10 +537,14 @@ github.com/reliant-labs/forge v0.1.2 h1:DfHapIDHukuDaEWHhyESbTfWxJNJQ1tFrDJUKGBB
 github.com/reliant-labs/forge v0.1.2/go.mod h1:voNxiGNN3DBfPwthAdKUIV9E1KUXy/Od3NoXpsIXWpk=
 github.com/reliant-labs/forge v0.1.3 h1:dwQygFcD+kvh4cA4hDYFR3IguzEaCtYzJy04gXzHYf8=
 github.com/reliant-labs/forge v0.1.3/go.mod h1:+KJW7qcICuMXj/R8togRZb3J5URCxn1QsQtFgBj4A5o=
+github.com/reliant-labs/forge v0.1.4 h1:rn+fR6ZvKct/YLI+NtJ0w9nyRN9MFLwG5ZxjvTW1Mo8=
+github.com/reliant-labs/forge v0.1.4/go.mod h1:vKJcoZmipLF5QdTwuX6or5Ag4AOmKFfnmtqTaYv3l2E=
 github.com/reliant-labs/forge/pkg v0.1.2 h1:8rvg0r3BBIlJFBrdZa9MK+H5Zo/imRiG2Xino7GnMuE=
 github.com/reliant-labs/forge/pkg v0.1.2/go.mod h1:ny/z3fmpdV/np0gZwvSK7zxfZZVxwdtRNAasdQM5FX8=
 github.com/reliant-labs/forge/pkg v0.1.3 h1:+XPVOd6ZfSfj87efc8vgH0NwOt3CYsNBt2x9he9dKKs=
 github.com/reliant-labs/forge/pkg v0.1.3/go.mod h1:ny/z3fmpdV/np0gZwvSK7zxfZZVxwdtRNAasdQM5FX8=
+github.com/reliant-labs/forge/pkg v0.1.4 h1:zoCXpklr9+QN1qEfhCKY2x5i3KPvh5ZOzL944I4+gwA=
+github.com/reliant-labs/forge/pkg v0.1.4/go.mod h1:ny/z3fmpdV/np0gZwvSK7zxfZZVxwdtRNAasdQM5FX8=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
Bumps forge + forge/pkg to **v0.1.4**, which names one-shot Jobs by a hash of their rendered pod spec — so re-applying an unchanged Job is a genuine no-op instead of an immutable-field error that failed the deploy *after* every Deployment had already rolled.

Also carries this round's CI work: the glibc builder fix and the now-blocking interpreter guard (#202-#207), plus control-plane's deploy-dispatch fix and ledger digest pinning.

Known-failing check: `E2E Frontend (Playwright)` on `chat.spec.ts` — pre-existing, identical on the merged v1.7.4/v1.7.5/v1.7.6 release PRs.