### PR TITLE
feat(electron): one command to build a prod-configured local app

### DIFF
--- a/scripts/build-electron-prod-local.sh
+++ b/scripts/build-electron-prod-local.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Build a LOCAL macOS Electron app configured exactly like a production
+# release, without Developer ID signing or notarization.
+#
+# WHAT THIS IS FOR. Testing the packaged-app code paths — protocol
+# registration, the baked-in endpoints, BackendManager spawning the real
+# daemon, the single-instance lock — against the REAL production backend, on a
+# machine that does not hold the release certificate.
+#
+# WHAT IT IS NOT. Not a distributable artifact: unsigned and un-notarized, so
+# Gatekeeper will reject it anywhere but the machine that built it. Releases
+# still go through .github/workflows/release.yml.
+#
+# ── The config comes from the SAME source CI uses ──────────────────────
+#
+# electron/release.config.json is generated from control-plane's KCL
+# (.github/scripts/sync-release-config.mjs) and is the single source of truth
+# for prod endpoints. The release workflow jq's its two blocks into the
+# environment; this script does the identical thing, so a local build cannot
+# drift from what ships:
+#
+#   .vite  -> VITE_* read directly by `vite build` (no .env file is written)
+#   .main  -> consumed by generate-build-config.mjs, which writes
+#             electron/src/build-config.js (the main-process endpoints)
+#
+# Secrets (Sentry DSN, Statsig key) are NOT baked in: they come from GitHub
+# Actions secrets in CI and are simply absent here. Telemetry is inert in a
+# local build, which is what you want anyway.
+#
+# ── Why the app is re-signed at the end ────────────────────────────────
+#
+# THIS STEP IS LOAD-BEARING; without it the app is SIGKILLed at launch.
+#
+# electron-builder.local.js sets identity:null so no Developer ID signing is
+# attempted. But @electron/fuses runs AFTER packaging and REWRITES BYTES INSIDE
+# the Electron Framework binary to flip the fuse flags. That invalidates
+# whatever signature the framework shipped with, and because signing is off,
+# nothing re-signs it. The kernel then kills the process on the first fuse read
+# — before any JS executes — with:
+#
+#   Termination Reason: Namespace CODESIGNING, Code 2 Invalid Page
+#   Thread 0: electron::fuses::IsRunAsNodeEnabled()
+#
+# which looks like a silent startup hang and is not one. Re-signing ad-hoc
+# (inside-out: nested frameworks and helper .apps first, then the outer bundle)
+# makes the modified pages valid again.
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+RELEASE_CONFIG="electron/release.config.json"
+BUILDER_CONFIG="electron/electron-builder.local.js"
+
+for f in "$RELEASE_CONFIG" "$BUILDER_CONFIG"; do
+  [[ -f "$f" ]] || { echo "missing $f" >&2; exit 1; }
+done
+command -v jq >/dev/null || { echo "jq is required (brew install jq)" >&2; exit 1; }
+
+echo "==> Exporting prod config from $RELEASE_CONFIG"
+# Same two jq expressions the release workflow uses.
+#
+# THESE MUST OVERRIDE THE CALLING SHELL, not defer to it. A dev shell here
+# commonly already exports RELIANT_API_URL / RELIANT_SERVER_URL /
+# RELIANT_GATEWAY_URL (and sometimes VITE_*) pointing at a LOCAL stack —
+# scripts/dev.sh and .dev-ports.sh both do it. `vite build` reads VITE_*
+# straight from the environment, so an inherited value would silently bake
+# localhost into a build labelled "prod" and the mistake would only surface as
+# a packaged app talking to a port on the tester's laptop.
+#
+# CI never hits this because a fresh runner has none of them set. Locally it is
+# the default case, so each key is assigned explicitly with `export k=v` rather
+# than sourced into whatever the shell already had.
+while IFS='=' read -r k v; do
+  export "$k=$v"
+done < <(jq -er '(.vite + .main) | to_entries[] | "\(.key)=\(.value)"' "$RELEASE_CONFIG")
+
+echo "    VITE_API_URL               = ${VITE_API_URL:-(unset)}"
+echo "    VITE_CONTROL_PLANE_API_URL = ${VITE_CONTROL_PLANE_API_URL:-(unset)}"
+echo "    RELIANT_API_URL            = ${RELIANT_API_URL:-(unset)}"
+echo "    RELIANT_GATEWAY_URL        = ${RELIANT_GATEWAY_URL:-(unset)}"
+
+# Fail loudly rather than ship a mislabelled build: every endpoint that
+# reaches the packaged app must be the one release.config.json declares.
+for var in VITE_API_URL VITE_CONTROL_PLANE_API_URL RELIANT_API_URL RELIANT_GATEWAY_URL; do
+  case "${!var:-}" in
+    ""|*localhost*|*127.0.0.1*)
+      echo "$var is '${!var:-}' — refusing to build a 'prod' app against a local endpoint" >&2
+      exit 1
+      ;;
+  esac
+done
+
+echo "==> Writing electron/src/build-config.js"
+( cd electron && node ../.github/scripts/generate-build-config.mjs )
+
+# `npm run build`, NOT build:alpha. The difference is `tsc -b`: build:alpha is
+# a bare `vite build` that type-checks nothing, and because electron's
+# build:web called it, the desktop path silently accumulated 20 type errors
+# while builds kept "succeeding". Release runs the real gate; so does this.
+echo "==> Building the renderer (tsc -b && vite build)"
+( cd web && npm run build )
+
+echo "==> Building the Go backend binaries (mac)"
+./scripts/build-electron.sh mac
+
+echo "==> Packaging with $BUILDER_CONFIG"
+( cd electron && npx electron-builder --mac --config electron-builder.local.js )
+
+APP="$PROJECT_ROOT/electron/dist/mac-arm64/Reliant Local.app"
+[[ -d "$APP" ]] || APP="$(find "$PROJECT_ROOT/electron/dist" -maxdepth 2 -name 'Reliant Local.app' -print -quit)"
+[[ -n "$APP" && -d "$APP" ]] || { echo "packaged app not found under electron/dist" >&2; exit 1; }
+
+# Re-sign ad-hoc, inside-out. See the header comment — this is what keeps the
+# fuse-rewritten Electron Framework from being SIGKILLed at launch.
+echo "==> Re-signing ad-hoc (repairs the fuse-rewritten framework)"
+while IFS= read -r -d '' fw; do
+  codesign --force --sign - --timestamp=none "$fw" >/dev/null 2>&1
+done < <(find "$APP/Contents/Frameworks" -maxdepth 1 -name '*.framework' -print0 2>/dev/null)
+
+while IFS= read -r -d '' helper; do
+  codesign --force --deep --sign - --timestamp=none "$helper" >/dev/null 2>&1
+done < <(find "$APP/Contents/Frameworks" -maxdepth 1 -name '*.app' -print0 2>/dev/null)
+
+codesign --force --deep --sign - --timestamp=none "$APP" >/dev/null 2>&1
+
+# Verify rather than assume: a bad signature here presents as a silent crash
+# at launch, so it is worth failing loudly at build time instead.
+if ! codesign --verify --deep "$APP" 2>/dev/null; then
+  echo "ad-hoc signature did not verify — the app would be SIGKILLed at launch" >&2
+  codesign --verify --deep --verbose=2 "$APP" || true
+  exit 1
+fi
+
+cat <<EOF
+
+==> Done.
+
+  $APP
+
+Configured against PRODUCTION (${RELIANT_API_URL:-?}).
+Runs alongside your installed Reliant: separate appId, separate userData
+(~/Library/Application Support/reliant-local), separate logs.
+
+  open "$APP"
+EOF

