### PR TITLE
chore: release v1.7.8

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -13,6 +13,14 @@ Regenerate with: make generate-changelog
 
 Track what's new in each Reliant release.
 
+<Update label="v1.7.8" description="August 22, 2026">
+### The app no longer goes blank when a setting is missing
+
+- **A missing setting no longer leaves you looking at a blank window** One piece of configuration is read the moment the app starts. If it was absent, the code that reads it stopped the app before anything was drawn — so instead of an error you got an empty window, with the explanation only visible in a developer console most people never open. The app now starts regardless and only reports the problem if you reach a feature that genuinely needs that setting, where the message says which setting is missing. Nothing is invented to paper over it: a build that is missing the value still says so rather than quietly behaving as though it has one.
+- **Windows gets told about new versions on time** After a release, the file the app checks to discover updates was being cleared for macOS and Linux but not for Windows, because the step that clears it named a file that does not exist. Windows users could keep being told they were up to date for up to a day after a new version shipped. The correct file is now cleared, and the release will stop and report if it is ever asked to clear something that is not there — the previous behaviour reported success while doing nothing.
+- **The end-to-end browser tests actually run** The browser test suite had never passed. Every test was failing for the same reason described above — the app never started, so nothing could be tested — which meant the suite could not report on anything else either. With that fixed the full suite now runs and passes, so a real regression in the interface will be caught before it ships instead of being hidden behind a permanently red result.
+</Update>
+
 <Update label="v1.7.7" description="August 22, 2026">
 ### Deployment plumbing, and a desktop build that runs everywhere it claims to
 

--- a/docs/data/releases/v1.7.8.yaml
+++ b/docs/data/releases/v1.7.8.yaml
@@ -1,0 +1,11 @@
+version: "v1.7.8"
+date: "2026-08-22"
+title: "The app no longer goes blank when a setting is missing"
+summary: "A maintenance release. A single missing piece of build configuration could leave the app showing nothing at all; now it starts normally and tells you what is missing only if you reach the part that needs it. Update notifications also stop lagging behind a new version on Windows."
+items:
+  - title: "A missing setting no longer leaves you looking at a blank window"
+    description: "One piece of configuration is read the moment the app starts. If it was absent, the code that reads it stopped the app before anything was drawn — so instead of an error you got an empty window, with the explanation only visible in a developer console most people never open. The app now starts regardless and only reports the problem if you reach a feature that genuinely needs that setting, where the message says which setting is missing. Nothing is invented to paper over it: a build that is missing the value still says so rather than quietly behaving as though it has one."
+  - title: "Windows gets told about new versions on time"
+    description: "After a release, the file the app checks to discover updates was being cleared for macOS and Linux but not for Windows, because the step that clears it named a file that does not exist. Windows users could keep being told they were up to date for up to a day after a new version shipped. The correct file is now cleared, and the release will stop and report if it is ever asked to clear something that is not there — the previous behaviour reported success while doing nothing."
+  - title: "The end-to-end browser tests actually run"
+    description: "The browser test suite had never passed. Every test was failing for the same reason described above — the app never started, so nothing could be tested — which meant the suite could not report on anything else either. With that fixed the full suite now runs and passes, so a real regression in the interface will be caught before it ships instead of being hidden behind a permanently red result."

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reliant",
-  "version": "1.7.4",
+  "version": "1.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reliant",
-      "version": "1.7.4",
+      "version": "1.7.8",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@sentry/electron": "^7.10.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reliant",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "description": "AI-powered coding assistant with intelligent agents for professional software development",
   "author": "Reliant Labs <support@reliantlabs.io>",
   "homepage": "https://reliantlabs.io",


### PR DESCRIPTION
Release v1.7.8. Tag `v1.7.8` is already pushed and the build is running; this lands the version bump and changelog on `main`.

**Contents:** forge/pkg v0.1.6, the Supabase white-screen fix, and the Windows update-feed purge fix.

- `electron/package.json` 1.7.7 → 1.7.8
- `docs/data/releases/v1.7.8.yaml` (release notes source)
- `docs/changelog.mdx` (regenerated from the YAML by `scripts/release.sh`)