### PR TITLE
fix(release): purge the real Windows update feed, and fail on bad targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1149,11 +1149,18 @@ jobs:
           BASE_URL="https://downloads.reliantlabs.io"
           FILES=()
 
-          # Always purge the auto-update manifests (these are what clients poll)
+          # Always purge the auto-update manifests (these are what clients poll).
+          #
+          # The Windows manifest is `<channel>.yml`, NOT `<channel>-win.yml` —
+          # electron-builder names the Windows feed after the channel alone and
+          # only suffixes the other platforms. Purging `latest-win.yml` hit a
+          # 404 and left the real feed cached: after v1.7.7 published, clients
+          # were still served version 1.7.5 for ~20h (cf-cache-status HIT,
+          # age 72856 against max-age 86400) while origin was already correct.
           if [[ "$CHANNEL" == "latest" ]]; then
-            FILES+=("${BASE_URL}/latest-mac.yml" "${BASE_URL}/latest-linux.yml" "${BASE_URL}/latest-win.yml")
+            FILES+=("${BASE_URL}/latest-mac.yml" "${BASE_URL}/latest-linux.yml" "${BASE_URL}/latest.yml")
           else
-            FILES+=("${BASE_URL}/alpha-mac.yml" "${BASE_URL}/alpha-linux.yml" "${BASE_URL}/alpha-win.yml")
+            FILES+=("${BASE_URL}/alpha-mac.yml" "${BASE_URL}/alpha-linux.yml" "${BASE_URL}/alpha.yml")
           fi
 
           # Purge versioned download URLs per platform
@@ -1169,7 +1176,9 @@ jobs:
           fi
           if [[ "$LINUX_RESULT" == "success" ]]; then
             FILES+=(
-              "${BASE_URL}/Reliant-${VERSION_NUM}-linux-x64.AppImage"
+              # x86_64, not x64 — electron-builder uses the GNU arch name for
+              # Linux AppImages while using x64 for mac/win.
+              "${BASE_URL}/Reliant-${VERSION_NUM}-linux-x86_64.AppImage"
               "${BASE_URL}/Reliant-${VERSION_NUM}-linux-arm64.AppImage"
               "${BASE_URL}/Reliant-${VERSION_NUM}-linux-amd64.deb"
               "${BASE_URL}/Reliant-${VERSION_NUM}-linux-arm64.deb"
@@ -1181,6 +1190,25 @@ jobs:
               "${BASE_URL}/Reliant-${VERSION_NUM}-win-arm64.exe"
               "${BASE_URL}/Reliant-${VERSION_NUM}-win-x64.exe.blockmap"
             )
+          fi
+
+          # Purging a URL that does not exist is accepted by Cloudflare with a
+          # 200, so a misspelled name fails SILENTLY and the real object stays
+          # cached — which is precisely how latest-win.yml went unnoticed. Check
+          # that each URL resolves and fail the step if one does not, so a
+          # rename in electron-builder's output surfaces here instead of as a
+          # stale feed a day later.
+          missing=0
+          for url in "${FILES[@]}"; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "$url")
+            if [[ "$code" != "200" ]]; then
+              echo "::error::purge target does not exist (HTTP ${code}): ${url}"
+              missing=$((missing + 1))
+            fi
+          done
+          if [[ "$missing" -gt 0 ]]; then
+            echo "::error::${missing} purge target(s) do not exist — the published artifact names have changed. Fix the list in this step; a purge of a non-existent URL is a silent no-op."
+            exit 1
           fi
 
           echo "Purging ${#FILES[@]} URLs from Cloudflare cache..."


### PR DESCRIPTION
The Windows auto-update feed served a stale version for ~20 hours after v1.7.7 shipped. The cause is a filename mismatch in the cache-purge step, not a missing purge.

## The bug

`Purge Cloudflare CDN cache` purges `latest-win.yml`. **That file does not exist** — electron-builder names the Windows feed after the channel alone (`latest.yml`) and only suffixes the other platforms. Verified against the live bucket:

| URL | Status |
|---|---|
| `latest.yml` | 200 |
| `latest-win.yml` | **404** |
| `alpha.yml` | 200 |
| `alpha-win.yml` | **404** |

So the real Windows feed was never purged. After v1.7.7 published, clients polling for updates were served **version 1.7.5** — `cf-cache-status: HIT`, `age: 72856` against `max-age=86400` — while origin was already correct. A cache-busted fetch returned 1.7.7. Windows users could be told "no update available" for up to a day after a release.

A second mismatch: the Linux AppImage is published as `linux-x86_64`, not `linux-x64`, so that purge target 404s too.

## Why it went unnoticed

**Cloudflare accepts a purge for a URL that does not exist and returns HTTP 200.** A misspelled name is a silent no-op, and the step reported success while doing nothing. That is the actual defect worth fixing — the wrong name was just how it surfaced.

## Changes

1. `latest-win.yml` → `latest.yml`, `alpha-win.yml` → `alpha.yml`.
2. `linux-x64.AppImage` → `linux-x86_64.AppImage`.
3. **A guard that makes this class of bug impossible to reship**: before purging, every target URL is checked and the step fails if any does not resolve. If electron-builder's output names change again, the release fails loudly here instead of producing a stale feed discovered days later.

## Verification

I ran the guard against the live bucket both ways:

- **Old list** → correctly fails, catching both real bugs:
  ```
  MISSING (404): https://downloads.reliantlabs.io/latest-win.yml
  MISSING (404): https://downloads.reliantlabs.io/Reliant-1.7.7-linux-x64.AppImage
  ```
- **Fixed list** → `missing=0`, all 16 URLs resolve.

Every other name in the purge list was checked individually against the published v1.7.7 artifacts and is correct (mac dmg/zip/blockmap ×2 arches, linux arm64 AppImage, both debs, win x64/arm64 exe + blockmap).

Workflow YAML parses and the step body passes `bash -n`.

## Note

This does not retroactively fix the v1.7.7 feed — that cache has since expired naturally and all three feeds now serve 1.7.7. This prevents the next occurrence.
