### PR TITLE
ci(release): unthrottle the backend matrix, saving ~7m per release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,7 +307,7 @@ jobs:
           EOF
 
   # ============================================================================
-  # BACKEND BINARIES: Matrix build (industry-standard fan-out)
+  # BACKEND BINARIES: Matrix build (full-width fan-out)
   # ============================================================================
   build-backend:
     name: Build backend (${{ matrix.target_os }}-${{ matrix.target_arch }})
@@ -315,8 +315,30 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
+      # fail-fast: false so ONE broken target reports its own failure instead of
+      # cancelling the other five — you want all six results from a release run.
       fail-fast: false
-      max-parallel: 2
+      #
+      # DELIBERATELY UNTHROTTLED — do not re-add `max-parallel`.
+      #
+      # These are six independent `go build` invocations that share nothing: no
+      # registry, no signing service, no notarization, no rate-limited third
+      # party. Every step in this job is a GitHub-native action
+      # (checkout / setup-go / download-artifact / upload-artifact), so there is
+      # no external quota for a throttle to protect.
+      #
+      # Nor is there a runner quota to protect. This org is on the GitHub Free
+      # plan: 20 concurrent jobs, of which 5 may be macOS. Six ubuntu-latest
+      # legs sit well inside that, and the `concurrency: releases` group at the
+      # top of this file already serializes whole release runs, so two of these
+      # matrices can never overlap.
+      #
+      # The previous `max-parallel: 2` cost ~7 minutes of pure waiting on every
+      # release. Each leg takes ~3 minutes, but the throttle stair-stepped them
+      # into ~10 (measured on the v1.7.11 run: linux pair 04:40:50-04:44:00,
+      # then darwin 04:43:59, then windows 04:46:53, with the last leg not
+      # finishing until 04:50:09). The three packaging jobs below are gated on
+      # the whole matrix, so they inherit every second of that delay.
       matrix:
         include:
           - target_os: linux


### PR DESCRIPTION
The `build-backend` matrix carried `max-parallel: 2`, under a comment describing it as an "industry-standard fan-out" — phrasing that reads as incidental rather than a deliberate quota decision. It was costing real time on every release.

Each of the six legs is a ~3 minute `go build`, but the throttle stair-stepped them across ~10 minutes. Measured on the v1.7.11 run ([33470420599](https://github.com/reliant-labs/reliant/actions/runs/33470420599)):

```
04:40:50 -> 04:44:00  linux-arm64
04:40:51 -> 04:43:57  linux-amd64
04:43:59 -> 04:47:10  darwin-amd64    <- waited on the throttle
04:44:02 -> 04:46:51  darwin-arm64    <- waited
04:46:53 -> 04:49:38  windows-amd64   <- waited
04:47:12 -> 04:50:09  windows-arm64   <- waited
04:50:11 -> 04:55:28  Build Linux
04:50:11 -> 04:56:26  Build Windows
04:50:12 -> 05:01:55  Build macOS
05:01:57 -> 05:03:49  Finalize Release
```

The three packaging jobs are gated on the whole matrix, so they inherited every second of the delay. Unthrottled, all six should finish in ~3 minutes.

## I checked for a real constraint first — there is none

- **No runner quota.** `reliant-labs` is on the GitHub **Free** plan (`gh api /orgs/reliant-labs` → `plan.name: free`), which allows **20 concurrent jobs, 5 of them macOS**. Six `ubuntu-latest` legs sit well inside that. The repo also has no self-hosted runners to contend for — `gh api /repos/reliant-labs/reliant/actions/runners` returns `total_count: 0`. (I could not read the org-level runner list; that endpoint needs `admin:org`, which this token lacks. Given the repo-level count is zero and every job here uses `runs-on: ubuntu-latest`/`macos-latest`/`windows-latest`, GitHub-hosted quota is the binding limit either way.)
- **No rate-limited external dependency.** Every step in the job is a GitHub-native action — `checkout`, `setup-go`, `download-artifact`, `upload-artifact`. No registry, no signing service, no notarization, no third-party API. There is no external quota for a throttle to protect.
- **No overlap between runs.** The workflow-level `concurrency: releases` group with `cancel-in-progress: false` already serializes whole release runs, so two of these matrices can never be in flight at once.

## What changed

Removed `max-parallel` entirely rather than setting it to 6, so the matrix width stays the single source of truth — adding a seventh target later will not silently re-introduce a throttle.

`fail-fast: false` is **kept**, and now has a comment saying why: a release wants all six results, not a cancelled sweep after the first failure.

The reasoning above is recorded inline at the matrix so the throttle does not get re-added by someone reading the old "industry-standard" comment.

## Not touched

macOS packaging (~11m) is notarization-bound on Apple's service and is not compressible from here.

## Verification

Releases are paused, so this is not exercised end to end. The workflow parses and the matrix is structurally intact:

```
YAML PARSED OK
max-parallel present: false
fail-fast: false
matrix legs: 6
   linux amd64 backend-linux-amd64
   linux arm64 backend-linux-arm64
   darwin amd64 backend-darwin-amd64
   darwin arm64 backend-darwin-arm64
   windows amd64 backend-windows-amd64
   windows arm64 backend-windows-arm64
job count: 6 prepare,build-backend,release-macos,release-linux,release-windows,finalize
concurrency: {"group":"releases","cancel-in-progress":false}
```

One file, comments plus the single `max-parallel` deletion.