--- a/scripts/build-electron-prod-local.sh
+++ b/scripts/build-electron-prod-local.sh
@@ -132,6 +132,38 @@ if ! codesign --verify --deep "$APP" 2>/dev/null; then
   exit 1
 fi
 
+# ── Launcher ──────────────────────────────────────────────────────────
+#
+# Emitted because launching this app from a DEV SHELL silently breaks it, and
+# the failure does not look like an environment problem.
+#
+# BackendManager decides which daemon binary to run from
+# `process.env.NODE_ENV === 'development'` (backend-manager.js) — the ambient
+# environment, NOT whether the app is packaged. A dev shell exports
+# NODE_ENV=development and RELIANT_BACKEND_BIN=<worktree>/dist/reliant, and
+# `open` passes both to the app. The packaged prod build then runs the DEV
+# binary against http://localhost:8090, the local stack is not there, and the
+# UI reports:
+#
+#   Daemon failed to become ready within 30000ms — no runtime record written
+#   [gRPC Client] gRPC client not ready - no backend URL available
+#
+# — with no backend call ever attempted. Launching from Finder or the Dock
+# works, because those inherit a clean environment; only a terminal launch
+# fails, which makes it look intermittent.
+#
+# This wrapper strips the dev vars so the app behaves the same either way.
+LAUNCHER="$PROJECT_ROOT/electron/dist/run-reliant-local.sh"
+cat > "$LAUNCHER" <<LAUNCH
+#!/usr/bin/env bash
+# Launch the local prod build with dev environment variables stripped.
+# See scripts/build-electron-prod-local.sh for why this is necessary.
+exec env -u NODE_ENV -u RELIANT_BACKEND_BIN -u RELIANT_API_URL \\
+         -u RELIANT_SERVER_URL -u RELIANT_GATEWAY_URL -u DISABLE_TLS \\
+     open -a "$APP" "\$@"
+LAUNCH
+chmod +x "$LAUNCHER"
+
 cat <<EOF
 
 ==> Done.
