### PR TITLE
fix(web): a missing Supabase key must not white-screen the app

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -318,6 +318,21 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}
 
+      # Without this the renderer builds with no VITE_SUPABASE_ANON_KEY, and
+      # supabase-js throws `supabaseKey is required.` — previously at module
+      # load, which left #root empty and timed out every test in the suite on a
+      # blank page. web/src/lib/supabase.ts now defers that failure to first
+      # use, so the app mounts either way; supplying the key here is what lets
+      # the auth-dependent tests actually exercise auth.
+      #
+      # Same mechanism as release.yml's "Export renderer build config". These
+      # are the public KCL-sourced values only — no secrets are layered on
+      # here, because Playwright needs none of them. VITE_SUPABASE_ANON_KEY is
+      # a publishable client-side key that already ships inside every desktop
+      # build and is committed in electron/release.config.json.
+      - name: Export renderer build config
+        run: jq -er '.vite | to_entries[] | "\(.key)=\(.value)"' electron/release.config.json >> "$GITHUB_ENV"
+
       - name: Build (alpha)
         working-directory: web
         run: npm run build:alpha

--- a/web/src/lib/__tests__/supabase.missingKey.test.ts
+++ b/web/src/lib/__tests__/supabase.missingKey.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// src/test/setup.ts globally mocks '@/lib/supabase' precisely because importing
+// it used to throw "supabaseKey is required." That mock is what kept this
+// defect invisible to the unit lane, so this file tests the real module.
+vi.unmock('@/lib/supabase')
+
+// Stub supabase-js so these tests assert OUR construction behavior (when
+// createClient is called, and with what) without opening a network client.
+// The real library's own guard — `if (!supabaseKey) throw` — is the thing this
+// module must now avoid tripping at import, so we reproduce it here rather
+// than trusting a stub that always succeeds.
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn((url: string, key: string) => {
+    if (!key) throw new Error('supabaseKey is required.')
+    return {
+      supabaseUrl: url,
+      auth: {
+        getSession: async function () {
+          // Reading `this` proves the proxy bound the method to the real
+          // client; an unbound call would see the proxy (or undefined) here.
+          if (!this || typeof this.getSession !== 'function') {
+            throw new Error('getSession lost its `this` binding')
+          }
+          return { data: { session: null }, error: null }
+        },
+      },
+    }
+  }),
+}))
+
+const ORIGINAL_ENV = { ...import.meta.env }
+
+function setEnv(vars: Record<string, string | undefined>) {
+  for (const [key, value] of Object.entries(vars)) {
+    if (value === undefined) {
+      delete (import.meta.env as Record<string, unknown>)[key]
+    } else {
+      (import.meta.env as Record<string, unknown>)[key] = value
+    }
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  // window.electronAPI is absent, and VITE_AUTH_MODE is unset, so getStorage()
+  // takes the browser path; nothing here needs an Electron or gRPC backend.
+  setEnv({ VITE_SUPABASE_URL: undefined, VITE_SUPABASE_ANON_KEY: undefined })
+})
+
+afterEach(() => {
+  for (const key of Object.keys(import.meta.env)) {
+    delete (import.meta.env as Record<string, unknown>)[key]
+  }
+  Object.assign(import.meta.env, ORIGINAL_ENV)
+})
+
+describe('supabase module with no anon key configured', () => {
+  // The regression itself: with VITE_SUPABASE_ANON_KEY unset, this module used
+  // to throw at IMPORT time. It is imported transitively from the app entry via
+  // authStore -> AuthInitializer, so the throw happened before React could
+  // mount, leaving #root empty and every Playwright test timing out on a blank
+  // page. Importing must now succeed.
+  it('imports without throwing', async () => {
+    await expect(import('@/lib/supabase')).resolves.toBeDefined()
+  })
+
+  it('reports that Supabase is not configured', async () => {
+    const { isSupabaseConfigured } = await import('@/lib/supabase')
+    expect(isSupabaseConfigured()).toBe(false)
+  })
+
+  it('does not invent a fallback key to make a broken build look healthy', async () => {
+    const { createClient } = await import('@supabase/supabase-js')
+    const createClientSpy = vi.mocked(createClient)
+    await import('@/lib/supabase')
+    expect(createClientSpy).not.toHaveBeenCalled()
+  })
+
+  // The failure is deferred, not swallowed. It surfaces at first auth use,
+  // where a React error boundary can render the reason, and it names the
+  // missing variable rather than supabase-js's opaque "supabaseKey is required."
+  it('throws an actionable error at first use, not at import', async () => {
+    const { supabase, MISSING_ANON_KEY_MESSAGE } = await import('@/lib/supabase')
+    expect(() => supabase.auth).toThrow(MISSING_ANON_KEY_MESSAGE)
+    expect(MISSING_ANON_KEY_MESSAGE).toContain('VITE_SUPABASE_ANON_KEY')
+  })
+})
+
+describe('supabase module with an anon key configured', () => {
+  beforeEach(() => {
+    setEnv({
+      VITE_SUPABASE_URL: 'https://dash.example.invalid',
+      VITE_SUPABASE_ANON_KEY: 'sb_publishable_test_key',
+    })
+  })
+
+  it('reports that Supabase is configured', async () => {
+    const { isSupabaseConfigured } = await import('@/lib/supabase')
+    expect(isSupabaseConfigured()).toBe(true)
+  })
+
+  it('builds the client lazily and reuses it across property accesses', async () => {
+    const { createClient } = await import('@supabase/supabase-js')
+    const createClientSpy = vi.mocked(createClient)
+    const { supabase } = await import('@/lib/supabase')
+
+    expect(createClientSpy).not.toHaveBeenCalled()
+
+    void supabase.auth
+    void supabase.auth
+    expect(createClientSpy).toHaveBeenCalledTimes(1)
+    expect(createClientSpy).toHaveBeenCalledWith(
+      'https://dash.example.invalid',
+      'sb_publishable_test_key',
+      expect.objectContaining({ auth: expect.objectContaining({ flowType: 'pkce' }) }),
+    )
+  })
+
+  it('preserves `this` when a client method is called through the proxy', async () => {
+    const { supabase } = await import('@/lib/supabase')
+    await expect(supabase.auth.getSession()).resolves.toEqual({
+      data: { session: null },
+      error: null,
+    })
+  })
+})

