### PR TITLE
chore: require forge/pkg v0.1.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,8 +28,8 @@ require (
 	github.com/pdfcpu/pdfcpu v0.13.0
 	github.com/pressly/goose/v3 v3.25.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/reliant-labs/forge v0.1.5
-	github.com/reliant-labs/forge/pkg v0.1.5
+	github.com/reliant-labs/forge v0.1.6
+	github.com/reliant-labs/forge/pkg v0.1.6
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/sqlc-dev/pqtype v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -533,10 +533,10 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.1.0 h1:137FnGdk+EQdCbye1FW+qOEcY5S+SpY9T0NiuqvtfMY=
 github.com/redis/go-redis/v9 v9.1.0/go.mod h1:urWj3He21Dj5k4TK1y59xH8Uj6ATueP8AH1cY3lZl4c=
-github.com/reliant-labs/forge v0.1.5 h1:iieD32e/QpQCYQoKQULrkCUlYzkxb1+rRufftAtqdA0=
-github.com/reliant-labs/forge v0.1.5/go.mod h1:E7CGoODpSqKlaYR4NLV7OOHF4zHh2mkMFnmXccU2J+0=
-github.com/reliant-labs/forge/pkg v0.1.5 h1:PpWAtg0+xVZMkDf5sFEzZQAqKNtueGAR+HLPqoTVtAc=
-github.com/reliant-labs/forge/pkg v0.1.5/go.mod h1:ny/z3fmpdV/np0gZwvSK7zxfZZVxwdtRNAasdQM5FX8=
+github.com/reliant-labs/forge v0.1.6 h1:6IlHQEwQapqIyh/qxcnKCaHnheCtTMBAWzqc9RTfiRo=
+github.com/reliant-labs/forge v0.1.6/go.mod h1:rthS9z8JNxUHp3qvW6zsK+YTqRZlXh5ZbF5gK4PmTyc=
+github.com/reliant-labs/forge/pkg v0.1.6 h1:wLMbzte+WXqnGPIFCfG9HMu6vEWI7HgTmZJ3xPOjmkY=
+github.com/reliant-labs/forge/pkg v0.1.6/go.mod h1:ny/z3fmpdV/np0gZwvSK7zxfZZVxwdtRNAasdQM5FX8=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
Bumps `github.com/reliant-labs/forge` and `forge/pkg` v0.1.5 → v0.1.6.

forge v0.1.6 makes a **released** forge scaffold a project that actually works — the KCL module is now always vendored (the `kcl-v0.1.0` tag it used to pin was never published, so released builds produced unresolvable projects and *broke* working ones on upgrade), CI frontends derive from KCL rather than a retired config key, and a fresh scaffold passes its own typecheck and style lint.

reliant consumes `forge/pkg`; this keeps the pin in step with control-plane so the two do not drift.

Diff is go.mod/go.sum only. `go build ./...` clean, `go test -short ./...` green.