### PR TITLE
chore: release v1.7.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # deploy time: `user: root` in compose or securityContext in k8s.
 
 # ── Build ────────────────────────────────────────────────────────────────────
-# golang:1.26.2-BOOKWORM (glibc), pinned by digest, pulled via the GCP Artifact
+# golang:1.26.6-BOOKWORM (glibc), pinned by digest, pulled via the GCP Artifact
 # Registry pull-through cache (dodges Docker Hub's per-IP rate limit).
 #
 # The builder's libc is load-bearing, not incidental. CGO_ENABLED=0 does NOT
@@ -35,7 +35,7 @@
 # /usr/lib/aarch64-linux-gnu/. scripts/check-image-interp.sh enforces this in
 # CI, because a build-only check cannot see it — the image builds fine and
 # only fails at exec.
-FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/reliant-nonprod-490701/dockerhub/library/golang@sha256:47ce5636e9936b2c5cbf708925578ef386b4f8872aec74a67bd13a627d242b19 AS builder
+FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/reliant-nonprod-490701/dockerhub/library/golang@sha256:116d58cbd88c1297624acc6e967a060012422bacf9930927e23fb719189c6f36 AS builder
 ARG TARGETARCH
 RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 WORKDIR /app

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -13,6 +13,16 @@ Regenerate with: make generate-changelog
 
 Track what's new in each Reliant release.
 
+<Update label="v1.7.9" description="August 27, 2026">
+### Signing in with Claude or Codex works in the browser, and the desktop app stops going blank
+
+- **Signing in with Claude or Codex now works outside the desktop app** These sign-ins have to hand control back to something running on your own machine, which previously only the desktop app could do — in a browser the sign-in simply had nowhere to return to. There is now a small command you can run in a terminal that receives the hand-back, so the same sign-in completes in a browser. It only bridges that one step: your account details are still exchanged and stored by the server, never by the local helper.
+- **The packaged app no longer opens to an empty window** The desktop app loaded its interface in a way that made every internal address resolve against your filesystem instead of the app itself, so nothing ever loaded and the window stayed blank. The failure was silent by construction — the page itself loaded fine, so no error appeared. The app now serves its own interface through a dedicated internal address, and the packaging step is checked so a build that would have shipped this cannot be released.
+- **A chat no longer stalls when the model returns nothing or declines** If the model finished a turn without producing any text, or declined to answer, the conversation could be left waiting on a reply that was never coming. Those endings are now recognised as real endings, so the chat continues and you can send the next message. Long-running turns are also cancelled properly when you stop them, rather than continuing invisibly in the background.
+- **Your font-size preference now applies everywhere** Parts of the interface were written with fixed text sizes, so they stayed the same no matter which font size you chose — enlarging the type to read them did nothing. Those places now scale with the rest of the app, and a check has been added so a fixed size cannot quietly reappear.
+- **The desktop app reconnects more reliably** When the background service the app depends on restarted or dropped its connection, the app could be left showing a stale state. Restarts, disconnections and leftover processes from a previous run are now detected and reported, so the app recovers on its own instead of needing to be quit and reopened.
+</Update>
+
 <Update label="v1.7.8" description="August 22, 2026">
 ### The app no longer goes blank when a setting is missing
 

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reliant",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reliant",
-      "version": "1.7.8",
+      "version": "1.7.9",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@sentry/electron": "^7.10.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reliant",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "description": "AI-powered coding assistant with intelligent agents for professional software development",
   "author": "Reliant Labs <support@reliantlabs.io>",
   "homepage": "https://reliantlabs.io",


### PR DESCRIPTION
Release commit for v1.7.9 — bumps `electron/package.json` + lockfile and regenerates the Mintlify changelog page from `docs/data/releases/v1.7.9.yaml`.

The `v1.7.9` tag is already pushed and the Release Electron App / Docker workflows are building.