--- a/web/src/lib/supabase.ts
+++ b/web/src/lib/supabase.ts
@@ -6,6 +6,11 @@ import { getIsDev } from './constants'
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'http://127.0.0.1:54321'
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || ''
 
+export const MISSING_ANON_KEY_MESSAGE =
+  'VITE_SUPABASE_ANON_KEY is not set in this build, so authentication is unavailable. ' +
+  'Source builds get it from the environment; released builds get it from ' +
+  'electron/release.config.json via the workflow\'s "Export renderer build config" step.'
+
 const isElectron = !!window.electronAPI
 
 // Custom storage adapter for Electron that uses our file-based auth storage
@@ -181,15 +186,70 @@ const getStorage = (): SupportedStorage => {
   return window.localStorage
 }
 
-export const supabase: SupabaseClient = createClient(supabaseUrl, supabaseAnonKey, {
-  auth: {
-    autoRefreshToken: true,
-    persistSession: true,
-    detectSessionInUrl: false,
-    storage: getStorage(),
-    storageKey: 'supabase-auth',
-    flowType: 'pkce',
+/** True when this build carries the config Supabase needs to start. */
+export const isSupabaseConfigured = (): boolean => Boolean(supabaseAnonKey)
+
+let client: SupabaseClient | null = null
+
+/**
+ * Build the real client on first use.
+ *
+ * This is deliberately NOT called at module scope. supabase-js throws
+ * `supabaseKey is required.` from createClient when the key is empty, and this
+ * module is imported transitively from the app entry (authStore ->
+ * AuthInitializer), so a module-scope call turned one missing build variable
+ * into a blank page: React never mounted and `#root` stayed empty, with the
+ * only evidence a console error nobody sees in a packaged app.
+ *
+ * Deferring the construction moves that failure to the first auth call, where
+ * a React error boundary can catch it and show the reason. Everything that
+ * doesn't touch auth keeps working.
+ *
+ * We do NOT substitute a fallback anon key. There is no local Supabase in this
+ * repo to fall back TO — no supabase/config.toml, no compose service, and
+ * scripts/dev.sh sets no VITE_SUPABASE_*, so the pre-existing
+ * `http://127.0.0.1:54321` URL default already points at nothing. Inventing a
+ * credential would make a misconfigured build look healthy while pointing
+ * somewhere useless, which is the exact failure sync-release-config.mjs was
+ * written to prevent ("a packaged app that silently ships pointing at
+ * localhost or at nothing — it builds green and fails on a user's machine").
+ * A released artifact still cannot reach this path: that script fails the
+ * build when vite.VITE_SUPABASE_ANON_KEY is empty.
+ */
+const getClient = (): SupabaseClient => {
+  if (client) return client
+  if (!supabaseAnonKey) throw new Error(MISSING_ANON_KEY_MESSAGE)
+
+  client = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      autoRefreshToken: true,
+      persistSession: true,
+      detectSessionInUrl: false,
+      storage: getStorage(),
+      storageKey: 'supabase-auth',
+      flowType: 'pkce',
+    },
+  })
+  return client
+}
+
+/**
+ * Drop-in replacement for the eagerly-created client.
+ *
+ * Callers keep writing `supabase.auth.signInWithPassword(...)`; the proxy
+ * constructs the underlying client on the first property access instead of at
+ * import time. Existing call sites are unchanged.
+ */
+export const supabase: SupabaseClient = new Proxy({} as SupabaseClient, {
+  get: (_target, property) => {
+    const resolved = getClient()
+    const value = Reflect.get(resolved, property) as unknown
+    // Bind methods to the real client so `this` is never the proxy, which
+    // would re-enter this trap for every internal property access.
+    return typeof value === 'function' ? value.bind(resolved) : value
   },
+  set: (_target, property, value) => Reflect.set(getClient(), property, value),
+  has: (_target, property) => Reflect.has(getClient(), property),
 })
 
 // NOTE: OAuth callback handling is done in authStore.ts to keep all auth logic centralized