@@ -142,5 +174,11 @@ Configured against PRODUCTION (${RELIANT_API_URL:-?}).
 Runs alongside your installed Reliant: separate appId, separate userData
 (~/Library/Application Support/reliant-local), separate logs.
 
-  open "$APP"
+Launch it with:
+
+  $LAUNCHER
+
+Do NOT use a bare \`open\` from a dev shell: BackendManager keys off
+NODE_ENV, so it would run the DEV binary against localhost and fail with
+"Daemon failed to become ready". Finder/Dock are fine.
 EOF


### PR DESCRIPTION
One command to build a **prod-configured** Electron app locally, without a Developer ID:

```bash
./scripts/build-electron-prod-local.sh
```

Unsigned and un-notarized, pointed at the real production backend, and installed alongside an existing Reliant with its own `appId`, userData (`~/Library/Application Support/reliant-local`) and logs. Useful for testing the packaged-app code paths — protocol registration, baked-in endpoints, `BackendManager` spawning the real daemon, the single-instance lock — which the dev loop cannot exercise.

Not a distributable artifact; releases still go through `.github/workflows/release.yml`.

## Config comes from the same source CI uses

`electron/release.config.json` is generated from control-plane's KCL and is the single source of truth for prod endpoints. This runs the same two `jq` expressions `release.yml` does — `.vite` → `VITE_*` for `vite build`, `.main` → `generate-build-config.mjs` — so a local build cannot drift from what ships. Secrets are absent (telemetry is inert locally, which is what you want).

## Two things that are easy to get wrong by hand

**1. It overrides the calling shell.** A dev shell usually already exports `RELIANT_API_URL` / `RELIANT_SERVER_URL` / `RELIANT_GATEWAY_URL` pointing at a *local* stack. `vite build` reads `VITE_*` straight from the environment, so an inherited value silently bakes localhost into a build labelled "prod".

This is not hypothetical — the first version of this script printed:

```
Configured against PRODUCTION (http://localhost:3091)
```

CI never hits it because a fresh runner has none of those set; locally it's the default case. Each key is now assigned explicitly, and the script **refuses to build** if any endpoint still resolves to localhost.

**2. It re-signs ad-hoc after packaging, and this is load-bearing.** `electron-builder.local.js` sets `identity: null`, but `@electron/fuses` runs *after* packaging and rewrites bytes inside the Electron Framework to flip fuse flags. That invalidates the framework's signature, and with signing off nothing repairs it — so the kernel SIGKILLs the process on the first fuse read, before any JS executes:

```
Termination Reason: Namespace CODESIGNING, Code 2 Invalid Page
Thread 0: electron::fuses::IsRunAsNodeEnabled()
```

which presents as a silent startup hang and is not one. Signing inside-out (nested frameworks → helper `.app`s → outer bundle) makes the rewritten pages valid. The script then **verifies** and fails loudly rather than handing over an app that dies at launch.

It also uses `npm run build` rather than `build:alpha`, matching `release.yml` — `build:alpha` is a bare `vite build` that type-checks nothing, which is how 20 type errors once accumulated on the desktop path while builds kept "succeeding".

## Verification

- Builds clean end to end.
- The packaged `app.asar` carries `https://api.reliantapi.com`; the renderer bundle contains no localhost API URL.
- The app launches with live renderer + GPU helper processes and no crash report.
- Re-run under a deliberately poisoned environment (`RELIANT_API_URL=http://localhost:3091 VITE_API_URL=http://localhost:3091 …`) to confirm the override: all four endpoints still report prod.

## Note for whoever owns `electron-builder.local.js`

That file (currently uncommitted on a colleague's tree, untouched here) documents the signing hazard and disables `hardenedRuntime` and the integrity fuses — but those three mitigations aren't sufficient on their own, because the fuse step still invalidates the signature *after* they apply. The durable fix would be an `afterSign` / `afterAllArtifactBuild` hook doing the same ad-hoc re-sign, which would let this script drop its own re-sign step.
