### PR TITLE
fix(release): commit the lockfile npm version already rewrote

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -163,7 +163,12 @@ fi
 
 # Create git tag with v prefix
 echo -e "${YELLOW}🏷️  Creating release commit and tag...${NC}"
-git add electron/package.json
+# `npm version` rewrites BOTH package.json and package-lock.json. Staging
+# only the former left the lockfile's version field behind on every release
+# — by v1.7.8 it still read 1.7.4, three releases stale — and left the
+# working tree dirty after a release, which is exactly the state that hides
+# a real uncommitted change.
+git add electron/package.json electron/package-lock.json
 if [[ "$REQUIRES_CHANGELOG" == "true" ]]; then
     git add "$CHANGELOG_FILE" "$GENERATED_CHANGELOG"
 fi


### PR DESCRIPTION
`npm version` rewrites both `electron/package.json` and `electron/package-lock.json`, but `scripts/release.sh` stages only the former. The lockfile change is left uncommitted and dropped.

By v1.7.8 the lockfile still read `"version": "1.7.4"` — **three releases stale**.

The version field in a lockfile isn't used for resolution, so this is harmless on its own. What matters is that every release ended with a **dirty working tree**, and a tree that is always dirty is one where a genuinely stray change goes unnoticed. It only surfaced at all because `gh pr create` warned "1 uncommitted change" while I was cutting v1.7.8.

I synced the lockfile by hand on the v1.7.8 release branch; this stops it recurring.

`bash -n scripts/release.sh` passes; `package.json` and `package-lock.json` are both at 1.7.8 on main.