### PR DESCRIPTION
## The product bug

`web/src/lib/supabase.ts` called `createClient` at **module scope** with the anon key defaulting to `''`. supabase-js has an unconditional `if (!supabaseKey) throw new Error('supabaseKey is required.')`, so with the key unset **the module threw while loading**. It is imported transitively from the app entry (`authStore` → `AuthInitializer`), so React never mounted: `#root` stayed empty and the whole UI was a blank page — the only evidence a console error nobody sees in a packaged app.

One missing build variable hard-white-screened the entire product.

## The fix, and why not the other one

**Lazy client, not a fallback key.** A `Proxy` defers `createClient` to first property access, so importing always succeeds and the failure surfaces at the first auth call — inside the existing `SentryErrorBoundary`, naming the missing variable instead of supabase-js's opaque message. Everything that doesn't touch auth keeps working. Call sites are unchanged.

I deliberately did **not** fall back to a local dev anon key. The deciding fact, which I verified rather than assumed: **there is no local Supabase in this repo to fall back to** — no `supabase/config.toml`, no compose service, and `scripts/dev.sh` sets no `VITE_SUPABASE_*`. The pre-existing `http://127.0.0.1:54321` URL default already points at nothing.

Inventing a credential would make a misconfigured build *look* healthy while pointing somewhere useless — the exact failure `sync-release-config.mjs:90` exists to prevent:

> a packaged app that silently ships pointing at localhost or at nothing — it builds green and fails on a user's machine

The defect was never the wrong default; it was that the wrong default was **silent**. This keeps a dev/source build degrading gracefully while staying loud, and a **released artifact cannot reach the new throw at all** — `sync-release-config.mjs` already fails the build when `vite.VITE_SUPABASE_ANON_KEY` is empty.

## Why the unit lane never caught it

`web/src/test/setup.ts:63` globally mocks `@/lib/supabase`, with a comment saying it does so *"so that importing grpc-client (which eagerly calls createClient) doesn't throw 'supabaseKey is required'"*. The fragility was known and papered over. The new test `vi.unmock`s it and asserts the **real** module.

Verified the test genuinely reproduces: **6 of 7 fail against the unfixed module** with `Error: supabaseKey is required.`, all 7 pass with the fix.

## The CI gap

`e2e-frontend` passed no `VITE_*` to its `Build (alpha)` step, so it built keyless and every test timed out on the blank page. Adds the same `Export renderer build config` jq step `release.yml` already uses (public KCL values only — Playwright needs no secrets).

`VITE_SUPABASE_ANON_KEY` is a **publishable** client-side key, already committed in `electron/release.config.json` and already shipped inside every desktop build. I verified this rather than taking it on trust: it carries the `sb_publishable_` prefix, and the repo's own redactor (`internal/workflow/runtime/redact.go:35`) matches only `sb_secret_` — publishable keys are deliberately not treated as sensitive. **No secret is required.**

## Measured results

Run locally with CI's exact config (`CI=true`, single worker, 2 retries, `vite preview`):

| Build | Result |
|---|---|
| original code, no key (**CI today**) | **31 failed**, 12 skipped, 5 passed |
| lazy client, no key | 10 failed, 12 skipped, 26 passed |
| lazy client + key (**this PR**) | **0 failed**, 12 skipped, **36 passed** |

The baseline reproduces the reported `31 failed, 12 skipped, 5 passed` exactly.

**This came out better than expected.** The brief anticipated ~10 residual failures from a refactored onboarding step model. Those are already fixed on main by `1dccce7f` ("rewrite onboarding.spec.ts against the current onboarding model", #182). The 10 that still fail *without* a key are auth-dependent onboarding tests, and they pass once the key is supplied. **No follow-up work is outstanding**, contrary to the original expectation.

## Other verification

- `npx tsc -b` — clean
- `eslint` on both changed files — clean
- Full unit suite: **273 files / 1996 tests passed**

One caveat reported honestly: the first full-suite run showed `OnboardingSpotlight.escape.test.tsx` failing on a timer leak (`setTimeout` in `OnboardingSpotlight.tsx:247` firing after teardown). It passes in isolation **both with and without** my change, and a clean re-run of the full suite was 1996/1996. Pre-existing flake, unrelated to this PR — not investigated further.

No stylesheets touched, so `lint:css` was not applicable.
