### PR TITLE
fix(onboarding): don't ask for compute while the bundled daemon registers

### DIFF
--- a/electron/src/backend-manager.js
+++ b/electron/src/backend-manager.js
@@ -1451,6 +1451,17 @@ class BackendManager {
       gatewayUrl: this.gatewayUrl,
       controlPlaneUrl: this.controlPlaneUrl,
       isShuttingDown: this.isShuttingDown,
+      // Whether the daemon is running but has no credentials yet, so it has
+      // NOT registered with the control-plane and cannot appear in
+      // ListDaemons.
+      //
+      // The renderer needs this to tell two states apart that look identical
+      // through ListDaemons alone — "this user has no daemon" and "this
+      // user's daemon is seconds away from registering". Onboarding's compute
+      // step asks the user to CHOOSE their compute, and asking during the
+      // second one produces a question that answers itself moments later.
+      // See web/src/components/OnboardingFlow/steps/ComputeStep.tsx.
+      awaitingCredentials: this.isAwaitingCredentials(),
     };
   }
 

--- a/electron/src/preload.js
+++ b/electron/src/preload.js
@@ -306,6 +306,11 @@ const injectReliantConfig = async () => {
         // "Control plane API URL not configured" in the packaged build.
         controlPlaneURL: status?.controlPlaneUrl || '',
         daemonPort: status?.daemonPort || null,
+        // The daemon is up but not yet credentialed, so it has not registered
+        // and cannot show up in ListDaemons. Onboarding waits on this rather
+        // than asking the user to pick their compute during the gap. See
+        // BackendManager.getStatus().
+        daemonAwaitingCredentials: Boolean(status?.awaitingCredentials),
         isElectron: true,
         platform: info.platform,
         isDev: !info.isPackaged

--- a/web/src/components/OnboardingFlow/steps/ComputeStep.tsx
+++ b/web/src/components/OnboardingFlow/steps/ComputeStep.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/hooks/useOnboardingQueries";
 import { RedeemCouponForm } from "@/components/RedeemCouponForm";
 import { useGoToBilling } from "@/hooks/useGoToBilling";
+import { useDaemonProvisioning } from "@/hooks/useDaemonProvisioning";
 import type {
   CodeSource,
   ComputeChoice,
@@ -102,6 +103,12 @@ export function ComputeStep({
   const [showLocal, setShowLocal] = useState(plan.compute === "local_daemon");
   const [error, setError] = useState<string | null>(null);
   const { activeDaemon, daemons, loading: daemonLoading } = useDaemonStatus();
+  // A packaged desktop build ships its own daemon, but it has no credentials
+  // until sign-in — so for ~15s after a fresh sign-in ListDaemons correctly
+  // returns EMPTY while a daemon is seconds from registering. Without this,
+  // the step reads that as "no daemon" and asks a question that answers
+  // itself. See useDaemonProvisioning.
+  const localDaemonProvisioning = useDaemonProvisioning();
   const events = useEventBus();
   const hasAdvanced = useRef(false);
   const hasTrackedConnectedRef = useRef(false);
@@ -364,7 +371,7 @@ export function ComputeStep({
   // Visual pattern mirrors DaemonConnectingGate's "connecting" phase
   // (centered spinner in a tinted circle + headline) so the two onboarding
   // wait states feel consistent.
-  if (daemonLoading) {
+  if (daemonLoading || localDaemonProvisioning) {
     return (
       <div
         className="space-y-5 py-6 text-center"
@@ -377,10 +384,14 @@ export function ComputeStep({
         </div>
         <div className="space-y-1">
           <h2 className="text-sm font-medium text-foreground">
-            Checking your workspace…
+            {localDaemonProvisioning
+              ? "Connecting your daemon…"
+              : "Checking your workspace…"}
           </h2>
           <p className="text-xs text-muted-foreground">
-            One moment while we look for an existing daemon.
+            {localDaemonProvisioning
+              ? "This app ships with a daemon — finishing its setup."
+              : "One moment while we look for an existing daemon."}
           </p>
         </div>
       </div>

--- a/web/src/hooks/__tests__/useDaemonProvisioning.test.ts
+++ b/web/src/hooks/__tests__/useDaemonProvisioning.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useDaemonProvisioning } from '../useDaemonProvisioning'
+
+/**
+ * These pin the disambiguation the onboarding compute step depends on.
+ *
+ * An EMPTY ListDaemons result is ambiguous on desktop: it means either "this
+ * user has no daemon" or "this user's bundled daemon has not been credentialed
+ * yet". Reading the second as the first is what put a fresh sign-in on the
+ * compute-choice step for ~15 seconds while its own daemon was registering.
+ */
+
+const getBackendStatus = vi.fn()
+
+const asDesktop = () => {
+  ;(window as Window & { electronAPI?: unknown }).electronAPI = { getBackendStatus }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  delete (window as Window & { electronAPI?: unknown }).electronAPI
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useDaemonProvisioning', () => {
+  it('is false in a browser, where there is no bundled daemon', async () => {
+    const { result } = renderHook(() => useDaemonProvisioning())
+
+    // Web callers must see today's behaviour unchanged: an empty daemon list
+    // there genuinely means "no daemon".
+    await waitFor(() => expect(result.current).toBe(false))
+    expect(getBackendStatus).not.toHaveBeenCalled()
+  })
+
+  it('reports provisioning while the daemon is awaiting credentials', async () => {
+    asDesktop()
+    getBackendStatus.mockResolvedValue({ awaitingCredentials: true })
+
+    const { result } = renderHook(() => useDaemonProvisioning())
+
+    await waitFor(() => expect(result.current).toBe(true))
+  })
+
+  it('clears once the daemon is credentialed', async () => {
+    asDesktop()
+    getBackendStatus.mockResolvedValue({ awaitingCredentials: true })
+
+    const { result } = renderHook(() => useDaemonProvisioning())
+    await waitFor(() => expect(result.current).toBe(true))
+
+    // The daemon finishes registering — the poll must notice and stop, or the
+    // step would sit on a spinner after the answer arrived.
+    getBackendStatus.mockResolvedValue({ awaitingCredentials: false })
+    await waitFor(() => expect(result.current).toBe(false), { timeout: 3000 })
+  })
+
+  it('is false when the daemon already has credentials', async () => {
+    asDesktop()
+    getBackendStatus.mockResolvedValue({ awaitingCredentials: false })
+
+    const { result } = renderHook(() => useDaemonProvisioning())
+
+    await waitFor(() => expect(result.current).toBe(false))
+  })
+
+  it('does not strand onboarding when the status read fails', async () => {
+    asDesktop()
+    getBackendStatus.mockRejectedValue(new Error('IPC gone'))
+
+    const { result } = renderHook(() => useDaemonProvisioning())
+
+    // A failed read must degrade to "not provisioning" so the user still gets
+    // a usable step rather than an indefinite spinner.
+    await waitFor(() => expect(result.current).toBe(false))
+  })
+
+  it('stops polling after unmount', async () => {
+    asDesktop()
+    getBackendStatus.mockResolvedValue({ awaitingCredentials: true })
+
+    const { result, unmount } = renderHook(() => useDaemonProvisioning())
+    await waitFor(() => expect(result.current).toBe(true))
+
+    unmount()
+    const callsAtUnmount = getBackendStatus.mock.calls.length
+    await new Promise((resolve) => setTimeout(resolve, 1500))
+
+    // A hook that kept polling after unmount would leak a timer per visit to
+    // the step.
+    expect(getBackendStatus.mock.calls.length).toBe(callsAtUnmount)
+  })
+})

--- a/web/src/hooks/useDaemonProvisioning.ts
+++ b/web/src/hooks/useDaemonProvisioning.ts
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Whether a local daemon is running but not yet registered with the
+ * control-plane, so it cannot appear in ListDaemons yet.
+ *
+ * ── The gap this closes ───────────────────────────────────────────────
+ *
+ * A packaged desktop build ships its own daemon, but that daemon has NO
+ * credentials until the user signs in. The sequence after a fresh sign-in is:
+ *
+ *   t+0s   sign-in completes, renderer navigates to /onboarding
+ *   t+0s   daemon is still "awaiting credentials" — not registered
+ *   t+11s  auth:save fires, daemon restarts with the new principal
+ *   t+15s  gateway registers it; it finally appears in ListDaemons
+ *
+ * For those ~15 seconds ListDaemons correctly returns an empty list, and the
+ * onboarding compute step reads that as "this user has no daemon" and asks
+ * them to choose their compute. The question answers itself moments later,
+ * but by then the user has usually clicked — and the step's `hasAdvanced`
+ * latch means the auto-skip effect can never fire afterwards.
+ *
+ * An empty daemon list is therefore ambiguous on desktop, and this hook is
+ * what disambiguates it: "no daemon" versus "a daemon that is seconds away".
+ *
+ * ── Why polling rather than an event ──────────────────────────────────
+ *
+ * window.RELIANT_CONFIG is injected at load and refreshed only on
+ * `backend-port` events, which do not fire for a credential change — the port
+ * is identical before and after. Rather than add an IPC event whose only
+ * consumer is this hook, we re-read the status the preload already exposes.
+ * The poll is short-lived by construction: it stops as soon as the daemon
+ * stops awaiting credentials, which is a one-way transition per sign-in.
+ *
+ * Returns false everywhere except a packaged desktop build with a daemon
+ * actually mid-provisioning, so web callers get today's behaviour unchanged.
+ */
+
+const POLL_INTERVAL_MS = 1000;
+
+// Bounds the wait so a daemon that never credentials (a crash, a revoked
+// token) cannot pin onboarding on a spinner forever. Comfortably longer than
+// the ~15s observed end-to-end, short enough that a stuck daemon still lets
+// the user reach the compute choice and pick cloud instead.
+const MAX_WAIT_MS = 45_000;
+
+type BackendStatus = { awaitingCredentials?: boolean };
+
+const readStatus = async (): Promise<BackendStatus | null> => {
+  const api = (window as unknown as {
+    electronAPI?: { getBackendStatus?: () => Promise<BackendStatus> };
+  }).electronAPI;
+  if (!api?.getBackendStatus) return null;
+  try {
+    return await api.getBackendStatus();
+  } catch {
+    // A failed status read must not strand onboarding: treat it as "not
+    // provisioning" so the user still gets a usable step.
+    return null;
+  }
+};
+
+export function useDaemonProvisioning(): boolean {
+  const [provisioning, setProvisioning] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const startedAt = Date.now();
+
+    const tick = async () => {
+      const status = await readStatus();
+      if (cancelled) return;
+
+      const awaiting = Boolean(status?.awaitingCredentials);
+      // Give up waiting once the daemon is credentialed OR the budget is
+      // spent. Both are terminal: the effect stops polling either way.
+      if (!awaiting || Date.now() - startedAt > MAX_WAIT_MS) {
+        setProvisioning(false);
+        return;
+      }
+
+      setProvisioning(true);
+      timer = window.setTimeout(tick, POLL_INTERVAL_MS);
+    };
+
+    let timer = window.setTimeout(tick, 0);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, []);
+
+  return provisioning;
+}


### PR DESCRIPTION
A fresh sign-in on the packaged desktop build lands on the compute step and asks the user to choose their daemon — even though the app ships one.

## Neither hypothesis held up

Both were plausible, and I checked both against prod rather than reasoning about them.

**Not a port conflict.** Every daemon spawns with `--port 9190`, which looks alarming, but nothing listens there — the real listeners are OS-assigned (49929 for the packaged build). Six daemons from the installed app plus the local prod build plus a dev stack coexist fine.

**Not a broken token.** The post-login credential handoff works end to end. Verified in prod:

- Gateway logged `Daemon registered userID=d6397e04-… daemonID=2e321713-… hostname=seans-mbp-2.lan`
- The `daemons` row exists
- The `daemon_attachment` row exists and is **fresh** — last heartbeat 8s old, well inside the 90s window
- `~/.reliant/daemon.json` holds the prod PAT with a `sub` matching the signed-in user

So `ListDaemons` returns `ACTIVE`, and the auto-skip logic in `ComputeStep` is correct. It was being told the truth.

## It is an ordering race

```
t+0s    sign-in completes, renderer navigates to /onboarding
t+0s    daemon logs "No daemon credentials found — waiting for sign-in"
t+11s   auth:save fires, daemon restarts with the new principal
t+15s   gateway registers it; it finally appears in ListDaemons
```

`ComputeStep` mounts at **t+0**, and `ListDaemons` is *correctly* empty for ~15 seconds. The step reads that as "this user has no daemon" and renders the choice.

The auto-skip effect would catch up on the next 5s poll — except it is latched behind `hasAdvanced`. Any interaction during that window makes the step permanent for the session. Which is exactly what a user does: the page is asking them a question.

The existing `daemonLoading` gate does not cover this. It tracks only the *first* `ListDaemons` fetch, which settles in ~200ms returning empty.

The underlying problem: **an empty daemon list is ambiguous on desktop** — "no daemon" versus "a daemon seconds from registering" — and nothing in the renderer could distinguish them. `BackendManager` knows (`isAwaitingCredentials()`), but `getStatus()` never exposed it.

## The fix

Surface `awaitingCredentials` through the status channel the preload already reads, and hold the compute choice behind the step's existing wait state while it is true — with copy that says what is actually happening ("Connecting your daemon…") instead of the generic lookup message.

Polling rather than an event because `RELIANT_CONFIG` refreshes only on `backend-port`, which does not fire for a credential change (the port is identical either side). Adding an IPC event whose only consumer is this hook seemed worse than re-reading a status that is already exposed. The poll is self-terminating — the transition is one-way per sign-in — and bounded at 45s so a daemon that never credentials still lets the user reach the choice and pick cloud.

**Web is untouched.** No `electronAPI`, so the hook returns `false` and an empty list keeps meaning "no daemon".

## Verification

- **web: 2002 tests pass** (main: 1989), `tsc -b` clean
- **electron: 125 tests pass**
- 6 new tests pin the disambiguation: browser, provisioning, the transition to credentialed, already-credentialed, a failed status read degrading to a usable step, and no polling after unmount
- Reverting just the one-line gate restores the old behaviour, confirming the change is load-bearing rather than incidental

## Note

I could not reproduce the *user-visible* symptom on demand — it needs a fresh sign-in with a cold daemon, and the window is ~15s. The race is established from the logs and the component logic rather than from a repro, so a real sign-in on this build is the confirming test. Everything the fix depends on (the `awaitingCredentials` transition, the gate, the fallbacks) is covered by tests.
