### PR TITLE
perf(ci): halve PR CI wall-clock; parallelize the slowest test packages

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -48,6 +48,65 @@ jobs:
       - name: Validate electron/release.config.json
         run: node .github/scripts/sync-release-config.mjs --check
 
+  # The generators moved OFF the critical path, and this job is what keeps
+  # that safe.
+  #
+  # .gitignore's "Generated code is committed" note makes the contract
+  # explicit: a checkout must build as-cloned, and regenerating must be a
+  # no-op. Every other job now relies on the committed output instead of
+  # spending ~140s re-deriving it, so something has to prove the two agree —
+  # otherwise stale generated code would ship silently, which is worse than a
+  # slow build.
+  #
+  # This runs in PARALLEL with the test jobs rather than in front of them, so
+  # it costs wall-clock only if it is the slowest job (it is not — measured
+  # ~14s of generate locally, against 190s of Go tests).
+  #
+  # It is a hard gate: if `make generate-go` produces a diff, the fix is to
+  # commit that diff in the change that caused it.
+  generate-drift:
+    name: Generated code is up to date
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Cache Go build cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-build-drift-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-build-drift-${{ runner.os }}-
+
+      - name: Install buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          version: '1.50.0'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          buf_api_token: ${{ secrets.BUF_API_KEY }}
+
+      - name: Generate Go code
+        run: make generate-go
+
+      - name: Fail if generated code differs from what is committed
+        run: |
+          set -euo pipefail
+          if ! git diff --quiet; then
+            echo "::error::Generated code is out of date. Run 'make generate-go' and commit the result."
+            git diff --stat
+            echo "--- full diff ---"
+            git diff
+            exit 1
+          fi
+          echo "Generated code matches the committed output."
+
   backend:
     name: Backend (Go)
     runs-on: ubuntu-latest
@@ -58,11 +117,32 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
+      # setup-go's `cache: true` caches the MODULE cache (~/go/pkg/mod) but
+      # NOT the build cache (~/.cache/go-build), so every run recompiled the
+      # whole dependency graph from source before a single test ran.
+      #
+      # Keyed on the resolved Go version + go.sum: a toolchain bump or a
+      # dependency change invalidates it, which is exactly when the cached
+      # objects stop being reusable. The restore-keys prefix means a go.sum
+      # change still restores the previous cache and recompiles only what
+      # actually changed, rather than starting cold.
+      - name: Cache Go build cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-build-backend-${{ runner.os }}-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-build-backend-${{ runner.os }}-${{ steps.setup-go.outputs.go-version }}-
+            go-build-backend-${{ runner.os }}-
+
+      # buf stays: `forge lint` wraps buf lint alongside golangci-lint, so
+      # dropping it here would quietly reduce what the lint step checks.
       - name: Install buf
         uses: bufbuild/buf-setup-action@v1
         with:
@@ -70,20 +150,32 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           buf_api_token: ${{ secrets.BUF_API_KEY }}
 
-      - name: Install goose
-        run: go install github.com/pressly/goose/v3/cmd/goose@latest
-
-      - name: Generate Go code
-        run: make generate-go
+      # Generated code is COMMITTED (see the "Generated code is committed"
+      # note in .gitignore): a checkout compiles and tests as-cloned, and
+      # regenerating is required to be a no-op. So this job does NOT need to
+      # run the generators to build or test — that was ~140s of the critical
+      # path producing, by contract, no change. Drift is caught by the
+      # dedicated `generate-drift` job below, which runs in PARALLEL rather
+      # than in front of the tests.
+      #
+      # goose was installed here for ~58s a job and never invoked: it is a
+      # LIBRARY dependency (github.com/pressly/goose/v3, imported by
+      # internal/db/connect.go, which embeds the migrations). Nothing in this
+      # repo shells out to the goose BINARY except check-migrations.yml, which
+      # installs it itself. Removed rather than cached.
 
       - name: Disable VCS stamping
         run: echo "GOFLAGS=-buildvcs=false" >> $GITHUB_ENV
 
+      # ripgrep is a genuine RUNTIME dependency of this job: internal/llm/tools
+      # shells out to `rg`, and requireRipgrep() SKIPS those tests when it is
+      # missing — so without it the job goes green having silently not run
+      # them. Installed from apt (prebuilt) rather than compiled from source.
+      #
+      # ubuntu-latest does not ship ripgrep, so the `command -v` guard this
+      # replaces never once took its fast path.
       - name: Install ripgrep
-        run: |
-          if ! command -v rg &> /dev/null; then
-            sudo apt-get update && sudo apt-get install -y ripgrep
-          fi
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
 
       # Lint via FORGE rather than a raw golangci-lint pin.
       #
@@ -108,16 +200,32 @@ jobs:
       # The findings are REPORTED on every PR so they stay visible and the
       # backlog shrinks. Flip this to a hard gate (drop continue-on-error) once
       # it reaches zero — that is a small, separate cleanup.
-      - name: Install forge
-        # Pin the CLI to the SAME version go.mod already requires, so the linter
-        # matches the library this code compiles against. @latest silently
-        # switched forge mid-release; a hardcoded version is a second place to
-        # remember to bump. go.mod is the single source of truth.
+      # Resolve the forge version BEFORE the cache step, so the cache key can
+      # be keyed on it. go.mod stays the single source of truth — @latest
+      # silently switched forge mid-release once, and a hardcoded version is a
+      # second place to remember to bump.
+      - name: Resolve forge version
+        id: forge-version
         run: |
           set -euo pipefail
           FORGE_VERSION="$(go list -m -f '{{.Version}}' github.com/reliant-labs/forge)"
-          echo "installing forge $FORGE_VERSION"
-          go install "github.com/reliant-labs/forge/cmd/forge@$FORGE_VERSION"
+          echo "version=$FORGE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "forge $FORGE_VERSION"
+
+      # Cache the BUILT binary keyed on the exact version, so the ~52s
+      # `go install` from source happens once per forge bump instead of once
+      # per run. No restore-keys: a stale binary from a different version is
+      # not a partial hit, it is the wrong linter.
+      - name: Cache forge binary
+        id: forge-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/go/bin/forge
+          key: forge-${{ runner.os }}-${{ steps.forge-version.outputs.version }}
+
+      - name: Install forge
+        if: steps.forge-cache.outputs.cache-hit != 'true'
+        run: go install "github.com/reliant-labs/forge/cmd/forge@${{ steps.forge-version.outputs.version }}"
 
       - name: Lint (forge)
         continue-on-error: true
@@ -136,32 +244,35 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
-      - name: Install buf
-        uses: bufbuild/buf-setup-action@v1
+      # See the backend job for why this is needed on top of setup-go's
+      # module cache. Separate key prefix because this job compiles a
+      # different package set (-tags=e2e), so sharing one cache entry would
+      # have the two jobs evicting each other's objects.
+      - name: Cache Go build cache
+        uses: actions/cache@v4
         with:
-          version: '1.50.0'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          buf_api_token: ${{ secrets.BUF_API_KEY }}
+          path: ~/.cache/go-build
+          key: go-build-e2e-${{ runner.os }}-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-build-e2e-${{ runner.os }}-${{ steps.setup-go.outputs.go-version }}-
+            go-build-e2e-${{ runner.os }}-
 
-      - name: Install goose
-        run: go install github.com/pressly/goose/v3/cmd/goose@latest
+      # buf is not needed here: nothing in this job generates code, and the
+      # e2e tests run against the committed generated output.
 
-      - name: Generate Go code
-        run: make generate-go
+      # Same reasoning as the backend job: generated code is committed, so the
+      # generators are not a build input here, and the goose BINARY is never
+      # invoked (goose is a library dependency). Both steps removed; drift is
+      # covered by the parallel `generate-drift` job.
 
       - name: Disable VCS stamping
         run: echo "GOFLAGS=-buildvcs=false" >> $GITHUB_ENV
-
-      - name: Install ripgrep
-        run: |
-          if ! command -v rg &> /dev/null; then
-            sudo apt-get update && sudo apt-get install -y ripgrep
-          fi
 
       - name: Go E2E tests
         # -tags=e2e is REQUIRED: every file under ./e2e/stories carries
@@ -177,11 +288,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
+      # No Go toolchain and no buf here: with the generators gone (see below)
+      # this job is pure Node — npm lint / typecheck / vitest / vite build.
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -190,25 +298,25 @@ jobs:
           cache: npm
           cache-dependency-path: web/package-lock.json
 
-      - name: Install buf
-        uses: bufbuild/buf-setup-action@v1
-        with:
-          version: '1.50.0'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          buf_api_token: ${{ secrets.BUF_API_KEY }}
-
       - name: Install deps
         working-directory: web
         run: npm ci || npm install
 
-      - name: Generate protobufs (TypeScript)
-        run: buf generate --template buf.gen.yaml
-
-      - name: Install goose
-        run: go install github.com/pressly/goose/v3/cmd/goose@latest
-
-      - name: Generate docs and shortcuts
-        run: make generate
+      # The generated TypeScript (web/src/gen/**, 38 files) and
+      # web/src/store/shortcutsData.generated.ts are COMMITTED, so this job
+      # lints, typechecks, tests and builds straight from the checkout.
+      # Verified locally: `npm run typecheck` and `npm run build:alpha` both
+      # succeed on a clean `git archive` of HEAD with no generator run.
+      #
+      # Removed from this job:
+      #   - `buf generate` (TS protobufs) — output is committed
+      #   - `go install goose` (~58s) — goose's BINARY is never invoked
+      #     anywhere in this repo; it is a library dep of internal/db
+      #   - `make generate` (~140s) — builds 14 Go-side docgen targets
+      #     (CLI/tools/models/Mintlify reference…) that web/ does not consume
+      #
+      # Drift in any of that committed output is caught by the `generate-drift`
+      # job, which runs in parallel.
 
       - name: Lint
         working-directory: web
@@ -274,11 +382,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
+      # Pure Node job now — no Go toolchain, no buf (see the note below).
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -287,38 +391,16 @@ jobs:
           cache: npm
           cache-dependency-path: web/package-lock.json
 
-      - name: Install buf
-        uses: bufbuild/buf-setup-action@v1
-        with:
-          version: '1.50.0'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          buf_api_token: ${{ secrets.BUF_API_KEY }}
-
       - name: Install deps
         working-directory: web
         run: npm ci || npm install
 
-      - name: Generate protobufs (TypeScript)
-        run: buf generate --template buf.gen.yaml
-
-      - name: Install goose
-        # Pinned to match the version in go.mod. This step was an unpinned
-        # `@latest` install; every one of this job's non-timeout failures in
-        # the last 50 runs (8/50) died here in <3s on a transient resolution
-        # flake, not because the version drifted. Pinning removes the flake
-        # source; it doesn't change behavior otherwise.
-        run: go install github.com/pressly/goose/v3/cmd/goose@v3.25.0
-
-      - name: Generate shortcuts
-        # Only `make generate-shortcuts` output is a build input for web/ —
-        # web/src/store/shortcutsData.generated.ts, imported by
-        # shortcutsStore.ts (confirmed: deleting it breaks `vite build` with
-        # "Could not resolve ./shortcutsData.generated"). The full `make
-        # generate` also builds 14 unrelated Go-side doc/reference targets
-        # (CLI reference, tools reference, Mintlify pages, etc.) that this
-        # job doesn't consume; that cost ~2.5-3 minutes of this job's budget
-        # for no effect on the build or the tests.
-        run: make generate-shortcuts
+      # web/src/store/shortcutsData.generated.ts — the one generated file this
+      # job's build genuinely needs (shortcutsStore.ts imports it; deleting it
+      # breaks `vite build`) — is COMMITTED, as is the generated TypeScript
+      # under web/src/gen/. So `make generate-shortcuts`, `buf generate` and
+      # the goose install that supported them are all gone from this job;
+      # `generate-drift` verifies the committed copies are current.
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4
@@ -373,11 +455,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
+      # No Go toolchain and no buf here. `npm run dist:pr` runs
+      # build:config -> build:web:alpha -> electron-builder --dir; none of that
+      # compiles Go. The backend binaries live in electron/resources/server,
+      # which is UNTRACKED — CI has never populated it, so this job has always
+      # packaged an empty server dir, and removing Go does not change what it
+      # produces. (build:backend exists but is not on the dist:pr path.)
+      #
+      # Also removed: `buf generate` (committed TS output) and `make generate`
+      # (~140s of Go docgen this job does not consume), plus the goose install
+      # (~58s) whose binary is never invoked.
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -388,25 +475,9 @@ jobs:
             web/package-lock.json
             electron/package-lock.json
 
-      - name: Install buf
-        uses: bufbuild/buf-setup-action@v1
-        with:
-          version: '1.50.0'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          buf_api_token: ${{ secrets.BUF_API_KEY }}
-
       - name: Install web deps
         working-directory: web
         run: npm ci || npm install
-
-      - name: Generate protobufs (TypeScript)
-        run: buf generate --template buf.gen.yaml
-
-      - name: Install goose
-        run: go install github.com/pressly/goose/v3/cmd/goose@latest
-
-      - name: Generate docs and shortcuts
-        run: make generate
 
       - name: Install electron deps
         working-directory: electron

--- a/generated/docs-source/reference/nodes.md
+++ b/generated/docs-source/reference/nodes.md
@@ -131,6 +131,7 @@ Send a prompt to a language model and get a response
 | `compaction_threshold` | integer | - |
 | `model` | string | - |
 | `pending_inbox` | boolean | - |
+| `aborted` | boolean | - |
 | `message_id` | string | - |
 | `last_stream_seq` | integer | - |
 

--- a/internal/db/postgres/generated/querier.go
+++ b/internal/db/postgres/generated/querier.go
@@ -451,6 +451,12 @@ type Querier interface {
 	// List root workflows (parent_id IS NULL) at a specific lifecycle.
 	// Root workflows are the entry points that need dedicated workers.
 	ListRootWorkflowsByStatus(ctx context.Context, arg ListRootWorkflowsByStatusParams) ([]Workflow, error)
+	// ORDER BY key, updated_at: key alone is not a total order, so any duplicate
+	// rows came back in an arbitrary sequence and the client — which loads rows
+	// into localStorage one after another — could end up keeping a stale value.
+	// The upsert above plus the partial unique index mean duplicates should no
+	// longer exist; ordering by updated_at as well guarantees that if any survive,
+	// the NEWEST wins rather than whichever the planner happened to emit last.
 	ListSettings(ctx context.Context, arg ListSettingsParams) ([]Setting, error)
 	ListSettingsByKey(ctx context.Context, arg ListSettingsByKeyParams) ([]Setting, error)
 	// Every spawn call a thread has issued, joined to the child's live workflow

--- a/internal/db/postgres/generated/settings.sql.go
+++ b/internal/db/postgres/generated/settings.sql.go
@@ -159,7 +159,7 @@ const listSettings = `-- name: ListSettings :many
 SELECT id, user_id, project_id, key, value, value_type, created_at, updated_at FROM settings
 WHERE user_id = $1
     AND project_id IS NOT DISTINCT FROM $2
-ORDER BY key
+ORDER BY key, updated_at
 `
 
 type ListSettingsParams struct {
@@ -167,6 +167,12 @@ type ListSettingsParams struct {
 	ProjectID sql.NullString `json:"project_id"`
 }
 
+// ORDER BY key, updated_at: key alone is not a total order, so any duplicate
+// rows came back in an arbitrary sequence and the client — which loads rows
+// into localStorage one after another — could end up keeping a stale value.
+// The upsert above plus the partial unique index mean duplicates should no
+// longer exist; ordering by updated_at as well guarantees that if any survive,
+// the NEWEST wins rather than whichever the planner happened to emit last.
 func (q *Queries) ListSettings(ctx context.Context, arg ListSettingsParams) ([]Setting, error) {
 	rows, err := q.db.QueryContext(ctx, listSettings, arg.UserID, arg.ProjectID)
 	if err != nil {

--- a/internal/llm/tools/anthropic_api_validation_test.go
+++ b/internal/llm/tools/anthropic_api_validation_test.go
@@ -12,6 +12,7 @@ import (
 // This test ensures we don't regress on the fix for:
 // "tools.41.custom.input_schema: Invalid $ref in schema: '#/$defs/LinterConfig' does not exist"
 func TestAnthropicAPISchemaCompliance(t *testing.T) {
+	t.Parallel()
 	factory := NewToolsFactory(&ToolsOptions{})
 	registry := GetToolRegistry()
 
@@ -74,6 +75,7 @@ func TestAnthropicAPISchemaCompliance(t *testing.T) {
 // TestLinterConfigSchemaResolution specifically tests that LinterConfig references
 // are properly resolved, as this was the original issue reported.
 func TestLinterConfigSchemaResolution(t *testing.T) {
+	t.Parallel()
 	factory := NewToolsFactory(&ToolsOptions{})
 	tool := factory.MetadataWriter()
 
@@ -139,6 +141,7 @@ func searchForRef(data interface{}, targetRef string) bool {
 
 // TestResolveSchemaRefsWithNestedArrays tests the fix for nested array item references
 func TestResolveSchemaRefsWithNestedArrays(t *testing.T) {
+	t.Parallel()
 	// This simulates the exact structure that was failing:
 	// An array with items that reference a definition
 	testSchema := map[string]interface{}{

--- a/internal/llm/tools/bash_output_test.go
+++ b/internal/llm/tools/bash_output_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestValidateParams(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		params  BashOutputParams

--- a/internal/llm/tools/bash_wait_registration_test.go
+++ b/internal/llm/tools/bash_wait_registration_test.go
@@ -8,6 +8,7 @@ import "testing"
 // the shell family is deliberately kept whole: an agent that can start a
 // background process must be able to wait for it.
 func TestBashWait_IsOfferedWithTheShellFamily(t *testing.T) {
+	t.Parallel()
 	for _, filter := range []string{"tag:default", "tag:shell", "tag:plan", "tag:readonly"} {
 		names := ExpandToolFilter([]string{filter}, nil)
 		found := false

--- a/internal/llm/tools/bash_wait_test.go
+++ b/internal/llm/tools/bash_wait_test.go
@@ -99,6 +99,7 @@ func runWait(t *testing.T, d daemon.Client, params BashWaitParams) (ToolResponse
 // A process that has already finished must return immediately with its exit
 // code — the whole point is that waiting costs no model round-trips.
 func TestBashWait_ReturnsExitCodeWhenProcessExits(t *testing.T) {
+	t.Parallel()
 	d := &scriptedDaemon{
 		steps:        []*daemon.ProcessInfo{running("p1"), running("p1"), exited("p1", 0)},
 		output:       "ok 42 tests passed",
@@ -129,6 +130,7 @@ func TestBashWait_ReturnsExitCodeWhenProcessExits(t *testing.T) {
 // A still-running process is NOT an error. Returning one would teach the model
 // that a slow build failed, which is the opposite of what happened.
 func TestBashWait_TimeoutIsNotAnError(t *testing.T) {
+	t.Parallel()
 	d := &scriptedDaemon{
 		steps:        []*daemon.ProcessInfo{running("p1")},
 		listErrAfter: -1,
@@ -161,6 +163,7 @@ func TestBashWait_TimeoutIsNotAnError(t *testing.T) {
 // A bad process id must fail fast. Blocking the full budget and then saying
 // "not found" wastes exactly the time this tool exists to save.
 func TestBashWait_UnknownProcessFailsFast(t *testing.T) {
+	t.Parallel()
 	d := &scriptedDaemon{steps: []*daemon.ProcessInfo{nil}, listErrAfter: -1}
 
 	start := time.Now()
@@ -186,6 +189,7 @@ func TestBashWait_UnknownProcessFailsFast(t *testing.T) {
 // to outlast it would be killed mid-flight and report a hard timeout — the very
 // failure `sleep 300` produced.
 func TestBashWait_ClampsTimeoutBelowToolCeiling(t *testing.T) {
+	t.Parallel()
 	d := &scriptedDaemon{steps: []*daemon.ProcessInfo{exited("p1", 0)}, listErrAfter: -1}
 
 	// Ask for an hour; the call must still return promptly.
@@ -213,6 +217,7 @@ func TestBashWait_ClampsTimeoutBelowToolCeiling(t *testing.T) {
 
 // A transient listing failure must not abandon a wait that may be nearly done.
 func TestBashWait_SurvivesTransientListingFailure(t *testing.T) {
+	t.Parallel()
 	d := &scriptedDaemon{
 		steps:        []*daemon.ProcessInfo{running("p1"), running("p1"), exited("p1", 3)},
 		output:       "FAILED",
@@ -232,6 +237,7 @@ func TestBashWait_SurvivesTransientListingFailure(t *testing.T) {
 // Cancelling the surrounding tool call must stop the loop rather than keep
 // polling a daemon for a result nobody is waiting on.
 func TestBashWait_StopsWhenToolCallCancelled(t *testing.T) {
+	t.Parallel()
 	d := &scriptedDaemon{steps: []*daemon.ProcessInfo{running("p1")}, listErrAfter: -1}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/llm/tools/code_context_test.go
+++ b/internal/llm/tools/code_context_test.go
@@ -98,12 +98,14 @@ func requireGopls(t *testing.T) {
 }
 
 func TestCodeContext_RequiresSymbol(t *testing.T) {
+	t.Parallel()
 	resp := runCodeContext(t, t.TempDir(), CodeContextParams{})
 	assert.True(t, resp.IsError)
 	assert.Contains(t, resp.Content, "symbol is required")
 }
 
 func TestCodeContext_FindsDefinition(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	requireGopls(t)
 	dir := codeContextFixture(t)
@@ -119,6 +121,7 @@ func TestCodeContext_FindsDefinition(t *testing.T) {
 // The behavior that justifies the tool: callers and callees arrive together,
 // in one call, without a per-hop turn.
 func TestCodeContext_ResolvesCallersAndCallees(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	requireGopls(t)
 	dir := codeContextFixture(t)
@@ -133,6 +136,7 @@ func TestCodeContext_ResolvesCallersAndCallees(t *testing.T) {
 }
 
 func TestCodeContext_ResolvesImplementations(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	requireGopls(t)
 	dir := codeContextFixture(t)
@@ -147,6 +151,7 @@ func TestCodeContext_ResolvesImplementations(t *testing.T) {
 }
 
 func TestCodeContext_UnknownSymbolExplainsItself(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	dir := codeContextFixture(t)
 
@@ -161,6 +166,7 @@ func TestCodeContext_UnknownSymbolExplainsItself(t *testing.T) {
 // An unsupported language must not silently present text matches as resolved
 // call edges.
 func TestCodeContext_TextEngineIsLabeled(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.rb"),
@@ -181,6 +187,7 @@ func TestCodeContext_TextEngineIsLabeled(t *testing.T) {
 // and nothing in the output let a reader tell that apart from a real answer.
 // An error the caller can act on beats a plausible wrong one.
 func TestCodeContext_MissingTypeScriptIsAnError(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"x"}`), 0o644))
@@ -202,6 +209,7 @@ func TestCodeContext_MissingTypeScriptIsAnError(t *testing.T) {
 // source subdirectory — sending an agent to install in src/ would create a
 // stray node_modules in the wrong place.
 func TestCodeContext_MissingTypeScriptNamesThePackageDir(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "web", "src", "lib"), 0o755))
@@ -321,6 +329,7 @@ func locateTypeScriptLib(t *testing.T) string {
 }
 
 func TestCodeContext_TypeScriptResolvesCallersAndCallees(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	dir := tsFixtureWithTypeScript(t)
 
@@ -334,6 +343,7 @@ func TestCodeContext_TypeScriptResolvesCallersAndCallees(t *testing.T) {
 }
 
 func TestCodeContext_TypeScriptResolvesImplementations(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	dir := tsFixtureWithTypeScript(t)
 
@@ -351,6 +361,7 @@ func TestCodeContext_TypeScriptResolvesImplementations(t *testing.T) {
 // tsserver yields the real signature; the declaration regex only sees the
 // source line it matched.
 func TestCodeContext_TypeScriptReportsSignature(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	dir := tsFixtureWithTypeScript(t)
 
@@ -364,6 +375,7 @@ func TestCodeContext_TypeScriptReportsSignature(t *testing.T) {
 // A file in src/ must be resolved by the TypeScript install at the project
 // root — the monorepo case, where each frontend carries its own copy.
 func TestCodeContext_FindsTypeScriptByWalkingUp(t *testing.T) {
+	t.Parallel()
 	dir := tsFixtureWithTypeScript(t)
 
 	found := findTSServer(dir, filepath.Join(dir, "src", "target.ts"))
@@ -373,6 +385,7 @@ func TestCodeContext_FindsTypeScriptByWalkingUp(t *testing.T) {
 }
 
 func TestCodeContext_SelectsEngineByExtension(t *testing.T) {
+	t.Parallel()
 	// A language with no server available anywhere degrades rather than
 	// erroring: unlike a missing npm install there is nothing to install, so
 	// an approximate answer is genuinely the best result on offer.
@@ -383,6 +396,7 @@ func TestCodeContext_SelectsEngineByExtension(t *testing.T) {
 }
 
 func TestCodeContext_PrefersNonTestDeclaration(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	requireGopls(t)
 	dir := codeContextFixture(t)
@@ -403,6 +417,7 @@ func TestCodeContext_PrefersNonTestDeclaration(t *testing.T) {
 // by entryPoint, which only appears if traversal re-queries from the caller's
 // DECLARATION rather than from the call site.
 func TestCodeContext_CallMapReachesSecondLevel(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	requireGopls(t)
 	dir := codeContextFixture(t)
@@ -422,6 +437,7 @@ func TestCodeContext_CallMapReachesSecondLevel(t *testing.T) {
 // keep the call site for display AND the enclosing declaration for traversal.
 // Losing the second silently flattens every tree to one level.
 func TestCodeContext_CallerKeepsDeclarationPosition(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	requireGopls(t)
 	dir := codeContextFixture(t)
@@ -448,6 +464,7 @@ func mustDeclare(t *testing.T, dir, symbol string) codeLocation {
 
 // depth is defaulted, not required: the common call is code_context(symbol).
 func TestCodeContext_DefaultsToMultiLevelTrace(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	requireGopls(t)
 	dir := codeContextFixture(t)
@@ -462,6 +479,7 @@ func TestCodeContext_DefaultsToMultiLevelTrace(t *testing.T) {
 // Source is included by default because the measured follow-up to a digest is a
 // view call — a whole turn — while the extra input tokens are nearly free.
 func TestCodeContext_IncludesSourceByDefault(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	requireGopls(t)
 	dir := codeContextFixture(t)
@@ -474,6 +492,7 @@ func TestCodeContext_IncludesSourceByDefault(t *testing.T) {
 }
 
 func TestCodeContext_SourceCanBeDisabled(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	requireGopls(t)
 	dir := codeContextFixture(t)
@@ -488,6 +507,7 @@ func TestCodeContext_SourceCanBeDisabled(t *testing.T) {
 }
 
 func TestCodeContext_SourcePreviewIsCapped(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	var body strings.Builder
 	body.WriteString("package big\n\nfunc Long() {\n")
@@ -508,6 +528,7 @@ func TestCodeContext_SourcePreviewIsCapped(t *testing.T) {
 
 // A brace inside a string must not end the preview early.
 func TestCodeContext_SourcePreviewIgnoresBracesInStrings(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "s.go")
 	require.NoError(t, os.WriteFile(path, []byte(
@@ -523,6 +544,7 @@ func TestCodeContext_SourcePreviewIgnoresBracesInStrings(t *testing.T) {
 // The node budget is what keeps a deep trace from costing more tokens than the
 // turns it saves.
 func TestCodeContext_CallMapIsBounded(t *testing.T) {
+	t.Parallel()
 	wide := make([]codeLocation, 40)
 	for i := range wide {
 		wide[i] = codeLocation{Path: "a.go", Line: i + 1, Enclosing: fmt.Sprintf("fn%d", i)}
@@ -540,6 +562,7 @@ func TestCodeContext_CallMapIsBounded(t *testing.T) {
 
 // A cycle must terminate and be labeled rather than expanded forever.
 func TestCodeContext_CallMapHandlesCycles(t *testing.T) {
+	t.Parallel()
 	a := codeLocation{Path: "a.go", Line: 10, Enclosing: "A"}
 	b := codeLocation{Path: "b.go", Line: 20, Enclosing: "B"}
 	engine := cycleEngine{a: a, b: b}
@@ -599,6 +622,7 @@ func (c cycleEngine) ResolveEdges(_ context.Context, _ string, decl codeLocation
 // workspace root are the user's code — scoping to the module instead would
 // break the cross-repo tracing this tool is most useful for.
 func TestCodeContext_ScopeKeepsWorkspaceExcludesDependencies(t *testing.T) {
+	t.Parallel()
 	root := filepath.Join("/ws")
 	for _, tc := range []struct {
 		path string
@@ -619,6 +643,7 @@ func TestCodeContext_ScopeKeepsWorkspaceExcludesDependencies(t *testing.T) {
 }
 
 func TestCodeContext_ScopeAllIncludesEverything(t *testing.T) {
+	t.Parallel()
 	assert.True(t, inScope("/ws", "/usr/local/go/src/fmt/errors.go", scopeAll))
 	assert.True(t, inScope("/ws", "/ws/web/node_modules/react/index.js", scopeAll))
 }
@@ -626,6 +651,7 @@ func TestCodeContext_ScopeAllIncludesEverything(t *testing.T) {
 // Filtering must be visible: silently dropping edges is indistinguishable from
 // a symbol that genuinely has none.
 func TestCodeContext_OmittedDependencyEdgesAreReported(t *testing.T) {
+	t.Parallel()
 	locs := []codeLocation{
 		{Path: "/ws/internal/a.go", Line: 1},
 		{Path: "/usr/local/go/src/fmt/errors.go", Line: 23},
@@ -646,6 +672,7 @@ func TestCodeContext_OmittedDependencyEdgesAreReported(t *testing.T) {
 // The node budget is the scarce resource in a deep trace, so an out-of-scope
 // edge must never consume a slot — otherwise stdlib crowds out the user's code.
 func TestCodeContext_CallMapDoesNotSpendBudgetOnDependencies(t *testing.T) {
+	t.Parallel()
 	engine := stubEngine{edges: []codeLocation{
 		{Path: "/ws/internal/real.go", Line: 1, Enclosing: "Real"},
 		{Path: "/usr/local/go/src/fmt/errors.go", Line: 23, Enclosing: "Errorf"},
@@ -667,6 +694,7 @@ func TestCodeContext_CallMapDoesNotSpendBudgetOnDependencies(t *testing.T) {
 // The text engine must refuse to build a map: text matches cannot distinguish a
 // call from a mention, and a tree of mentions would be confidently wrong.
 func TestCodeContext_TextEngineBuildsNoCallMap(t *testing.T) {
+	t.Parallel()
 	edges := textEngine{}.ResolveEdges(context.Background(), ".", codeLocation{}, "callers")
 	assert.Empty(t, edges)
 }
@@ -676,6 +704,7 @@ func TestCodeContext_TextEngineBuildsNoCallMap(t *testing.T) {
 // implementation. Picking the interface yields an empty call map, which reads
 // as "nothing calls this" on a symbol with many callers.
 func TestCodeContext_PrefersDeclarationThatResolves(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	requireGopls(t)
 	dir := codeContextFixture(t)
@@ -693,6 +722,7 @@ func TestCodeContext_PrefersDeclarationThatResolves(t *testing.T) {
 // Answering about one of many same-named declarations without saying so is how
 // a reader ends up confidently reading about the wrong type.
 func TestCodeContext_ReportsAmbiguousDeclarations(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	requireGopls(t)
 	dir := codeContextFixture(t)
@@ -710,6 +740,7 @@ func TestCodeContext_ReportsAmbiguousDeclarations(t *testing.T) {
 
 // The description must not promise resolution for languages that cannot get it.
 func TestCodeContext_DescriptionNamesSupportedLanguages(t *testing.T) {
+	t.Parallel()
 	desc := NewCodeContextTool().Description()
 	assert.Contains(t, desc, "GO AND TYPESCRIPT/JAVASCRIPT ONLY")
 	assert.Contains(t, desc, "rg", "unsupported languages must be pointed at the alternative")
@@ -721,6 +752,7 @@ func TestCodeContext_DescriptionNamesSupportedLanguages(t *testing.T) {
 // ever use of this tool, and it returned a worse answer than the grep it
 // replaced.
 func TestCodeContext_PrefersSourceOverProse(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	requireGopls(t)
 	dir := codeContextFixture(t)
@@ -742,6 +774,7 @@ func TestCodeContext_PrefersSourceOverProse(t *testing.T) {
 // drift, a file the engine can resolve gets ranked as unresolvable (or worse,
 // the reverse) and queries degrade for no visible reason.
 func TestCodeContext_RankingMatchesEngines(t *testing.T) {
+	t.Parallel()
 	for ext := range resolvableSourceExtensions {
 		engine, _, err := selectEngine(t.TempDir(), "/x/y/thing"+ext)
 		// Either the engine resolves, or the toolchain is missing and that is
@@ -767,6 +800,7 @@ func TestCodeContext_RankingMatchesEngines(t *testing.T) {
 // The narrowest request must not be the worst answer: asking where a symbol is
 // defined should still say who calls it, or the caller spends another turn.
 func TestCodeContext_DefinitionStillIncludesGraph(t *testing.T) {
+	t.Parallel()
 	requireRipgrep(t)
 	requireGopls(t)
 	dir := codeContextFixture(t)
@@ -779,6 +813,7 @@ func TestCodeContext_DefinitionStillIncludesGraph(t *testing.T) {
 }
 
 func TestCodeContext_SectionsAreBounded(t *testing.T) {
+	t.Parallel()
 	locs := make([]codeLocation, 60)
 	for i := range locs {
 		locs[i] = codeLocation{Path: "a.go", Line: i + 1}
@@ -793,6 +828,7 @@ func TestCodeContext_SectionsAreBounded(t *testing.T) {
 }
 
 func TestCodeContext_RegisteredAsDefaultReadOnlyTool(t *testing.T) {
+	t.Parallel()
 	assert.Contains(t, names.AllToolNames, names.ToolCodeContext)
 
 	var found *ToolDefinition
@@ -812,6 +848,7 @@ func TestCodeContext_RegisteredAsDefaultReadOnlyTool(t *testing.T) {
 // The tool only pays off if agents have it without discovering it first. A tag
 // alone does not prove that — `tag:default` must actually EXPAND to include it.
 func TestCodeContext_IncludedInDefaultToolset(t *testing.T) {
+	t.Parallel()
 	expanded := ExpandToolFilter([]string{"tag:default"}, nil)
 	assert.Contains(t, expanded, ToolCodeContext,
 		"code_context must arrive without load_tool; got: %v", expanded)
@@ -821,6 +858,7 @@ func TestCodeContext_IncludedInDefaultToolset(t *testing.T) {
 // reaches. Those are exactly the agents that spend turns on grep walks, so the
 // tool has to be named in each one.
 func TestCodeContext_ReachesCodeNavigationPresets(t *testing.T) {
+	t.Parallel()
 	for _, preset := range []string{
 		"researcher", "planner", "debug", "code_reviewer", "refactor", "tester",
 		"general", "implementer",
@@ -870,6 +908,7 @@ func presetToolFilter(t *testing.T, preset string) []string {
 }
 
 func TestCodeContext_NeedsNoPermission(t *testing.T) {
+	t.Parallel()
 	// Requiring approval would push agents back to bash — the tool being replaced.
 	ok, err := (&codeContextTool{}).RequiresPermission(CodeContextParams{Symbol: "X"})
 	require.NoError(t, err)

--- a/internal/llm/tools/component_library_test.go
+++ b/internal/llm/tools/component_library_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestComponentLibraryRegistry(t *testing.T) {
+	t.Parallel()
 	lib := components.NewLibrary()
 	reg := lib.Registry()
 
@@ -51,6 +52,7 @@ func TestComponentLibraryRegistry(t *testing.T) {
 }
 
 func TestComponentLibraryCategories(t *testing.T) {
+	t.Parallel()
 	lib := components.NewLibrary()
 	counts := make(map[components.Category]int)
 	for _, entry := range lib.Registry() {
@@ -73,6 +75,7 @@ func TestComponentLibraryCategories(t *testing.T) {
 }
 
 func TestComponentLibraryGet(t *testing.T) {
+	t.Parallel()
 	tool := &componentLibraryTool{}
 
 	// Get existing component
@@ -101,6 +104,7 @@ func TestComponentLibraryGet(t *testing.T) {
 }
 
 func TestComponentLibrarySearch(t *testing.T) {
+	t.Parallel()
 	tool := &componentLibraryTool{}
 
 	// Search by tag keyword
@@ -159,6 +163,7 @@ func TestComponentLibrarySearch(t *testing.T) {
 }
 
 func TestComponentLibraryList(t *testing.T) {
+	t.Parallel()
 	tool := &componentLibraryTool{}
 	lib := components.NewLibrary()
 
@@ -193,6 +198,7 @@ func TestComponentLibraryList(t *testing.T) {
 }
 
 func TestComponentLibraryInstall(t *testing.T) {
+	t.Parallel()
 	tool := &componentLibraryTool{}
 
 	t.Run("install writes file to disk", func(t *testing.T) {
@@ -287,6 +293,7 @@ func TestComponentLibraryInstall(t *testing.T) {
 }
 
 func TestComponentLibraryRequiresPermission(t *testing.T) {
+	t.Parallel()
 	tool := &componentLibraryTool{}
 
 	// Read-only actions don't require permission
@@ -311,6 +318,7 @@ func TestComponentLibraryRequiresPermission(t *testing.T) {
 }
 
 func TestComponentLibraryToolInterface(t *testing.T) {
+	t.Parallel()
 	tool := NewComponentLibraryTool()
 	if tool.Name() != "component_library" {
 		t.Errorf("tool name = %q, want %q", tool.Name(), "component_library")

--- a/internal/llm/tools/edit_concurrent_test.go
+++ b/internal/llm/tools/edit_concurrent_test.go
@@ -103,6 +103,7 @@ func lostEdits(t *testing.T, path string, results []string) []int {
 // ambiguous — no two edits touch the same text — so there is no correct
 // outcome other than "all N applied".
 func TestEditConcurrentSameFileNoLostWrites(t *testing.T) {
+	t.Parallel()
 	for _, n := range []int{2, 3, 4, 8} {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
 			path, run := concurrentEditFixture(t, n)
@@ -122,6 +123,7 @@ func TestEditConcurrentSameFileNoLostWrites(t *testing.T) {
 // trials. A race that shows up once in ten runs is still a race; this is the
 // measurement that answers "at what N does it start losing writes".
 func TestEditConcurrentSameFileRepeated(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("race measurement; skipped under -short")
 	}
@@ -175,6 +177,7 @@ func (d *interposingDaemon) ReadFile(ctx context.Context, path string, opts *dae
 // stale under it must fail loudly. Reporting "Content replaced in file" while
 // having erased somebody else's write is the failure mode that costs data.
 func TestEditExternalWriteBetweenReadAndWriteErrors(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "contended.txt")
 	require.NoError(t, os.WriteFile(path, []byte("alpha\nbeta\ngamma\n"), 0o644))
@@ -220,6 +223,7 @@ func TestEditExternalWriteBetweenReadAndWriteErrors(t *testing.T) {
 // uncontended single edit — by far the common case — must behave exactly as
 // before, success text and file contents included.
 func TestEditSingleEditUnchanged(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "single.go")
 	require.NoError(t, os.WriteFile(path, []byte("package main\n\nfunc main() {}\n"), 0o644))
@@ -242,6 +246,7 @@ func TestEditSingleEditUnchanged(t *testing.T) {
 // read-modify-write shape through the same daemon client, so it inherits the
 // same defect. Two inserts in one batch, both to one file, both must land.
 func TestInsertAtConcurrentSameFileNoLostWrites(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "insert.txt")
 	require.NoError(t, os.WriteFile(path, []byte("aaa\nbbb\nccc\nddd\n"), 0o644))
@@ -284,6 +289,7 @@ func TestInsertAtConcurrentSameFileNoLostWrites(t *testing.T) {
 
 // TestEditLinesConcurrentSameFileNoLostWrites — same shape for edit_lines.
 func TestEditLinesConcurrentSameFileNoLostWrites(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "lines.txt")
 	require.NoError(t, os.WriteFile(path, []byte("l1\nl2\nl3\nl4\nl5\nl6\n"), 0o644))

--- a/internal/llm/tools/edit_eof_test.go
+++ b/internal/llm/tools/edit_eof_test.go
@@ -137,6 +137,7 @@ func TestEditReplaceLastDeclaration(t *testing.T) {
 // Split/Join over the same corrupted content, so it dropped the final newline
 // too. It must also not let an insert land past the real last line.
 func TestInsertAtPreservesTrailingNewline(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "f.txt")
 	require.NoError(t, os.WriteFile(path, []byte("alpha\nbravo\ncharlie\n"), 0o644))
@@ -165,6 +166,7 @@ func TestInsertAtPreservesTrailingNewline(t *testing.T) {
 // strings.Split on exact content would append an empty final element and print
 // a bogus numbered blank line at the bottom of every file.
 func TestViewNoPhantomTrailingLine(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "f.txt")
 	require.NoError(t, os.WriteFile(path, []byte("alpha\nbravo\n"), 0o644))
@@ -184,6 +186,7 @@ func TestViewNoPhantomTrailingLine(t *testing.T) {
 // the formatter, which must strip it for display (addLineNumbers already does)
 // without that stripping leaking back into anything that gets written.
 func TestViewCRLFRendersClean(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "f.txt")
 	require.NoError(t, os.WriteFile(path, []byte("alpha\r\nbravo\r\n"), 0o644))
@@ -202,6 +205,7 @@ func TestViewCRLFRendersClean(t *testing.T) {
 // TestEditLinesPreservesTrailingNewline: edit_lines reported an extra phantom
 // line and, on the corrupted content, dropped the final newline on write.
 func TestEditLinesPreservesTrailingNewline(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "f.txt")
 	require.NoError(t, os.WriteFile(path, []byte("alpha\nbravo\ncharlie\n"), 0o644))

--- a/internal/llm/tools/edit_test.go
+++ b/internal/llm/tools/edit_test.go
@@ -24,6 +24,7 @@ func newTestToolContext(t *testing.T, tempDir, chatID, thread string) *rctx.Tool
 }
 
 func TestEditToolFileModifiedCheck(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	testFile := filepath.Join(tempDir, "test.txt")
 
@@ -146,6 +147,7 @@ func TestEditToolFileModifiedCheck(t *testing.T) {
 // happy-path replacement, replace_all, non-unique old_string, not-found, and
 // file creation — all with top-level params (no edits array).
 func TestEditToolFlatSchema(t *testing.T) {
+	t.Parallel()
 	tool := &editTool{}
 	chatID := "test-chat"
 	thread := "0"
@@ -279,6 +281,7 @@ func TestEditToolFlatSchema(t *testing.T) {
 }
 
 func TestEditToolThreadIsolation(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	testFile := filepath.Join(tempDir, "thread_test.txt")
 
@@ -347,6 +350,7 @@ func TestEditToolThreadIsolation(t *testing.T) {
 }
 
 func TestEditToolDeleteContentModifiedCheck(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	testFile := filepath.Join(tempDir, "delete_test.txt")
 
@@ -397,6 +401,7 @@ func TestEditToolDeleteContentModifiedCheck(t *testing.T) {
 }
 
 func TestEditToolValidateFileForEdit(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 
 	tool := &editTool{}

--- a/internal/llm/tools/fetch_test.go
+++ b/internal/llm/tools/fetch_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestFetchTool(t *testing.T) {
+	t.Parallel()
 	tool := NewFetchTool()
 
 	assert.Equal(t, FetchToolName, tool.Name())
@@ -23,6 +24,7 @@ func TestFetchTool(t *testing.T) {
 }
 
 func TestFetchToolValidation(t *testing.T) {
+	t.Parallel()
 	tool := NewFetchTool()
 	typedTool := tool.(*ToolWrapper[FetchParams, ToolResponse])
 
@@ -53,6 +55,7 @@ func TestFetchToolValidation(t *testing.T) {
 }
 
 func TestFetchReadabilityExtraction(t *testing.T) {
+	t.Parallel()
 	// Create a test server that returns realistic HTML with nav chrome
 	richHTML := `<!DOCTYPE html>
 <html>
@@ -164,6 +167,7 @@ func TestFetchReadabilityExtraction(t *testing.T) {
 }
 
 func TestFetchJSRenderedDetection(t *testing.T) {
+	t.Parallel()
 	// Simulate a JS-rendered SPA page - large HTML, almost no text content
 	spaHTML := `<!DOCTYPE html>
 <html>
@@ -206,6 +210,7 @@ func TestFetchJSRenderedDetection(t *testing.T) {
 }
 
 func TestFetchNonHTMLContent(t *testing.T) {
+	t.Parallel()
 	jsonContent := `{"name": "test", "version": "1.0.0"}`
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -242,6 +247,7 @@ func TestFetchNonHTMLContent(t *testing.T) {
 }
 
 func TestExtractWithReadability(t *testing.T) {
+	t.Parallel()
 	html := `<!DOCTYPE html>
 <html>
 <head><title>Article Title</title></head>
@@ -268,6 +274,7 @@ explanations that make this article valuable to the reader.</p>
 }
 
 func TestExtractTextFromHTML(t *testing.T) {
+	t.Parallel()
 	html := `<!DOCTYPE html>
 <html>
 <head><title>Test</title><script>var x = 1;</script><style>body { color: red; }</style></head>

--- a/internal/llm/tools/file_concurrency_test.go
+++ b/internal/llm/tools/file_concurrency_test.go
@@ -52,6 +52,7 @@ func mustReturnWithin(t *testing.T, d time.Duration, what string, f func()) {
 // lock and drives every gate an edit passes through on its way to Execute; each
 // must complete while the lock is held.
 func TestPathLockNotHeldAcrossPermissionGate(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "gated.txt")
 	require.NoError(t, os.WriteFile(path, []byte("hello\n"), 0o644))
@@ -108,6 +109,7 @@ func TestPathLockNotHeldAcrossPermissionGate(t *testing.T) {
 // The failure is an ERROR, never a success — the whole point of the fix is that
 // an edit which could not be applied must say so.
 func TestPathLockIsContextCancellable(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "contended.txt")
 	require.NoError(t, os.WriteFile(path, []byte("hello\n"), 0o644))
@@ -152,6 +154,7 @@ func TestPathLockIsContextCancellable(t *testing.T) {
 // opposite argument order still acquire in the same global order, so neither can
 // hold one while waiting for the other.
 func TestPathLockMultiPathOrdering(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	a := filepath.Join(dir, "a.txt")
 	b := filepath.Join(dir, "b.txt")
@@ -202,6 +205,7 @@ func TestPathLockMultiPathOrdering(t *testing.T) {
 // when the bytes on disk are not the bytes the edit was computed from, the write
 // must be reported as a conflict and the other writer's content put back.
 func TestWriteFileGuardedDetectsClobber(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "cas.txt")
 	require.NoError(t, os.WriteFile(path, []byte("theirs\n"), 0o644))

--- a/internal/llm/tools/load_tool_test.go
+++ b/internal/llm/tools/load_tool_test.go
@@ -32,6 +32,7 @@ func newLoadToolTestCtx(t *testing.T, permission string) *rctx.ToolContext {
 // ----- Load / search behavior -----
 
 func TestLoadTool_LoadByName_Success(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 	ctx := newLoadToolTestCtx(t, PermissionOrchestrator)
 
@@ -47,6 +48,7 @@ func TestLoadTool_LoadByName_Success(t *testing.T) {
 }
 
 func TestLoadTool_LoadByName_NonexistentTool(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 	ctx := newLoadToolTestCtx(t, PermissionOrchestrator)
 
@@ -57,6 +59,7 @@ func TestLoadTool_LoadByName_NonexistentTool(t *testing.T) {
 }
 
 func TestLoadTool_SearchByQuery_ReturnsMatches(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 	ctx := newLoadToolTestCtx(t, PermissionOrchestrator)
 
@@ -69,6 +72,7 @@ func TestLoadTool_SearchByQuery_ReturnsMatches(t *testing.T) {
 }
 
 func TestLoadTool_SearchByQuery_NoMatches(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 	ctx := newLoadToolTestCtx(t, PermissionOrchestrator)
 
@@ -81,6 +85,7 @@ func TestLoadTool_SearchByQuery_NoMatches(t *testing.T) {
 }
 
 func TestLoadTool_EmptyParams_ReturnsError(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 	ctx := newLoadToolTestCtx(t, PermissionOrchestrator)
 
@@ -94,6 +99,7 @@ func TestLoadTool_EmptyParams_ReturnsError(t *testing.T) {
 // ----- MCP tool discovery / loading -----
 
 func TestLoadTool_SearchByQuery_SurfacesConnectedMCPTool(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 	ctx := newLoadToolTestCtx(t, PermissionOrchestrator)
 
@@ -109,6 +115,7 @@ func TestLoadTool_SearchByQuery_SurfacesConnectedMCPTool(t *testing.T) {
 }
 
 func TestLoadTool_LoadMCPTool_ConnectedSucceeds(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 	ctx := newLoadToolTestCtx(t, PermissionOrchestrator)
 
@@ -127,6 +134,7 @@ func TestLoadTool_LoadMCPTool_ConnectedSucceeds(t *testing.T) {
 }
 
 func TestLoadTool_LoadMCPTool_UnconnectedErrors(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 	ctx := newLoadToolTestCtx(t, PermissionOrchestrator)
 
@@ -145,6 +153,7 @@ func TestLoadTool_LoadMCPTool_UnconnectedErrors(t *testing.T) {
 }
 
 func TestLoadTool_LoadMCPTool_NoneConnectedErrors(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 	ctx := newLoadToolTestCtx(t, PermissionOrchestrator)
 
@@ -158,6 +167,7 @@ func TestLoadTool_LoadMCPTool_NoneConnectedErrors(t *testing.T) {
 // ----- Permission gating -----
 
 func TestLoadTool_PermissionGating_ReadOnlyCannotLoadMutatingTool(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 	ctx := newLoadToolTestCtx(t, PermissionReadOnly)
 
@@ -169,6 +179,7 @@ func TestLoadTool_PermissionGating_ReadOnlyCannotLoadMutatingTool(t *testing.T) 
 }
 
 func TestLoadTool_PermissionGating_ReadOnlyCanLoadReadOnlyTool(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 	ctx := newLoadToolTestCtx(t, PermissionReadOnly)
 
@@ -179,6 +190,7 @@ func TestLoadTool_PermissionGating_ReadOnlyCanLoadReadOnlyTool(t *testing.T) {
 }
 
 func TestLoadTool_PermissionGating_MutatingCanLoadMutatingTool(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 	ctx := newLoadToolTestCtx(t, PermissionMutating)
 
@@ -189,6 +201,7 @@ func TestLoadTool_PermissionGating_MutatingCanLoadMutatingTool(t *testing.T) {
 }
 
 func TestLoadTool_PermissionGating_OrchestratorCanLoadAnything(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 
 	// Try a representative set spanning readonly and mutating tools.
@@ -208,6 +221,7 @@ func TestLoadTool_PermissionGating_OrchestratorCanLoadAnything(t *testing.T) {
 // ----- Store integration -----
 
 func TestLoadTool_StoresInLoadedToolsStore(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 	ctx := newLoadToolTestCtx(t, PermissionOrchestrator)
 
@@ -223,6 +237,7 @@ func TestLoadTool_StoresInLoadedToolsStore(t *testing.T) {
 }
 
 func TestLoadTool_LoadAlreadyLoadedTool_Idempotent(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 	ctx := newLoadToolTestCtx(t, PermissionOrchestrator)
 
@@ -244,6 +259,7 @@ func TestLoadTool_LoadAlreadyLoadedTool_Idempotent(t *testing.T) {
 }
 
 func TestLoadTool_DeniedLoadNotStored(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 	ctx := newLoadToolTestCtx(t, PermissionReadOnly)
 
@@ -261,6 +277,7 @@ func TestLoadTool_DeniedLoadNotStored(t *testing.T) {
 // ----- SetDeferredTools / Description -----
 
 func TestLoadTool_DescriptionIncludesDeferredTools(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 
 	// Without deferred tools, description is the base text.
@@ -275,6 +292,7 @@ func TestLoadTool_DescriptionIncludesDeferredTools(t *testing.T) {
 }
 
 func TestLoadTool_DescriptionNoDeferredTools(t *testing.T) {
+	t.Parallel()
 	tool := &loadToolTool{}
 	tool.SetDeferredTools(nil)
 	assert.Equal(t, loadToolDescription, tool.Description())
@@ -284,6 +302,7 @@ func TestLoadTool_DescriptionNoDeferredTools(t *testing.T) {
 }
 
 func TestLoadTool_ImplementsDeferredToolsAware(t *testing.T) {
+	t.Parallel()
 	tool := NewLoadToolTool()
 	u, ok := tool.(interface{ Unwrap() any })
 	require.True(t, ok, "load_tool wrapper must implement Unwrap")

--- a/internal/llm/tools/loaded_tools_store_test.go
+++ b/internal/llm/tools/loaded_tools_store_test.go
@@ -20,6 +20,7 @@ func newTestStore() *LoadedToolsStore {
 }
 
 func TestLoadedToolsStore_AddAndGet(t *testing.T) {
+	t.Parallel()
 	s := newTestStore()
 	chatID := "chat-add-get"
 
@@ -30,6 +31,7 @@ func TestLoadedToolsStore_AddAndGet(t *testing.T) {
 }
 
 func TestLoadedToolsStore_Has(t *testing.T) {
+	t.Parallel()
 	s := newTestStore()
 	chatID := "chat-has"
 
@@ -40,6 +42,7 @@ func TestLoadedToolsStore_Has(t *testing.T) {
 }
 
 func TestLoadedToolsStore_MultipleChatsIsolated(t *testing.T) {
+	t.Parallel()
 	s := newTestStore()
 	chatA := "chat-A"
 	chatB := "chat-B"
@@ -60,6 +63,7 @@ func TestLoadedToolsStore_MultipleChatsIsolated(t *testing.T) {
 }
 
 func TestLoadedToolsStore_Clear(t *testing.T) {
+	t.Parallel()
 	s := newTestStore()
 	chatID := "chat-clear"
 
@@ -74,6 +78,7 @@ func TestLoadedToolsStore_Clear(t *testing.T) {
 }
 
 func TestLoadedToolsStore_ClearDoesNotAffectOtherChats(t *testing.T) {
+	t.Parallel()
 	s := newTestStore()
 	chatA := "chat-keep"
 	chatB := "chat-clear"
@@ -88,6 +93,7 @@ func TestLoadedToolsStore_ClearDoesNotAffectOtherChats(t *testing.T) {
 }
 
 func TestLoadedToolsStore_AddDuplicate_NoError(t *testing.T) {
+	t.Parallel()
 	s := newTestStore()
 	chatID := "chat-dup"
 
@@ -99,6 +105,7 @@ func TestLoadedToolsStore_AddDuplicate_NoError(t *testing.T) {
 }
 
 func TestLoadedToolsStore_SetAndGetPermission(t *testing.T) {
+	t.Parallel()
 	s := newTestStore()
 	chatID := "chat-perm"
 
@@ -111,6 +118,7 @@ func TestLoadedToolsStore_SetAndGetPermission(t *testing.T) {
 }
 
 func TestLoadedToolsStore_GetPermission_DefaultOrchestrator(t *testing.T) {
+	t.Parallel()
 	s := newTestStore()
 
 	// No permission ever set -> backward-compatible default of orchestrator.
@@ -119,6 +127,7 @@ func TestLoadedToolsStore_GetPermission_DefaultOrchestrator(t *testing.T) {
 }
 
 func TestLoadedToolsStore_ClearRemovesPermission(t *testing.T) {
+	t.Parallel()
 	s := newTestStore()
 	chatID := "chat-clear-perm"
 
@@ -135,6 +144,7 @@ func TestLoadedToolsStore_ClearRemovesPermission(t *testing.T) {
 }
 
 func TestLoadedToolsStore_AvailableMCPTools_SetGetClear(t *testing.T) {
+	t.Parallel()
 	s := newTestStore() // note: newTestStore does not init availableMCP; setter must lazily init
 	chatID := "chat-mcp"
 
@@ -159,6 +169,7 @@ func TestLoadedToolsStore_AvailableMCPTools_SetGetClear(t *testing.T) {
 }
 
 func TestSearchTools_SurfacesConnectedMCPTool(t *testing.T) {
+	t.Parallel()
 	mcpTools := []MCPToolInfo{
 		{Name: "mcp__chrome-devtools__take_screenshot", Description: "Capture a screenshot of the current page"},
 		{Name: "mcp__chrome-devtools__navigate_page", Description: "Navigate the browser to a URL"},
@@ -201,6 +212,7 @@ func containsToolResult(results []ToolSearchResult, name string) bool {
 }
 
 func TestLoadedToolsStore_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
 	s := newTestStore()
 
 	const goroutines = 50

--- a/internal/llm/tools/mcp_adapter_absent_argument_test.go
+++ b/internal/llm/tools/mcp_adapter_absent_argument_test.go
@@ -37,6 +37,7 @@ func (r *argumentRecordingRuntime) CallTool(_, _, _ string, arguments map[string
 // forward exactly the keys the model produced — never materialize a zero value
 // for a key the model left out, and never drop a zero value the model chose.
 func TestMCPToolAdapter_ForwardsProvidedKeysAndOnlyProvidedKeys(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name    string
 		input   string

--- a/internal/llm/tools/mcp_adapter_schema_test.go
+++ b/internal/llm/tools/mcp_adapter_schema_test.go
@@ -13,6 +13,7 @@ import (
 // treat that key as a property name and preserve its subschema, not collapse it
 // to the bare string "object" (which invopop rejects, forcing a loose fallback).
 func TestParseSchema_PropertyNamedType(t *testing.T) {
+	t.Parallel()
 	adapter := &MCPToolAdapter{
 		serverName: "chrome-devtools",
 		tool: mcp.Tool{
@@ -53,6 +54,7 @@ func TestParseSchema_PropertyNamedType(t *testing.T) {
 // TestNormalizeSchemaForInvopop_PreservesPropertyNamedType is a focused unit test
 // for the normalizer: a property named "type" must remain a subschema map.
 func TestNormalizeSchemaForInvopop_PreservesPropertyNamedType(t *testing.T) {
+	t.Parallel()
 	input := map[string]interface{}{
 		"type": []interface{}{"object", "null"},
 		"properties": map[string]interface{}{
@@ -93,6 +95,7 @@ func TestNormalizeSchemaForInvopop_PreservesPropertyNamedType(t *testing.T) {
 }
 
 func TestNormalizeSchemaType_ArrayPrefersConcreteNonNull(t *testing.T) {
+	t.Parallel()
 	typeValue := []interface{}{"object", "null"}
 	got := normalizeSchemaType(typeValue)
 	if got != "object" {
@@ -101,6 +104,7 @@ func TestNormalizeSchemaType_ArrayPrefersConcreteNonNull(t *testing.T) {
 }
 
 func TestNormalizeSchemaForInvopop_NormalizesNestedTypeArrays(t *testing.T) {
+	t.Parallel()
 	input := map[string]interface{}{
 		"type": []interface{}{"object", "null"},
 		"properties": map[string]interface{}{
@@ -144,6 +148,7 @@ func TestNormalizeSchemaForInvopop_NormalizesNestedTypeArrays(t *testing.T) {
 }
 
 func TestExtractSchemaHints(t *testing.T) {
+	t.Parallel()
 	input := map[string]interface{}{
 		"properties": map[string]interface{}{
 			"zeta":  map[string]interface{}{"type": "string"},
@@ -162,6 +167,7 @@ func TestExtractSchemaHints(t *testing.T) {
 }
 
 func TestMCPToolAdapterName_UsesLogicalServerName(t *testing.T) {
+	t.Parallel()
 	adapter, err := NewProjectMCPToolAdapter(
 		"/tmp/project",
 		"chrome-devtools",
@@ -177,6 +183,7 @@ func TestMCPToolAdapterName_UsesLogicalServerName(t *testing.T) {
 }
 
 func TestNewProjectMCPToolAdapter_RejectsScopedServerIdentifier(t *testing.T) {
+	t.Parallel()
 	_, err := NewProjectMCPToolAdapter(
 		"/tmp/project",
 		"/tmp/project::chrome-devtools",
@@ -188,6 +195,7 @@ func TestNewProjectMCPToolAdapter_RejectsScopedServerIdentifier(t *testing.T) {
 }
 
 func TestValidateMCPLogicalServerName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		in      string
@@ -213,6 +221,7 @@ func TestValidateMCPLogicalServerName(t *testing.T) {
 }
 
 func TestMCPToolRegistryBuildAdapters_PrunesDuplicateLogicalToolNamesDeterministically(t *testing.T) {
+	t.Parallel()
 	registry := NewMCPToolRegistry(nil, "/tmp/project")
 	serverTools := map[string][]mcp.Tool{
 		"alpha": {

--- a/internal/llm/tools/mcp_adapter_session_test.go
+++ b/internal/llm/tools/mcp_adapter_session_test.go
@@ -38,6 +38,7 @@ func (r *sessionRecordingRuntime) CallTool(session, _, _ string, _ map[string]in
 // not the chat: the engine fans several threads out inside one chat, and those
 // siblings are exactly the callers that were clobbering each other.
 func TestMCPToolAdapter_PassesTheAgentThreadAsTheSessionKey(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name   string
 		chatID string

--- a/internal/llm/tools/move_code_test.go
+++ b/internal/llm/tools/move_code_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestMoveCodeTool(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	chatID := "test-chat-move"
 	thread := "0"

--- a/internal/llm/tools/output_limiter_test.go
+++ b/internal/llm/tools/output_limiter_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestCheckOutputSize(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		toolName    string
@@ -59,6 +60,7 @@ func TestCheckOutputSize(t *testing.T) {
 }
 
 func TestTruncateOutput(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		toolName string
@@ -122,6 +124,7 @@ func TestTruncateOutput(t *testing.T) {
 }
 
 func TestGetToolSpecificSuggestions(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		toolName    string
 		expectCount int // minimum expected suggestions
@@ -145,6 +148,7 @@ func TestGetToolSpecificSuggestions(t *testing.T) {
 }
 
 func TestOutputLimitError(t *testing.T) {
+	t.Parallel()
 	err := &OutputLimitError{
 		ToolName:   ShellToolName,
 		OutputSize: 60000,
@@ -168,6 +172,7 @@ func TestOutputLimitError(t *testing.T) {
 }
 
 func TestViewToolTruncation(t *testing.T) {
+	t.Parallel()
 	// View tool should use head+tail truncation like bash
 	largeOutput := strings.Repeat("line of code\n", 5000)
 	result := TruncateOutput("view", largeOutput, true)
@@ -190,6 +195,7 @@ func TestViewToolTruncation(t *testing.T) {
 }
 
 func TestViewSuggestionsExist(t *testing.T) {
+	t.Parallel()
 	suggestions := getToolSpecificSuggestions("view")
 	if len(suggestions) < 2 {
 		t.Errorf("expected at least 2 suggestions for view, got %d", len(suggestions))
@@ -210,6 +216,7 @@ func TestViewSuggestionsExist(t *testing.T) {
 
 // A skill that fits must pass through untouched — no notice, no reformatting.
 func TestCapSkillContent_UnderBudgetIsUntouched(t *testing.T) {
+	t.Parallel()
 	body := strings.Repeat("a", MaxSkillBodySize)
 	got, truncated := CapSkillContent(body)
 	if truncated {
@@ -224,6 +231,7 @@ func TestCapSkillContent_UnderBudgetIsUntouched(t *testing.T) {
 // load is where the tool appends its sub-skill / related-skill / suggested-tools
 // pointers, so a silent cut severs the links to the rest of the skill tree.
 func TestCapSkillContent_OverBudgetIsMarkedAndFits(t *testing.T) {
+	t.Parallel()
 	// Size the fixture FROM the budget rather than to a fixed line count: a
 	// literal count silently stops exercising truncation the moment the
 	// ceiling is raised, and the test then passes while proving nothing.
@@ -264,6 +272,7 @@ func TestCapSkillContent_OverBudgetIsMarkedAndFits(t *testing.T) {
 // The notice length varies with the digits of the numbers it reports, so the
 // fitting loop has to converge for any input size, never overshooting.
 func TestCapSkillContent_FitsAtEveryOversizeBoundary(t *testing.T) {
+	t.Parallel()
 	for _, extra := range []int{1, 9, 99, 999, 9_999, 99_999, 1_000_000} {
 		body := strings.Repeat("x", MaxSkillBodySize+extra)
 		got, truncated := CapSkillContent(body)
@@ -279,6 +288,7 @@ func TestCapSkillContent_FitsAtEveryOversizeBoundary(t *testing.T) {
 // TruncateOutput must route the skill tool to the skill-aware cap rather than
 // the generic tail cut, so both skill-delivery paths emit identical bytes.
 func TestTruncateOutput_SkillUsesSkillCap(t *testing.T) {
+	t.Parallel()
 	body := strings.Repeat("skill content line\n", 2000)
 	viaTruncate := TruncateOutput(ToolSkill, body, true)
 	viaCap, _ := CapSkillContent(body)
@@ -299,6 +309,7 @@ func TestTruncateOutput_SkillUsesSkillCap(t *testing.T) {
 // would still have arrived cut at 24KB — which is exactly what drove eleven
 // fan-out agents to page a generated proto by `grep`, one message at a time.
 func TestOutputCeiling_ViewReadsMoreThanOtherTools(t *testing.T) {
+	t.Parallel()
 	big := strings.Repeat("x", 40_000) // over MaxOutputSize, under MaxReadSize
 
 	t.Run("view delivers it whole", func(t *testing.T) {

--- a/internal/llm/tools/output_truncation_test.go
+++ b/internal/llm/tools/output_truncation_test.go
@@ -18,6 +18,7 @@ import (
 // TestViewToolOutputTruncation tests that large file outputs are properly truncated
 // to stay within the MaxOutputSize limit (16KB)
 func TestViewToolOutputTruncation(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 
 	// Create the view tool
@@ -102,6 +103,7 @@ func TestViewToolOutputTruncation(t *testing.T) {
 
 // TestViewToolLongLineTruncation tests that individual lines over MaxLineLength are truncated
 func TestViewToolLongLineTruncation(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 
 	tool := &viewTool{}
@@ -131,6 +133,7 @@ func TestViewToolLongLineTruncation(t *testing.T) {
 
 // TestTruncationMessagesContainGuidance tests that truncation messages include actionable hints
 func TestTruncationMessagesContainGuidance(t *testing.T) {
+	t.Parallel()
 	t.Run("View truncation message mentions offset", func(t *testing.T) {
 		largeOutput := strings.Repeat("line of code\n", 5000)
 		result := TruncateOutput("view", largeOutput, true)
@@ -180,6 +183,7 @@ func TestTruncationMessagesContainGuidance(t *testing.T) {
 // cliff, a skill has to be delivered under the same ceiling as any other tool
 // result, and head+tail truncation needs enough room to leave two useful ends.
 func TestOutputLimitsConstants(t *testing.T) {
+	t.Parallel()
 	t.Run("the warning threshold arrives before the ceiling", func(t *testing.T) {
 		assert.Less(t, TruncationWarningThreshold, MaxOutputSize,
 			"a warning at or past the ceiling fires only once output is already cut")

--- a/internal/llm/tools/permissions_test.go
+++ b/internal/llm/tools/permissions_test.go
@@ -10,6 +10,7 @@ import (
 // ----- PermissionAtLeast -----
 
 func TestPermissionAtLeast_ReadOnlyNotSufficientForMutating(t *testing.T) {
+	t.Parallel()
 	assert.False(t, PermissionAtLeast(PermissionReadOnly, PermissionMutating),
 		"readonly must not satisfy mutating requirement")
 	assert.False(t, PermissionAtLeast(PermissionReadOnly, PermissionOrchestrator),
@@ -17,6 +18,7 @@ func TestPermissionAtLeast_ReadOnlyNotSufficientForMutating(t *testing.T) {
 }
 
 func TestPermissionAtLeast_MutatingNotSufficientForOrchestrator(t *testing.T) {
+	t.Parallel()
 	assert.False(t, PermissionAtLeast(PermissionMutating, PermissionOrchestrator),
 		"mutating must not satisfy orchestrator requirement")
 	// But mutating >= readonly
@@ -25,18 +27,21 @@ func TestPermissionAtLeast_MutatingNotSufficientForOrchestrator(t *testing.T) {
 }
 
 func TestPermissionAtLeast_OrchestratorIsSufficientForAll(t *testing.T) {
+	t.Parallel()
 	assert.True(t, PermissionAtLeast(PermissionOrchestrator, PermissionReadOnly))
 	assert.True(t, PermissionAtLeast(PermissionOrchestrator, PermissionMutating))
 	assert.True(t, PermissionAtLeast(PermissionOrchestrator, PermissionOrchestrator))
 }
 
 func TestPermissionAtLeast_SamePermission(t *testing.T) {
+	t.Parallel()
 	assert.True(t, PermissionAtLeast(PermissionReadOnly, PermissionReadOnly))
 	assert.True(t, PermissionAtLeast(PermissionMutating, PermissionMutating))
 	assert.True(t, PermissionAtLeast(PermissionOrchestrator, PermissionOrchestrator))
 }
 
 func TestPermissionAtLeast_InvalidPermission(t *testing.T) {
+	t.Parallel()
 	// Unknown permissions must not satisfy any real permission requirement.
 	assert.False(t, PermissionAtLeast("bogus", PermissionReadOnly),
 		"unknown 'have' permission must be treated as insufficient")
@@ -77,6 +82,7 @@ func containsNone(haystack []string, needles ...string) bool {
 }
 
 func TestInitialToolsForPermission_ReadOnly(t *testing.T) {
+	t.Parallel()
 	got := InitialToolsForPermission(PermissionReadOnly)
 
 	// Read-only agents must get the core discovery/read tools.
@@ -98,6 +104,7 @@ func TestInitialToolsForPermission_ReadOnly(t *testing.T) {
 }
 
 func TestInitialToolsForPermission_Mutating(t *testing.T) {
+	t.Parallel()
 	got := InitialToolsForPermission(PermissionMutating)
 
 	// Mutating agents get everything readonly gets...
@@ -113,6 +120,7 @@ func TestInitialToolsForPermission_Mutating(t *testing.T) {
 }
 
 func TestInitialToolsForPermission_Orchestrator(t *testing.T) {
+	t.Parallel()
 	got := InitialToolsForPermission(PermissionOrchestrator)
 
 	// Orchestrator at minimum contains everything the mutating level has.
@@ -130,6 +138,7 @@ func TestInitialToolsForPermission_Orchestrator(t *testing.T) {
 // ----- MinimumPermissionForTool -----
 
 func TestMinimumPermissionForTool_ReadOnlyTools(t *testing.T) {
+	t.Parallel()
 	readOnlyTools := []string{ToolView, ToolFetch, ToolWebSearch}
 	for _, name := range readOnlyTools {
 		assert.Equal(t, PermissionReadOnly, MinimumPermissionForTool(name),
@@ -138,6 +147,7 @@ func TestMinimumPermissionForTool_ReadOnlyTools(t *testing.T) {
 }
 
 func TestMinimumPermissionForTool_MutatingTools(t *testing.T) {
+	t.Parallel()
 	mutatingTools := []string{ToolWrite, ToolEdit, ToolFindReplace, ToolMoveCode}
 	for _, name := range mutatingTools {
 		assert.Equal(t, PermissionMutating, MinimumPermissionForTool(name),
@@ -153,6 +163,7 @@ func TestMinimumPermissionForTool_MutatingTools(t *testing.T) {
 // shell can still redirect into a file. A hard read-only boundary has to be
 // enforced below the tool layer.
 func TestMinimumPermissionForTool_ShellIsReadOnlyTier(t *testing.T) {
+	t.Parallel()
 	for _, name := range []string{ShellToolName, ToolBashList, ToolBashOutput, ToolBashKill} {
 		assert.Equal(t, PermissionReadOnly, MinimumPermissionForTool(name),
 			"tool %q must be loadable by a readonly agent so search still works", name)
@@ -160,18 +171,21 @@ func TestMinimumPermissionForTool_ShellIsReadOnlyTier(t *testing.T) {
 }
 
 func TestMinimumPermissionForTool_OrchestratorTools(t *testing.T) {
+	t.Parallel()
 	// The implementation explicitly lists "spawn" and ToolAgent as orchestrator-only.
 	assert.Equal(t, PermissionOrchestrator, MinimumPermissionForTool("spawn"))
 	assert.Equal(t, PermissionOrchestrator, MinimumPermissionForTool(ToolAgent))
 }
 
 func TestMinimumPermissionForTool_UnknownTool(t *testing.T) {
+	t.Parallel()
 	// Unknown tools default to readonly (safe default per implementation comment).
 	assert.Equal(t, PermissionReadOnly, MinimumPermissionForTool("nonexistent_tool_xyz"),
 		"unknown tools must default to the safest permission level")
 }
 
 func TestMinimumPermissionForTool_MCPTools(t *testing.T) {
+	t.Parallel()
 	// MCP tools (prefix mcp__) aren't in the registry and should get the safe default.
 	assert.Equal(t, PermissionReadOnly, MinimumPermissionForTool("mcp__proxyman__get_flow_detail"))
 	assert.Equal(t, PermissionReadOnly, MinimumPermissionForTool("mcp__serena__find_symbol"))

--- a/internal/llm/tools/plan_resolve_test.go
+++ b/internal/llm/tools/plan_resolve_test.go
@@ -159,6 +159,7 @@ func TestPlanReadThrough_OwnPlanWins(t *testing.T) {
 // tasks have no dependency between them, which is precisely the fan-out set —
 // the number is only useful if it says so.
 func TestPlanReadThrough_ReadySetIsStatedAsFanOut(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 

--- a/internal/llm/tools/plan_tool_test.go
+++ b/internal/llm/tools/plan_tool_test.go
@@ -18,6 +18,7 @@ import (
 // <uuid>" branch, which names no remedy — an agent was observed retrying it
 // eight times in a row against the same empty thread.
 func TestPlanTools_MissingPlanErrorNamesTheRemedy(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 
@@ -58,6 +59,7 @@ func TestPlanTools_MissingPlanErrorNamesTheRemedy(t *testing.T) {
 }
 
 func TestCreatePlan_InlineDependencies(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 
@@ -119,6 +121,7 @@ func TestCreatePlan_InlineDependencies(t *testing.T) {
 }
 
 func TestCreatePlan_InlineDependencies_Validation(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 
@@ -224,6 +227,7 @@ func TestCreatePlan_InlineDependencies_Validation(t *testing.T) {
 }
 
 func TestCreatePlan_NoDependencies_BackwardsCompat(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 
@@ -254,6 +258,7 @@ func TestCreatePlan_NoDependencies_BackwardsCompat(t *testing.T) {
 }
 
 func TestCreatePlan_TaskMetadata(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 
@@ -320,6 +325,7 @@ func TestCreatePlan_TaskMetadata(t *testing.T) {
 }
 
 func TestCreatePlan_ParallelWithDependency(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 
@@ -370,6 +376,7 @@ func TestCreatePlan_ParallelWithDependency(t *testing.T) {
 }
 
 func TestCreatePlan_MixedValidAndInvalidDeps(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 

--- a/internal/llm/tools/preview_url_test.go
+++ b/internal/llm/tools/preview_url_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestIsPreviewablePort(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		addr string
 		want bool
@@ -39,6 +40,7 @@ func TestIsPreviewablePort(t *testing.T) {
 }
 
 func TestProxyPreviewURL(t *testing.T) {
+	t.Parallel()
 	// Dev/test: path-based proxy URL on the local proxy host.
 	require.Equal(t,
 		"http://localhost:28080/proxy/daemon-123/3000/",

--- a/internal/llm/tools/read_attachment_test.go
+++ b/internal/llm/tools/read_attachment_test.go
@@ -16,6 +16,7 @@ func newReadAttachmentCtx() *rctx.ToolContext {
 }
 
 func TestReadAttachmentReadPDF(t *testing.T) {
+	t.Parallel()
 	tool := &ReadAttachmentTool{}
 
 	t.Run("small PDF returns whole document block", func(t *testing.T) {
@@ -62,6 +63,7 @@ func TestReadAttachmentReadPDF(t *testing.T) {
 }
 
 func TestReadAttachmentGuards(t *testing.T) {
+	t.Parallel()
 	tool := &ReadAttachmentTool{} // nil repo
 
 	resp, err := tool.Execute(newReadAttachmentCtx(), ReadAttachmentParams{AttachmentID: "x"})

--- a/internal/llm/tools/registry_test.go
+++ b/internal/llm/tools/registry_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestExpandToolFilter(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name              string
 		filter            []string
@@ -137,6 +138,7 @@ func TestExpandToolFilter(t *testing.T) {
 }
 
 func TestMatchGlob(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		pattern string
 		name    string
@@ -163,6 +165,7 @@ func TestMatchGlob(t *testing.T) {
 }
 
 func TestExpandToolFilterDeduplication(t *testing.T) {
+	t.Parallel()
 	// Verify that tools are never duplicated even when specified both
 	// explicitly and via tag expansion
 	tests := []struct {
@@ -213,6 +216,7 @@ func TestExpandToolFilterDeduplication(t *testing.T) {
 }
 
 func TestTagDefault(t *testing.T) {
+	t.Parallel()
 	// Verify that tag:default includes the expected default tools
 	mcpTools := []string{"mcp__test__foo"}
 	result := ExpandToolFilter([]string{"tag:default"}, mcpTools)
@@ -259,6 +263,7 @@ func TestTagDefault(t *testing.T) {
 }
 
 func TestTagReadOnly(t *testing.T) {
+	t.Parallel()
 	// Verify that tag:readonly includes only truly read-only tools (don't modify files/code/state)
 	mcpTools := []string{"mcp__test__readonly"}
 	result := ExpandToolFilter([]string{"tag:readonly"}, mcpTools)
@@ -306,6 +311,7 @@ func TestTagReadOnly(t *testing.T) {
 }
 
 func TestTagPlan(t *testing.T) {
+	t.Parallel()
 	// Verify that tag:plan includes all tools available in planning mode
 	mcpTools := []string{}
 	result := ExpandToolFilter([]string{"tag:plan"}, mcpTools)
@@ -355,6 +361,7 @@ func TestTagPlan(t *testing.T) {
 // ============================================================================
 
 func TestParseSpawnFilter(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		spec string
@@ -441,6 +448,7 @@ func TestParseSpawnFilter(t *testing.T) {
 }
 
 func TestExpandToolFilterWithSpawn(t *testing.T) {
+	t.Parallel()
 	mcpTools := []string{"mcp__test__tool"}
 
 	t.Run("extracts spawn configs and expands tools", func(t *testing.T) {
@@ -523,6 +531,7 @@ func TestExpandToolFilterWithSpawn(t *testing.T) {
 }
 
 func TestExpandToolFilterWithSpawn_AskUser(t *testing.T) {
+	t.Parallel()
 	mcpTools := []string{}
 
 	t.Run("ask_user in filter appears in ToolNames", func(t *testing.T) {
@@ -554,6 +563,7 @@ func TestExpandToolFilterWithSpawn_AskUser(t *testing.T) {
 }
 
 func TestExpandToolFilterIgnoresSpawn(t *testing.T) {
+	t.Parallel()
 	// ExpandToolFilter should ignore spawn: entries
 	mcpTools := []string{}
 	filter := []string{
@@ -573,6 +583,7 @@ func TestExpandToolFilterIgnoresSpawn(t *testing.T) {
 }
 
 func TestExpandToolFilterMCPTags(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		filter       []string

--- a/internal/llm/tools/response_tool_test.go
+++ b/internal/llm/tools/response_tool_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestResponseTool_BasicUsage(t *testing.T) {
+	t.Parallel()
 	def := ResponseToolDefinition{
 		Name:        "test_response",
 		Description: "A test response tool",
@@ -85,6 +86,7 @@ func TestResponseTool_BasicUsage(t *testing.T) {
 }
 
 func TestResponseTool_Run(t *testing.T) {
+	t.Parallel()
 	def := ResponseToolDefinition{
 		Name:        "validation_result",
 		Description: "Report validation results",
@@ -141,6 +143,7 @@ func TestResponseTool_Run(t *testing.T) {
 }
 
 func TestResponseTool_RunInvalidJSON(t *testing.T) {
+	t.Parallel()
 	def := ResponseToolDefinition{
 		Name:        "test",
 		Description: "Test",
@@ -172,6 +175,7 @@ func TestResponseTool_RunInvalidJSON(t *testing.T) {
 }
 
 func TestResponseTool_ArraySchema(t *testing.T) {
+	t.Parallel()
 	// Test the array schema format with nested results
 	def := ResponseToolDefinition{
 		Name:        "filtered_results",
@@ -230,6 +234,7 @@ func TestResponseTool_ArraySchema(t *testing.T) {
 }
 
 func TestResponseTool_EmptySchema(t *testing.T) {
+	t.Parallel()
 	def := ResponseToolDefinition{
 		Name:        "test",
 		Description: "Test",
@@ -246,6 +251,7 @@ func TestResponseTool_EmptySchema(t *testing.T) {
 }
 
 func TestResponseTool_IsReadOnly(t *testing.T) {
+	t.Parallel()
 	def := ResponseToolDefinition{
 		Name:        "test",
 		Description: "Test",
@@ -264,6 +270,7 @@ func TestResponseTool_IsReadOnly(t *testing.T) {
 }
 
 func TestResponseTool_RequiresNoPermission(t *testing.T) {
+	t.Parallel()
 	def := ResponseToolDefinition{
 		Name:        "test",
 		Description: "Test",
@@ -285,6 +292,7 @@ func TestResponseTool_RequiresNoPermission(t *testing.T) {
 }
 
 func TestResponseTool_RunWithArrayInput(t *testing.T) {
+	t.Parallel()
 	def := ResponseToolDefinition{
 		Name:        "filtered_results",
 		Description: "Submit filtered results",
@@ -350,6 +358,7 @@ func TestResponseTool_RunWithArrayInput(t *testing.T) {
 // TestResponseToolMetadataForWorkflow tests the workflow response tool scenario
 // This validates that metadata contains the nested structure needed for CEL evaluation
 func TestResponseToolMetadataForWorkflow(t *testing.T) {
+	t.Parallel()
 	// This test validates the workflow scenario:
 	// 1. A node uses a response tool with structured schema
 	// 2. LLM responds with structured data matching the schema

--- a/internal/llm/tools/schema_repair_keys_test.go
+++ b/internal/llm/tools/schema_repair_keys_test.go
@@ -29,6 +29,7 @@ func writeSchemaJSON(t *testing.T) []byte {
 // {"file_path": ...} and the write was hard-rejected with
 // `unexpected additional properties ["file"]`, costing a full turn to retry.
 func TestValidateJSONWithRepair_WriteFileAliasIsRepaired(t *testing.T) {
+	t.Parallel()
 	schema := writeSchemaJSON(t)
 	input := `{"file": "/tmp/scratchpad/x.md", "content": "hello"}`
 
@@ -55,6 +56,7 @@ func TestValidateJSONWithRepair_WriteFileAliasIsRepaired(t *testing.T) {
 // TestValidateJSONWithRepair_WriteCamelCaseAliasIsRepaired covers the other
 // spelling models reach for: filePath instead of file_path.
 func TestValidateJSONWithRepair_WriteCamelCaseAliasIsRepaired(t *testing.T) {
+	t.Parallel()
 	schema := writeSchemaJSON(t)
 	input := `{"filePath": "/tmp/scratchpad/y.md", "content": "hi"}`
 
@@ -77,6 +79,7 @@ func TestValidateJSONWithRepair_WriteCamelCaseAliasIsRepaired(t *testing.T) {
 // onto an already-present "file_path" would silently write to a different path
 // than the one requested — strictly worse than a clean rejection.
 func TestValidateJSONWithRepair_NeverClobbersProvidedValue(t *testing.T) {
+	t.Parallel()
 	schema := writeSchemaJSON(t)
 	input := `{"file": "/tmp/decoy.md", "file_path": "/tmp/real.md", "content": "hi"}`
 
@@ -89,6 +92,7 @@ func TestValidateJSONWithRepair_NeverClobbersProvidedValue(t *testing.T) {
 // key could plausibly mean two different schema properties, the repair declines
 // rather than guessing.
 func TestRepairAliasedKeys_AmbiguousMatchIsRejected(t *testing.T) {
+	t.Parallel()
 	schema := map[string]any{
 		"type":                 "object",
 		"additionalProperties": false,
@@ -108,6 +112,7 @@ func TestRepairAliasedKeys_AmbiguousMatchIsRejected(t *testing.T) {
 // TestRepairAliasedKeys_TypeMismatchIsRejected asserts a lexical match alone is
 // not enough: the supplied value must also fit the target property's type.
 func TestRepairAliasedKeys_TypeMismatchIsRejected(t *testing.T) {
+	t.Parallel()
 	schema := map[string]any{
 		"type":                 "object",
 		"additionalProperties": false,
@@ -127,6 +132,7 @@ func TestRepairAliasedKeys_TypeMismatchIsRejected(t *testing.T) {
 // unknown key is actually illegal. When additionalProperties is permitted the
 // key is a legitimate value and renaming it would destroy data.
 func TestRepairAliasedKeys_OpenSchemaIsLeftAlone(t *testing.T) {
+	t.Parallel()
 	schema := map[string]any{
 		"type": "object",
 		"properties": map[string]any{
@@ -144,6 +150,7 @@ func TestRepairAliasedKeys_OpenSchemaIsLeftAlone(t *testing.T) {
 // TestRepairAliasedKeys_UnrelatedKeyIsLeftAlone asserts the matcher is lexical,
 // not semantic: it must not invent a mapping between unrelated names.
 func TestRepairAliasedKeys_UnrelatedKeyIsLeftAlone(t *testing.T) {
+	t.Parallel()
 	schema := map[string]any{
 		"type":                 "object",
 		"additionalProperties": false,
@@ -163,6 +170,7 @@ func TestRepairAliasedKeys_UnrelatedKeyIsLeftAlone(t *testing.T) {
 // both the wrong key and what it was resolved to, so the log answers "which
 // alias did the model reach for" without re-deriving it.
 func TestRepairAliasedKeys_ReportsRenamePath(t *testing.T) {
+	t.Parallel()
 	schema := map[string]any{
 		"type":                 "object",
 		"additionalProperties": false,
@@ -184,6 +192,7 @@ func TestRepairAliasedKeys_ReportsRenamePath(t *testing.T) {
 // TestValidateJSONWithRepair_ValidInputUntouched guards the common path: a
 // correct call must not be perturbed by the repair layer.
 func TestValidateJSONWithRepair_ValidInputUntouched(t *testing.T) {
+	t.Parallel()
 	schema := writeSchemaJSON(t)
 	input := `{"file_path": "/tmp/ok.md", "content": "hi"}`
 
@@ -202,6 +211,7 @@ func TestValidateJSONWithRepair_ValidInputUntouched(t *testing.T) {
 // it survives the wrapper's strict DisallowUnknownFields decode after
 // validation, which this exercises and the unit tests above do not.
 func TestWriteTool_FileAliasWritesTheFile(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	target := filepath.Join(tempDir, "aliased.md")
 
@@ -230,6 +240,7 @@ func TestWriteTool_FileAliasWritesTheFile(t *testing.T) {
 // wrapper level: when the model supplies BOTH the alias and the real key, the
 // call must fail rather than silently write to one of the two paths.
 func TestWriteTool_AmbiguousAliasStillRejected(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	decoy := filepath.Join(tempDir, "decoy.md")
 	real := filepath.Join(tempDir, "real.md")

--- a/internal/llm/tools/schema_repair_test.go
+++ b/internal/llm/tools/schema_repair_test.go
@@ -31,6 +31,7 @@ func deckPlanSchema() []byte {
 }
 
 func TestValidateJSONWithRepair(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		toolName   string
@@ -192,6 +193,7 @@ func TestValidateJSONWithRepair(t *testing.T) {
 // (unwrapToType peels the layers inside a single repair), never a
 // repair-of-a-repair.
 func TestRepairStringifiedJSON_RepairedAtMostOncePerPath(t *testing.T) {
+	t.Parallel()
 	var schemaMap map[string]interface{}
 	if err := json.Unmarshal(deckPlanSchema(), &schemaMap); err != nil {
 		t.Fatal(err)
@@ -218,6 +220,7 @@ func TestRepairStringifiedJSON_RepairedAtMostOncePerPath(t *testing.T) {
 // TestRepairStringifiedJSON_NeverRepairsStringSchemas exercises the "never
 // repair when the schema expects string" rule directly at the walk level.
 func TestRepairStringifiedJSON_NeverRepairsStringSchemas(t *testing.T) {
+	t.Parallel()
 	schemaMap := map[string]interface{}{
 		"type": "object",
 		"properties": map[string]interface{}{

--- a/internal/llm/tools/shell_description_test.go
+++ b/internal/llm/tools/shell_description_test.go
@@ -9,6 +9,7 @@ import (
 // The model populates `description`; the wrapper decodes with
 // DisallowUnknownFields, so an undeclared field would be a hard error.
 func TestShellDescriptionAccepted(t *testing.T) {
+	t.Parallel()
 	in := `{"command":"git status","description":"Show working tree status"}`
 	var p ShellParams
 	dec := json.NewDecoder(strings.NewReader(in))
@@ -26,6 +27,7 @@ func TestShellDescriptionAccepted(t *testing.T) {
 
 // Omitting it must still work: old transcripts and models that skip it.
 func TestShellDescriptionOptional(t *testing.T) {
+	t.Parallel()
 	var p ShellParams
 	dec := json.NewDecoder(strings.NewReader(`{"command":"ls"}`))
 	dec.DisallowUnknownFields()
@@ -39,6 +41,7 @@ func TestShellDescriptionOptional(t *testing.T) {
 
 // The description must survive re-serialization, which is how it reaches the UI.
 func TestShellDescriptionRoundTrips(t *testing.T) {
+	t.Parallel()
 	p := ShellParams{Command: "ls", Description: "List files in current directory"}
 	b, err := json.Marshal(p)
 	if err != nil {
@@ -51,6 +54,7 @@ func TestShellDescriptionRoundTrips(t *testing.T) {
 
 // Real line breaks, not literal backslash-n, must reach the model.
 func TestShellDescriptionSchemaHasRealNewlines(t *testing.T) {
+	t.Parallel()
 	s := NewShellTool().ParamSchema()
 	prop, ok := s.Properties.Get("description")
 	if !ok {

--- a/internal/llm/tools/shell_search_guard_test.go
+++ b/internal/llm/tools/shell_search_guard_test.go
@@ -10,6 +10,7 @@ import (
 // three fan-out units independently ran a full-disk find. Those calls averaged
 // 268.7s each and five hit the hard timeout at 5m0s.
 func TestUnscopedSearchRefusal(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		command string
@@ -73,6 +74,7 @@ func TestUnscopedSearchRefusal(t *testing.T) {
 // The refusal is only useful if it tells the agent what to do instead. Without
 // the alternative the agent has no way to answer the question it was asking.
 func TestUnscopedSearchRefusalNamesTheScopedAlternative(t *testing.T) {
+	t.Parallel()
 	msg := unscopedSearchRefusal(`find / -path "*forge/pkg/svcerr*"`)
 	if msg == "" {
 		t.Fatal("expected a refusal")
@@ -91,6 +93,7 @@ func TestUnscopedSearchRefusalNamesTheScopedAlternative(t *testing.T) {
 // Execute returns the refusal as a tool error before touching the daemon, which
 // is why a nil-daemon context still has to be rejected first.
 func TestShellToolRefusesFilesystemWideScan(t *testing.T) {
+	t.Parallel()
 	if unscopedSearchRefusal(`find / -name "*.go"`) == "" {
 		t.Fatal("guard did not fire on the canonical offender")
 	}

--- a/internal/llm/tools/shell_test.go
+++ b/internal/llm/tools/shell_test.go
@@ -15,6 +15,7 @@ import (
 // a JSON envelope larger than MaxOutputSize and the generic tool_wrapper
 // truncation head+tail-cut the JSON string, corrupting the envelope.
 func TestFitBashOutputToBudget(t *testing.T) {
+	t.Parallel()
 	// ~44KB stdout + ~20KB stderr: comfortably over the budget once encoded.
 	stdout := strings.Repeat("stdout line of output\n", 2000)
 	stderr := strings.Repeat("stderr warning line\n", 1000)
@@ -47,6 +48,7 @@ func TestFitBashOutputToBudget(t *testing.T) {
 // TestFitBashOutputToBudget_SmallOutputUnchanged verifies output that already
 // fits is returned verbatim (no needless truncation markers).
 func TestFitBashOutputToBudget_SmallOutputUnchanged(t *testing.T) {
+	t.Parallel()
 	stdout := "hello world\n"
 	stderr := "a warning\n"
 
@@ -59,6 +61,7 @@ func TestFitBashOutputToBudget_SmallOutputUnchanged(t *testing.T) {
 // TestFitBashOutputToBudget_LargeStdoutEmptyStderr covers the common case of a
 // chatty command with no stderr.
 func TestFitBashOutputToBudget_LargeStdoutEmptyStderr(t *testing.T) {
+	t.Parallel()
 	stdout := strings.Repeat("x", 60000)
 
 	o, e := fitBashOutputToBudget(stdout, "", 1, MaxOutputSize)

--- a/internal/llm/tools/shell_timing_test.go
+++ b/internal/llm/tools/shell_timing_test.go
@@ -60,6 +60,7 @@ func runShell(t *testing.T, d *stallDaemon) (BashOutput, ShellResponseMetadata) 
 // what makes a future "why did that take ten minutes?" answerable from the
 // stored transcript instead of from four independent lines of evidence.
 func TestShell_DurationAlwaysInMetadata(t *testing.T) {
+	t.Parallel()
 	_, meta := runShell(t, &stallDaemon{stall: 0, durationMs: 1234})
 
 	if meta.CommandDurationMs != 1234 {
@@ -73,6 +74,7 @@ func TestShell_DurationAlwaysInMetadata(t *testing.T) {
 // cost across thousands of calls; the signal is the DISAGREEMENT, not the
 // number.
 func TestShell_NoTimingBlockWhenClocksAgree(t *testing.T) {
+	t.Parallel()
 	out, _ := runShell(t, &stallDaemon{stall: 0, durationMs: 5})
 
 	if out.Timing != nil {
@@ -84,6 +86,7 @@ func TestShell_NoTimingBlockWhenClocksAgree(t *testing.T) {
 // gate unattributable: the tool call cost far more wall-clock than the command
 // itself ran. When two independent clocks disagree, say so.
 func TestShell_TimingBlockWhenTransportDominates(t *testing.T) {
+	t.Parallel()
 	out, _ := runShell(t, &stallDaemon{stall: 1500 * time.Millisecond, durationMs: 20})
 
 	if out.Timing == nil {
@@ -105,6 +108,7 @@ func TestShell_TimingBlockWhenTransportDominates(t *testing.T) {
 // genuinely long command with ordinary transport overhead must stay quiet,
 // even though the absolute gap is larger than on a fast call.
 func TestShell_NoTimingBlockForSmallOverheadOnSlowCommand(t *testing.T) {
+	t.Parallel()
 	// 1.2s of stall against a command that ran 300s: a 0.4% overhead.
 	out, _ := runShell(t, &stallDaemon{stall: 1200 * time.Millisecond, durationMs: 300_000})
 

--- a/internal/llm/tools/skill_test.go
+++ b/internal/llm/tools/skill_test.go
@@ -92,6 +92,7 @@ func (e *skillTestEnv) execute(t *testing.T, params SkillParams) ToolResponse {
 // -----------------------------------------------------------------------------
 
 func TestSkillTool_List_EmptyPath_ReturnsTopLevelOnly(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "list"})
@@ -107,6 +108,7 @@ func TestSkillTool_List_EmptyPath_ReturnsTopLevelOnly(t *testing.T) {
 }
 
 func TestSkillTool_List_WithPath_ReturnsChildren(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "list", Path: "go"})
@@ -123,6 +125,7 @@ func TestSkillTool_List_WithPath_ReturnsChildren(t *testing.T) {
 }
 
 func TestSkillTool_List_WithDeepPath_ReturnsChildren(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "list", Path: "go/error-handling"})
@@ -132,6 +135,7 @@ func TestSkillTool_List_WithDeepPath_ReturnsChildren(t *testing.T) {
 }
 
 func TestSkillTool_List_NonexistentPath_ReturnsError(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "list", Path: "nonexistent"})
@@ -140,6 +144,7 @@ func TestSkillTool_List_NonexistentPath_ReturnsError(t *testing.T) {
 }
 
 func TestSkillTool_List_LeafSkill_ReturnsEmpty(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	// 'go/defer' has no sub-skills.
@@ -149,6 +154,7 @@ func TestSkillTool_List_LeafSkill_ReturnsEmpty(t *testing.T) {
 }
 
 func TestSkillTool_List_IncludesDescription(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "list"})
@@ -165,6 +171,7 @@ func TestSkillTool_List_IncludesDescription(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestSkillTool_Load_TopLevelSkill_ReturnsBody(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "load", Path: "go"})
@@ -175,6 +182,7 @@ func TestSkillTool_Load_TopLevelSkill_ReturnsBody(t *testing.T) {
 }
 
 func TestSkillTool_Load_NestedSkill_ReturnsBody(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "load", Path: "go/error-handling"})
@@ -185,6 +193,7 @@ func TestSkillTool_Load_NestedSkill_ReturnsBody(t *testing.T) {
 }
 
 func TestSkillTool_Load_WithSubSkills_AppendsSubSkillsSection(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "load", Path: "go"})
@@ -197,6 +206,7 @@ func TestSkillTool_Load_WithSubSkills_AppendsSubSkillsSection(t *testing.T) {
 }
 
 func TestSkillTool_Load_WithAllowedTools_AppendsToolsSection(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "load", Path: "database-migration"})
@@ -209,6 +219,7 @@ func TestSkillTool_Load_WithAllowedTools_AppendsToolsSection(t *testing.T) {
 }
 
 func TestSkillTool_Load_LeafSkill_NoSubSkillsSection(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "load", Path: "go/defer"})
@@ -220,6 +231,7 @@ func TestSkillTool_Load_LeafSkill_NoSubSkillsSection(t *testing.T) {
 }
 
 func TestSkillTool_Load_NonexistentSkill_ReturnsError(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "load", Path: "nonexistent"})
@@ -228,6 +240,7 @@ func TestSkillTool_Load_NonexistentSkill_ReturnsError(t *testing.T) {
 }
 
 func TestSkillTool_Load_PathNormalization(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	// Case-insensitive lookup is explicitly implemented via strings.ToLower.
@@ -253,6 +266,7 @@ func TestSkillTool_Load_PathNormalization(t *testing.T) {
 }
 
 func TestSkillTool_Load_SiblingsSection(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	// go/defer has sibling go/error-handling
@@ -270,6 +284,7 @@ func TestSkillTool_Load_SiblingsSection(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestSkillTool_Search_FindsByName(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "search", Query: "migration"})
@@ -280,6 +295,7 @@ func TestSkillTool_Search_FindsByName(t *testing.T) {
 }
 
 func TestSkillTool_Search_FindsByDescription(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "search", Query: "error"})
@@ -292,6 +308,7 @@ func TestSkillTool_Search_FindsByDescription(t *testing.T) {
 }
 
 func TestSkillTool_Search_FindsNestedSkills(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "search", Query: "defer"})
@@ -302,6 +319,7 @@ func TestSkillTool_Search_FindsNestedSkills(t *testing.T) {
 }
 
 func TestSkillTool_Search_NoMatches_ReturnsEmptyResults(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "search", Query: "zebra"})
@@ -312,6 +330,7 @@ func TestSkillTool_Search_NoMatches_ReturnsEmptyResults(t *testing.T) {
 }
 
 func TestSkillTool_Search_ShowsFullPath(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "search", Query: "wrap"})
@@ -322,6 +341,7 @@ func TestSkillTool_Search_ShowsFullPath(t *testing.T) {
 }
 
 func TestSkillTool_ListAndSearch_RenderNormalizedStoredSkillPaths(t *testing.T) {
+	t.Parallel()
 	skills := config.NormalizeStoredSkills([]config.StoredSkill{
 		{
 			Name:        "testing-methodology",
@@ -344,6 +364,7 @@ func TestSkillTool_ListAndSearch_RenderNormalizedStoredSkillPaths(t *testing.T) 
 }
 
 func TestSkillTool_Search_EmptyQuery_ReturnsError(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "search", Query: ""})
@@ -356,6 +377,7 @@ func TestSkillTool_Search_EmptyQuery_ReturnsError(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestSkillTool_InvalidAction_ReturnsError(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "delete"})
@@ -368,6 +390,7 @@ func TestSkillTool_InvalidAction_ReturnsError(t *testing.T) {
 }
 
 func TestSkillTool_Load_MissingPath_ReturnsError(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "load"})
@@ -376,6 +399,7 @@ func TestSkillTool_Load_MissingPath_ReturnsError(t *testing.T) {
 }
 
 func TestSkillTool_Search_MissingQuery_ReturnsError(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "search"})
@@ -388,6 +412,7 @@ func TestSkillTool_Search_MissingQuery_ReturnsError(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestSkillsAnnouncement_OnlyTopLevel(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 	got := SkillsAnnouncement(env.tool.skills)
 
@@ -402,6 +427,7 @@ func TestSkillsAnnouncement_OnlyTopLevel(t *testing.T) {
 }
 
 func TestSkillsAnnouncement_EmptyReturnsEmpty(t *testing.T) {
+	t.Parallel()
 	got := SkillsAnnouncement(nil)
 	assert.Empty(t, got)
 }
@@ -454,6 +480,7 @@ func newForgeNamespaceEnv() *skillTestEnv {
 // independently called `skill load frontend/design` — the path `forge skill
 // list` prints and `forge skill load` accepts — and each got a 404.
 func TestSkillTool_Load_AcceptsPathForgePrints(t *testing.T) {
+	t.Parallel()
 	env := newForgeNamespaceEnv()
 
 	for _, path := range []string{"frontend/design", "forge/frontend/design", "FRONTEND/DESIGN", "  frontend/design  "} {
@@ -466,6 +493,7 @@ func TestSkillTool_Load_AcceptsPathForgePrints(t *testing.T) {
 // forge's skill bodies cross-reference each other unprefixed, so following a
 // skill's own advice has to work.
 func TestSkillTool_Load_AcceptsUnprefixedCrossReference(t *testing.T) {
+	t.Parallel()
 	env := newForgeNamespaceEnv()
 
 	resp := env.execute(t, SkillParams{Action: "load", Path: "frontend/state"})
@@ -480,6 +508,7 @@ func TestSkillTool_Load_AcceptsUnprefixedCrossReference(t *testing.T) {
 // Listing a group by the name forge prints must list that group's children,
 // and must echo the prefixed path those children carry.
 func TestSkillTool_List_AcceptsPathForgePrints(t *testing.T) {
+	t.Parallel()
 	env := newForgeNamespaceEnv()
 
 	resp := env.execute(t, SkillParams{Action: "list", Path: "frontend"})
@@ -493,6 +522,7 @@ func TestSkillTool_List_AcceptsPathForgePrints(t *testing.T) {
 // A multi-repo project stacks "<repo>/" on top of "forge/". The bare path is
 // still what forge prints, so it still has to resolve.
 func TestSkillTool_Load_AcceptsPathForgePrints_NestedRepo(t *testing.T) {
+	t.Parallel()
 	env := &skillTestEnv{tool: &skillTool{skills: []config.StoredSkill{
 		{SkillPath: "api/forge/frontend/design", Name: "frontend-design", Body: "# Nested design", Source: "api"},
 	}}}
@@ -505,6 +535,7 @@ func TestSkillTool_Load_AcceptsPathForgePrints_NestedRepo(t *testing.T) {
 // An exact match must never be shadowed by a suffix match, or a project skill
 // could be silently replaced by a forge skill of the same name.
 func TestSkillTool_Load_ExactMatchBeatsSuffixMatch(t *testing.T) {
+	t.Parallel()
 	env := &skillTestEnv{tool: &skillTool{skills: []config.StoredSkill{
 		{SkillPath: "deploy", Name: "deploy", Body: "# Project deploy"},
 		{SkillPath: "forge/deploy", Name: "deploy", Body: "# Forge deploy"},
@@ -519,6 +550,7 @@ func TestSkillTool_Load_ExactMatchBeatsSuffixMatch(t *testing.T) {
 // Two equally-good suffix candidates must not be guessed between — the caller
 // gets the "did you mean" list instead.
 func TestSkillTool_Load_AmbiguousSuffix_ReturnsCandidates(t *testing.T) {
+	t.Parallel()
 	env := &skillTestEnv{tool: &skillTool{skills: []config.StoredSkill{
 		{SkillPath: "api/forge/db", Name: "db", Body: "# API db"},
 		{SkillPath: "web/forge/db", Name: "db", Body: "# Web db"},
@@ -533,6 +565,7 @@ func TestSkillTool_Load_AmbiguousSuffix_ReturnsCandidates(t *testing.T) {
 // The suffix match is component-aligned — a bare word must not match the tail
 // of a longer path component.
 func TestSkillTool_Load_SuffixMatchIsComponentAligned(t *testing.T) {
+	t.Parallel()
 	env := &skillTestEnv{tool: &skillTool{skills: []config.StoredSkill{
 		{SkillPath: "forge/frontend-design", Name: "frontend-design", Body: "# Hyphenated"},
 	}}}
@@ -628,6 +661,7 @@ func listedSkillPaths(content string) []string {
 // `list frontend` answered "no sub-skills found under: frontend" while
 // `load frontend/design` happily loaded one of its members.
 func TestSkillTool_List_NamespaceAgreesWithLoad(t *testing.T) {
+	t.Parallel()
 	env := newForgeProjectSkillsEnv()
 
 	want := addressableNamespaces(env.tool.skills)
@@ -664,6 +698,7 @@ func TestSkillTool_List_NamespaceAgreesWithLoad(t *testing.T) {
 // A path with genuinely nothing under it must say so actionably — naming the
 // namespaces that do exist, so the agent can retry instead of giving up.
 func TestSkillTool_List_EmptyNamespace_NamesExistingNamespaces(t *testing.T) {
+	t.Parallel()
 	env := newForgeProjectSkillsEnv()
 
 	resp := env.execute(t, SkillParams{Action: "list", Path: "nonexistent"})

--- a/internal/llm/tools/skill_window_test.go
+++ b/internal/llm/tools/skill_window_test.go
@@ -65,6 +65,7 @@ func newOversizeSkillEnv() *skillTestEnv {
 // remains. Without this an agent cannot tell a complete result from a cut one,
 // which is what drives the observed "load then sed -n" recovery round-trips.
 func TestSkillTool_Load_Oversize_ReportsTotalSizeAndHasMore(t *testing.T) {
+	t.Parallel()
 	env := newOversizeSkillEnv()
 	full := oversizeSkillBody()
 
@@ -116,6 +117,7 @@ func extractContinueOffset(t *testing.T, resp ToolResponse) int {
 // defensive paging: the observed agent paged a 15,231-byte skill that was never
 // truncated, purely because the result did not say it was complete.
 func TestSkillTool_Load_UnderBudget_ReportsCompleteDelivery(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "load", Path: "go/defer"})
@@ -133,6 +135,7 @@ func TestSkillTool_Load_UnderBudget_ReportsCompleteDelivery(t *testing.T) {
 // tail. Telling it to open SKILL.md on disk is not actionable when skills are
 // embedded in a binary and synced through the config pipeline.
 func TestSkillTruncationNotice_NamesToolParametersNotDisk(t *testing.T) {
+	t.Parallel()
 	notice := skillTruncationNotice(50_000, 26_000)
 
 	assert.NotContains(t, notice, "SKILL.md",
@@ -146,6 +149,7 @@ func TestSkillTruncationNotice_NamesToolParametersNotDisk(t *testing.T) {
 // The whole point: content dropped from the default load must be reachable
 // through the tool. This walks the exact recovery an agent would perform.
 func TestSkillTool_Load_Oversize_TailReachableByOffset(t *testing.T) {
+	t.Parallel()
 	env := newOversizeSkillEnv()
 
 	first := env.execute(t, SkillParams{Action: "load", Path: "db"})
@@ -177,6 +181,7 @@ func TestSkillTool_Load_Oversize_TailReachableByOffset(t *testing.T) {
 // Capping in the tool rather than leaving it to the wrapper is what keeps the
 // footer (the part naming the next call) from being cut off.
 func TestSkillTool_Load_Window_RespectsBudgetIncludingFooter(t *testing.T) {
+	t.Parallel()
 	env := newOversizeSkillEnv()
 
 	for _, offset := range []int{0, 1, 12_000, 23_999} {
@@ -192,6 +197,7 @@ func TestSkillTool_Load_Window_RespectsBudgetIncludingFooter(t *testing.T) {
 // Section-aware retrieval: an agent that saw the outline can fetch the section
 // it needs in one targeted call rather than guessing a byte range.
 func TestSkillTool_Load_Section_FetchesNamedSectionOnly(t *testing.T) {
+	t.Parallel()
 	env := newOversizeSkillEnv()
 
 	resp := env.execute(t, SkillParams{Action: "load", Path: "db", Section: "FKs And Diamonds"})
@@ -206,6 +212,7 @@ func TestSkillTool_Load_Section_FetchesNamedSectionOnly(t *testing.T) {
 // the agent learns the section names from the same call that told it the skill
 // was too big.
 func TestSkillTool_Load_Oversize_ListsSectionsForFollowUp(t *testing.T) {
+	t.Parallel()
 	env := newOversizeSkillEnv()
 
 	resp := env.execute(t, SkillParams{Action: "load", Path: "db"})
@@ -220,6 +227,7 @@ func TestSkillTool_Load_Oversize_ListsSectionsForFollowUp(t *testing.T) {
 // Section names are matched case-insensitively and by unique substring, so an
 // agent that half-remembers a heading still lands on it.
 func TestSkillTool_Load_Section_ResolvesLoosely(t *testing.T) {
+	t.Parallel()
 	env := newOversizeSkillEnv()
 
 	resp := env.execute(t, SkillParams{Action: "load", Path: "db", Section: "diamonds"})
@@ -229,6 +237,7 @@ func TestSkillTool_Load_Section_ResolvesLoosely(t *testing.T) {
 
 // A miss must name the real sections rather than dead-ending.
 func TestSkillTool_Load_Section_UnknownNamesRealSections(t *testing.T) {
+	t.Parallel()
 	env := newOversizeSkillEnv()
 
 	resp := env.execute(t, SkillParams{Action: "load", Path: "db", Section: "no-such-section"})
@@ -238,6 +247,7 @@ func TestSkillTool_Load_Section_UnknownNamesRealSections(t *testing.T) {
 
 // The filter path: locate content in a large skill without paging to it.
 func TestSkillTool_Load_Regex_DeliversMatchingLinesWithNumbers(t *testing.T) {
+	t.Parallel()
 	env := newOversizeSkillEnv()
 
 	resp := env.execute(t, SkillParams{Action: "load", Path: "db", Regex: "DIAMOND MARKER"})
@@ -251,6 +261,7 @@ func TestSkillTool_Load_Regex_DeliversMatchingLinesWithNumbers(t *testing.T) {
 }
 
 func TestSkillTool_Load_Regex_ContextLinesAreIncluded(t *testing.T) {
+	t.Parallel()
 	env := newOversizeSkillEnv()
 
 	resp := env.execute(t, SkillParams{
@@ -263,6 +274,7 @@ func TestSkillTool_Load_Regex_ContextLinesAreIncluded(t *testing.T) {
 }
 
 func TestSkillTool_Load_Regex_CaseInsensitive(t *testing.T) {
+	t.Parallel()
 	env := newOversizeSkillEnv()
 
 	sensitive := env.execute(t, SkillParams{Action: "load", Path: "db", Regex: "diamond marker"})
@@ -278,6 +290,7 @@ func TestSkillTool_Load_Regex_CaseInsensitive(t *testing.T) {
 
 // A filter with no hits must still tell the agent what the skill contains.
 func TestSkillTool_Load_Regex_NoMatchesOffersSections(t *testing.T) {
+	t.Parallel()
 	env := newOversizeSkillEnv()
 
 	resp := env.execute(t, SkillParams{Action: "load", Path: "db", Regex: "zzz-not-present"})
@@ -289,6 +302,7 @@ func TestSkillTool_Load_Regex_NoMatchesOffersSections(t *testing.T) {
 
 // Headings inside fenced code blocks are shell comments, not sections.
 func TestSkillSections_IgnoresFencedCodeBlocks(t *testing.T) {
+	t.Parallel()
 	body := "# Title\n\n```bash\n# not a heading\nls\n```\n\n## Real Section\n\nbody\n"
 
 	var titles []string
@@ -301,6 +315,7 @@ func TestSkillSections_IgnoresFencedCodeBlocks(t *testing.T) {
 }
 
 func TestSkillTool_Load_RejectsContradictorySelectors(t *testing.T) {
+	t.Parallel()
 	env := newOversizeSkillEnv()
 
 	resp := env.execute(t, SkillParams{Action: "load", Path: "db", Section: "Seeding", Regex: "x"})
@@ -316,6 +331,7 @@ func TestSkillTool_Load_RejectsContradictorySelectors(t *testing.T) {
 // tools — must be byte-identical to today. The delivery footer is additive and
 // appended after it.
 func TestSkillTool_Load_NormalSkill_ContentPrefixUnchanged(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	resp := env.execute(t, SkillParams{Action: "load", Path: "go"})
@@ -335,6 +351,7 @@ func TestSkillTool_Load_NormalSkill_ContentPrefixUnchanged(t *testing.T) {
 // bytes into the cached prompt prefix, where a per-call delivery footer would
 // be both meaningless and permanently resident.
 func TestLoadSkillForInjection_ExcludesDeliveryFooter(t *testing.T) {
+	t.Parallel()
 	env := newSkillTestEnv(t)
 
 	_, body, ok := LoadSkillForInjection(env.tool.skills, "go/defer")

--- a/internal/llm/tools/spawn_send_test.go
+++ b/internal/llm/tools/spawn_send_test.go
@@ -72,6 +72,7 @@ func runSpawnSend(t *testing.T, tool Tool, rc *rctx.ToolContext, params SpawnSen
 }
 
 func TestSpawnSend_ToRunningChild_QueuesHonestReceipt(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -115,6 +116,7 @@ func (n *recordingAgentMessageNotifier) NotifyAgentMessageQueued(_ context.Conte
 // this child is the last one, the parent's gate wakes for the completion,
 // exits, and the message is marked undelivered having never been read.
 func TestSpawnSend_ChildToParent_RingsMailboxDoorbell(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -146,6 +148,7 @@ func TestSpawnSend_ChildToParent_RingsMailboxDoorbell(t *testing.T) {
 // A refused send must not ring the doorbell: there is no row to drain, and
 // waking a parked parent to find an empty mailbox is a wasted turn.
 func TestSpawnSend_RefusedSend_DoesNotRingDoorbell(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -167,6 +170,7 @@ func TestSpawnSend_RefusedSend_DoesNotRingDoorbell(t *testing.T) {
 // with no Temporal connection at all, and spawn_send has to keep working
 // there — degraded to next-boundary delivery, not broken.
 func TestSpawnSend_NilNotifier_StillQueues(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -190,6 +194,7 @@ func TestSpawnSend_NilNotifier_StillQueues(t *testing.T) {
 // regression: messaging a finished agent must fail loudly with a pointer to
 // spawn(agent_id=...), never silently no-op or resurrect the thread.
 func TestSpawnSend_ToFinishedAgent_FailsWithGuidance(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -212,6 +217,7 @@ func TestSpawnSend_ToFinishedAgent_FailsWithGuidance(t *testing.T) {
 }
 
 func TestSpawnSend_ToSibling_Rejected(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -239,6 +245,7 @@ func TestSpawnSend_ToSibling_Rejected(t *testing.T) {
 // A sub-agent messaging its own parent is the reverse relationship spawn_send
 // must also allow per spec §4.4/§4.3.
 func TestSpawnSend_ChildToParent_Allowed(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 	ctx := context.Background()

--- a/internal/llm/tools/spawn_status_test.go
+++ b/internal/llm/tools/spawn_status_test.go
@@ -58,6 +58,7 @@ func seedMessage(t *testing.T, repo db.Repository, ctx context.Context, chatID, 
 // belonging to an unrelated parent thread in the same chat must never leak
 // into the listing, even though they share a chat_id.
 func TestSpawnStatus_Listing_OnlyReturnsCallersOwnChildren(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -88,6 +89,7 @@ func TestSpawnStatus_Listing_OnlyReturnsCallersOwnChildren(t *testing.T) {
 }
 
 func TestSpawnStatus_Listing_NoChildren_ReturnsFriendlyMessage(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -114,6 +116,7 @@ func TestSpawnStatus_Listing_NoChildren_ReturnsFriendlyMessage(t *testing.T) {
 // Single-agent mode must reject an agent_id that is not the caller's own
 // spawn child — it must not be usable as a general "peek at any thread" tool.
 func TestSpawnStatus_SingleAgent_RejectsNonChildAgent(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -132,6 +135,7 @@ func TestSpawnStatus_SingleAgent_RejectsNonChildAgent(t *testing.T) {
 }
 
 func TestSpawnStatus_SingleAgent_OwnChildWithNoMessages_ReturnsFriendlyMessage(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -152,6 +156,7 @@ func TestSpawnStatus_SingleAgent_OwnChildWithNoMessages_ReturnsFriendlyMessage(t
 // first one and not a concatenation of all of them — an orchestrator wants
 // the agent's current answer, not its whole history.
 func TestSpawnStatus_SingleAgent_ReturnsLastAssistantMessage_NotFirstOrConcatenated(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -180,6 +185,7 @@ func TestSpawnStatus_SingleAgent_ReturnsLastAssistantMessage_NotFirstOrConcatena
 // A child that is already terminal at call time must return promptly with
 // wait: true — no reason to poll or block at all.
 func TestSpawnStatus_Wait_ReturnsPromptlyWhenAlreadyTerminal(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -206,6 +212,7 @@ func TestSpawnStatus_Wait_ReturnsPromptlyWhenAlreadyTerminal(t *testing.T) {
 // full budget and then saying "not found" wastes exactly the time waiting
 // exists to save.
 func TestSpawnStatus_Wait_UnknownAgentFailsFast(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -229,6 +236,7 @@ func TestSpawnStatus_Wait_UnknownAgentFailsFast(t *testing.T) {
 // result once its (short) budget elapses, and must not have touched the
 // agent.
 func TestSpawnStatus_Wait_TimeoutIsNotAnError(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -263,6 +271,7 @@ func TestSpawnStatus_Wait_TimeoutIsNotAnError(t *testing.T) {
 // already-terminal agent proves the call still completes normally rather
 // than erroring on the oversized value.
 func TestSpawnStatus_Wait_ClampsTimeoutAboveCeiling(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 	ctx := context.Background()

--- a/internal/llm/tools/spawn_tools_registration_test.go
+++ b/internal/llm/tools/spawn_tools_registration_test.go
@@ -6,6 +6,7 @@ import "testing"
 // spawn_status must NOT be orchestrator-tier: an agent that already holds a
 // handle to a sub-agent it spawned needs no extra privilege to observe it.
 func TestSpawnStatus_IsNotOrchestratorTier(t *testing.T) {
+	t.Parallel()
 	if got := MinimumPermissionForTool(ToolSpawnStatus); got == PermissionOrchestrator {
 		t.Errorf("spawn_status must not require orchestrator permission — a depth-1 sub-agent could never check its own children")
 	}
@@ -15,6 +16,7 @@ func TestSpawnStatus_IsNotOrchestratorTier(t *testing.T) {
 // they must be present in the master name list validators check requests
 // against.
 func TestSpawnTools_AreRegistered(t *testing.T) {
+	t.Parallel()
 	names := map[string]bool{ToolSpawnStatus: false, ToolSpawnSend: false}
 	for _, def := range GetToolRegistry() {
 		if _, ok := names[def.Name]; ok {
@@ -32,6 +34,7 @@ func TestSpawnTools_AreRegistered(t *testing.T) {
 // and tag:readonly filters (plan mode) should still be able to pick it up
 // once permission allows it.
 func TestSpawnStatus_IsReadOnlyTagged(t *testing.T) {
+	t.Parallel()
 	found := false
 	for _, def := range GetToolRegistry() {
 		if def.Name != ToolSpawnStatus {
@@ -57,6 +60,7 @@ func TestSpawnStatus_IsReadOnlyTagged(t *testing.T) {
 // list their names — a name present in the registry but unreachable through
 // the factory is effectively unregistered.
 func TestSpawnTools_ConstructibleViaFactory(t *testing.T) {
+	t.Parallel()
 	factory := NewToolsFactory(&ToolsOptions{})
 	for _, name := range []string{ToolSpawnStatus, ToolSpawnSend} {
 		tool := factory.GetToolByName(name, nil)

--- a/internal/llm/tools/task_ordinal_test.go
+++ b/internal/llm/tools/task_ordinal_test.go
@@ -24,6 +24,7 @@ import (
 // task title, so the only way to notice was to read the response closely and
 // realise it named the wrong one.
 func TestUpdateTask_OrdinalIsOneIndexed(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 

--- a/internal/llm/tools/tool_schema_validation_test.go
+++ b/internal/llm/tools/tool_schema_validation_test.go
@@ -10,6 +10,7 @@ import (
 // TestAllToolsSchemasResolved verifies that all registered tools have schemas
 // without $ref or $defs, as required by the Anthropic API
 func TestAllToolsSchemasResolved(t *testing.T) {
+	t.Parallel()
 	// Create factory
 	factory := NewToolsFactory(&ToolsOptions{})
 

--- a/internal/llm/tools/tools_test.go
+++ b/internal/llm/tools/tools_test.go
@@ -44,6 +44,7 @@ func (m *mockReadOnlyTool) IsReadOnly() bool {
 }
 
 func TestIsToolReadOnly(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		tool     Tool

--- a/internal/llm/tools/unwrap_test.go
+++ b/internal/llm/tools/unwrap_test.go
@@ -33,6 +33,7 @@ func unwrapArraySchema() *jsonschema.Schema {
 }
 
 func TestUnwrapStringifiedValues(t *testing.T) {
+	t.Parallel()
 	arraySchema := unwrapArraySchema()
 
 	// Create a test schema with various types
@@ -125,6 +126,7 @@ func TestUnwrapStringifiedValues(t *testing.T) {
 }
 
 func TestUnwrapStringifiedValues_DoubleStringified(t *testing.T) {
+	t.Parallel()
 	schema := unwrapArraySchema()
 
 	// items arrives as a JSON string whose contents are *themselves* a JSON
@@ -147,6 +149,7 @@ func TestUnwrapStringifiedValues_DoubleStringified(t *testing.T) {
 }
 
 func TestUnwrapStringifiedValues_WholeObjectStringified(t *testing.T) {
+	t.Parallel()
 	schema := unwrapArraySchema()
 
 	// The entire argument payload arrived as a JSON-encoded string rather than
@@ -160,6 +163,7 @@ func TestUnwrapStringifiedValues_WholeObjectStringified(t *testing.T) {
 }
 
 func TestUnwrapStringifiedObject(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   string
@@ -183,6 +187,7 @@ func TestUnwrapStringifiedObject(t *testing.T) {
 }
 
 func TestUnwrapToType(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		strVal string
@@ -208,6 +213,7 @@ func TestUnwrapToType(t *testing.T) {
 }
 
 func TestUnwrapStringifiedValues_NilSchema(t *testing.T) {
+	t.Parallel()
 	input := `{"items": "[{\"file_path\": \"/test.go\"}]"}`
 	result := unwrapStringifiedValues(input, nil)
 
@@ -217,6 +223,7 @@ func TestUnwrapStringifiedValues_NilSchema(t *testing.T) {
 }
 
 func TestUnwrapStringifiedValues_InvalidJSON(t *testing.T) {
+	t.Parallel()
 	schema := unwrapArraySchema()
 
 	input := `{invalid json}`

--- a/internal/llm/tools/view_test.go
+++ b/internal/llm/tools/view_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestViewToolLimitLogic(t *testing.T) {
+	t.Parallel()
 	// Create a temporary test file with known content
 	tempDir := t.TempDir()
 	testFile := filepath.Join(tempDir, "test.txt")
@@ -112,6 +113,7 @@ func TestViewToolLimitLogic(t *testing.T) {
 }
 
 func TestViewToolLimitEdgeCases(t *testing.T) {
+	t.Parallel()
 	// Create a temporary test file with exactly 1000 lines
 	tempDir := t.TempDir()
 	testFile := filepath.Join(tempDir, "large_test.txt")
@@ -168,6 +170,7 @@ func newViewTestCtx(t *testing.T, dir string) *rctx.ToolContext {
 }
 
 func TestViewBinaryAndPDFDetection(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	tool := &viewTool{}
 	ctx := newViewTestCtx(t, tempDir)
@@ -334,6 +337,7 @@ func buildTestPDF(n int) []byte {
 // `offset: 1`, and one cost a scaffolded file its `"use client";` directive when
 // the agent composed the file back from what it had read.
 func TestViewReturnsTheFirstLine(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	tool := &viewTool{}
 	worktree := &rctx.WorktreeInfo{ID: "test", Path: dir}

--- a/internal/llm/tools/websearch_demo_test.go
+++ b/internal/llm/tools/websearch_demo_test.go
@@ -28,6 +28,7 @@ import (
 //
 //	RELIANT_TEST_NETWORK=1 go test ./internal/llm/tools/ -run TestWebSearchDemo
 func TestWebSearchDemo(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping demo test in short mode")
 	}
@@ -120,6 +121,7 @@ func TestWebSearchDemo(t *testing.T) {
 
 // TestWebSearchToolSchema verifies the tool schema is properly generated
 func TestWebSearchToolSchema(t *testing.T) {
+	t.Parallel()
 	tool := NewWebSearchTool()
 
 	// Verify the tool has a schema

--- a/internal/llm/tools/websearch_mock_test.go
+++ b/internal/llm/tools/websearch_mock_test.go
@@ -12,6 +12,7 @@ import (
 // TestExtractActualURL tests the URL extraction logic
 
 func TestExtractActualURL(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -48,6 +49,7 @@ func TestExtractActualURL(t *testing.T) {
 }
 
 func TestFormatWebSearchResults(t *testing.T) {
+	t.Parallel()
 	results := []searchResult{
 		{
 			Title:       "Test Result 1",
@@ -86,6 +88,7 @@ func TestFormatWebSearchResults(t *testing.T) {
 }
 
 func TestFormatWebSearchResultsEmpty(t *testing.T) {
+	t.Parallel()
 	results := []searchResult{}
 	params := WebSearchParams{
 		Query: "no results query",
@@ -101,6 +104,7 @@ func TestFormatWebSearchResultsEmpty(t *testing.T) {
 }
 
 func TestWebSearchToolMetadata(t *testing.T) {
+	t.Parallel()
 	tool := NewWebSearchTool()
 	typedTool := tool.(*ToolWrapper[WebSearchParams, ToolResponse])
 
@@ -150,6 +154,7 @@ func TestWebSearchToolMetadata(t *testing.T) {
 }
 
 func TestWebSearchToolCountLimits(t *testing.T) {
+	t.Parallel()
 
 	t.Run("CountAboveMax", func(t *testing.T) {
 		params := WebSearchParams{

--- a/internal/llm/tools/websearch_query_test.go
+++ b/internal/llm/tools/websearch_query_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestValidateSearchQuery(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		query          string
@@ -113,6 +114,7 @@ func searchSubstring(s, substr string) bool {
 }
 
 func TestFormatWebSearchResultsZeroResults(t *testing.T) {
+	t.Parallel()
 	params := WebSearchParams{
 		Query: "test query",
 		Count: 10,

--- a/internal/llm/tools/websearch_test.go
+++ b/internal/llm/tools/websearch_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestWebSearchTool(t *testing.T) {
+	t.Parallel()
 	tool := NewWebSearchTool()
 
 	assert.Equal(t, WebSearchToolName, tool.Name())
@@ -56,6 +57,7 @@ func TestWebSearchTool(t *testing.T) {
 }
 
 func TestWebSearchToolValidation(t *testing.T) {
+	t.Parallel()
 	tool := NewWebSearchTool()
 	typedTool := tool.(*ToolWrapper[WebSearchParams, ToolResponse])
 

--- a/internal/llm/tools/workflow_editing_test.go
+++ b/internal/llm/tools/workflow_editing_test.go
@@ -67,6 +67,7 @@ edges: []
 // =============================================================================
 
 func TestWriteWorkflow_RequiresID(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 
@@ -215,6 +216,7 @@ edges: []
 }
 
 func TestWriteWorkflow_UpdateExisting(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 
@@ -295,6 +297,7 @@ edges: []
 }
 
 func TestWriteWorkflow_ConflictDetection(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 
@@ -370,6 +373,7 @@ func TestWriteWorkflow_ConflictDetection(t *testing.T) {
 }
 
 func TestWriteWorkflow_ValidationErrors(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 
@@ -470,6 +474,7 @@ nodes:
 }
 
 func TestWriteWorkflow_ResponseStructure(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 
@@ -532,6 +537,7 @@ func TestWriteWorkflow_ResponseStructure(t *testing.T) {
 // =============================================================================
 
 func TestCreateWorkflow_DefaultTemplate(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 
@@ -561,6 +567,7 @@ func TestCreateWorkflow_DefaultTemplate(t *testing.T) {
 }
 
 func TestCreateWorkflow_WithName(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 
@@ -587,6 +594,7 @@ func TestCreateWorkflow_WithName(t *testing.T) {
 }
 
 func TestCreateWorkflow_WithContent(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 
@@ -613,6 +621,7 @@ func TestCreateWorkflow_WithContent(t *testing.T) {
 }
 
 func TestCreateWorkflow_WithInvalidContent(t *testing.T) {
+	t.Parallel()
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 

--- a/internal/llm/tools/workflow_suggestions_test.go
+++ b/internal/llm/tools/workflow_suggestions_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestGetWorkflowSuggestionsTool(t *testing.T) {
+	t.Parallel()
 	tool := NewGetWorkflowSuggestionsTool()
 	typedTool := tool.(*ToolWrapper[GetWorkflowSuggestionsParams, ToolResponse])
 

--- a/internal/llm/tools/write_test.go
+++ b/internal/llm/tools/write_test.go
@@ -15,6 +15,7 @@ import (
 // read-before-write guard: writing an existing-but-unread file now SUCCEEDS and
 // the model-visible content carries a compact diff of what was overwritten.
 func TestWriteTool_ExistingUnreadFile_SucceedsWithDiff(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	testFile := filepath.Join(tempDir, "notes.txt")
 	require.NoError(t, os.WriteFile(testFile, []byte("original line 1\noriginal line 2\n"), 0644))
@@ -57,6 +58,7 @@ func TestWriteTool_ExistingUnreadFile_SucceedsWithDiff(t *testing.T) {
 // guard remains a HARD ERROR: a file read, then modified externally, then
 // written must be rejected to protect against multi-agent data loss.
 func TestWriteTool_ConcurrentModification_StillErrors(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	testFile := filepath.Join(tempDir, "shared.txt")
 	require.NoError(t, os.WriteFile(testFile, []byte("v1\n"), 0644))
@@ -93,6 +95,7 @@ func TestWriteTool_ConcurrentModification_StillErrors(t *testing.T) {
 // specific to unread overwrites: a properly-read file overwrite succeeds with a
 // plain success message and no diff note.
 func TestWriteTool_ReadThenWrite_NoClobberNote(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	testFile := filepath.Join(tempDir, "known.txt")
 	require.NoError(t, os.WriteFile(testFile, []byte("aaa\n"), 0644))

--- a/internal/servergateway/daemon_connector_h2c_test.go
+++ b/internal/servergateway/daemon_connector_h2c_test.go
@@ -96,6 +96,7 @@ func startTestDaemonServer(t *testing.T) (baseURL string, opened <-chan struct{}
 // times out on stream.Receive() within 10s. If it passes, the bug must
 // require the cluster environment (NetworkPolicy, MTU, kube-proxy, etc).
 func TestH2cBidiReceive(t *testing.T) {
+	t.Parallel()
 	baseURL, streamOpened, stop := startTestDaemonServer(t)
 	defer stop()
 

--- a/internal/servergateway/daemon_connector_test.go
+++ b/internal/servergateway/daemon_connector_test.go
@@ -16,6 +16,7 @@ func newTestConnector() *DaemonConnector {
 }
 
 func TestStartConnection_AddsToActiveConns(t *testing.T) {
+	t.Parallel()
 	dc := newTestConnector()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -32,6 +33,7 @@ func TestStartConnection_AddsToActiveConns(t *testing.T) {
 }
 
 func TestStopConnection_CancelsActiveConnection(t *testing.T) {
+	t.Parallel()
 	dc := newTestConnector()
 
 	connCtx, connCancel := context.WithCancel(context.Background())
@@ -47,6 +49,7 @@ func TestStopConnection_CancelsActiveConnection(t *testing.T) {
 }
 
 func TestStopConnection_UnknownDaemon_NoOp(t *testing.T) {
+	t.Parallel()
 	dc := newTestConnector()
 
 	// Should not panic.
@@ -58,6 +61,7 @@ func TestStopConnection_UnknownDaemon_NoOp(t *testing.T) {
 }
 
 func TestStartConnection_ReplacesExisting(t *testing.T) {
+	t.Parallel()
 	dc := newTestConnector()
 	ctx := context.Background()
 
@@ -77,6 +81,7 @@ func TestStartConnection_ReplacesExisting(t *testing.T) {
 }
 
 func TestCloseAll_CancelsAllConnections(t *testing.T) {
+	t.Parallel()
 	dc := newTestConnector()
 
 	ctx1, cancel1 := context.WithCancel(context.Background())

--- a/internal/servergateway/flowhealth_test.go
+++ b/internal/servergateway/flowhealth_test.go
@@ -41,6 +41,7 @@ func held(daemonID string, connectedAt, lastActivity time.Time) services.HeldDae
 }
 
 func TestDaemonFlowHealth_Pure(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	long := now.Add(-2 * time.Hour)         // connected long enough to be evidence
 	fresh := now.Add(-10 * time.Second)     // lease renewed / stream exchanging
@@ -191,6 +192,7 @@ func serveFlowHealth(t *testing.T, lister flowHealthAttachmentLister, streams fl
 }
 
 func TestFlowHealthHandler_Healthy200(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	long := now.Add(-time.Hour)
 	rr := serveFlowHealth(t,
@@ -217,6 +219,7 @@ func TestFlowHealthHandler_Healthy200(t *testing.T) {
 // over EVERY row in the table, so those two orphans held the whole
 // environment at 503 permanently and dragged `forge env smoke` red with it.
 func TestFlowHealthHandler_OrphanRowsStayGreen(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	long := now.Add(-time.Hour)
 	rr := serveFlowHealth(t,
@@ -244,6 +247,7 @@ func TestFlowHealthHandler_OrphanRowsStayGreen(t *testing.T) {
 // for: a daemon this gateway is actively serving whose lease has stopped
 // being renewed — inbound traffic has died while we keep talking into it.
 func TestFlowHealthHandler_StaleLiveAttachment503(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	rr := serveFlowHealth(t,
 		fakeLister{attachments: []*db.DaemonAttachment{att("a", now.Add(-10*time.Minute))}},
@@ -265,6 +269,7 @@ func TestFlowHealthHandler_StaleLiveAttachment503(t *testing.T) {
 // The alternative ("at least one daemon must be attached") is precisely the
 // unachievable assertion that made this endpoint permanently red.
 func TestFlowHealthHandler_EmptyRegistry200(t *testing.T) {
+	t.Parallel()
 	rr := serveFlowHealth(t, fakeLister{}, fakeStreams{}, "")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200 on an empty registry, got %d (%s)", rr.Code, rr.Body.String())
@@ -282,6 +287,7 @@ func TestFlowHealthHandler_EmptyRegistry200(t *testing.T) {
 // also tightened the in-memory window the stream would look dead to the
 // sweeper instead and the knob would cancel itself out.
 func TestFlowHealthHandler_StaleAfterKnob(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	rr := serveFlowHealth(t,
 		fakeLister{attachments: []*db.DaemonAttachment{att("a", now.Add(-1*time.Second))}},
@@ -298,6 +304,7 @@ func TestFlowHealthHandler_StaleAfterKnob(t *testing.T) {
 // same table, so a registry we cannot read is a flow that is genuinely broken
 // for users.
 func TestFlowHealthHandler_ReadError503(t *testing.T) {
+	t.Parallel()
 	rr := serveFlowHealth(t, fakeLister{err: errors.New("db down")}, fakeStreams{}, "")
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503 on read error, got %d", rr.Code)
@@ -307,6 +314,7 @@ func TestFlowHealthHandler_ReadError503(t *testing.T) {
 // TestFlowHealthHandler_NilStreamSource keeps the handler total: a nil source
 // asserts nothing rather than panicking on a health probe.
 func TestFlowHealthHandler_NilStreamSource(t *testing.T) {
+	t.Parallel()
 	rr := serveFlowHealth(t, fakeLister{attachments: []*db.DaemonAttachment{att("a", time.Now())}}, nil, "")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (%s)", rr.Code, rr.Body.String())
@@ -321,6 +329,7 @@ func TestFlowHealthHandler_NilStreamSource(t *testing.T) {
 // truncates past that). A body that overflows loses its tail — the part an
 // operator reads to find out WHY — so the length is part of the contract.
 func TestFlowHealthBodyFitsSmokeDetail(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	long := now.Add(-time.Hour)
 	cases := map[string]*httptest.ResponseRecorder{

--- a/internal/servergateway/managed_reconciler_test.go
+++ b/internal/servergateway/managed_reconciler_test.go
@@ -17,6 +17,7 @@ import (
 // creation must retry rather than fail the reconciler permanently. Once the
 // stream appears, creation succeeds and the reconciler proceeds.
 func TestCreateConsumerWithRetry_RetriesWhenStreamMissing(t *testing.T) {
+	t.Parallel()
 	r := &ManagedDaemonReconciler{}
 
 	calls := 0
@@ -45,6 +46,7 @@ func TestCreateConsumerWithRetry_RetriesWhenStreamMissing(t *testing.T) {
 // JetStream API error (code=404 err_code=10059 description="stream not found")
 // is treated as retryable, not just the normalized ErrStreamNotFound sentinel.
 func TestCreateConsumerWithRetry_RetriesRawAPIError(t *testing.T) {
+	t.Parallel()
 	r := &ManagedDaemonReconciler{}
 
 	rawErr := &jetstream.APIError{
@@ -76,6 +78,7 @@ func TestCreateConsumerWithRetry_RetriesRawAPIError(t *testing.T) {
 // TestCreateConsumerWithRetry_NonRetryableSurfaces verifies that errors other
 // than stream-not-found are returned immediately without retrying.
 func TestCreateConsumerWithRetry_NonRetryableSurfaces(t *testing.T) {
+	t.Parallel()
 	r := &ManagedDaemonReconciler{}
 
 	sentinel := errors.New("boom: some other failure")
@@ -97,6 +100,7 @@ func TestCreateConsumerWithRetry_NonRetryableSurfaces(t *testing.T) {
 // TestCreateConsumerWithRetry_CtxCancelStops verifies the retry loop honors
 // context cancellation while the stream remains absent (no infinite spin).
 func TestCreateConsumerWithRetry_CtxCancelStops(t *testing.T) {
+	t.Parallel()
 	r := &ManagedDaemonReconciler{}
 
 	create := func(ctx context.Context) (jetstream.Consumer, error) {

--- a/internal/servergateway/pprof_test.go
+++ b/internal/servergateway/pprof_test.go
@@ -30,6 +30,7 @@ func freePort(t *testing.T) string {
 // the one that runs in production. It must not listen, must not leak a
 // goroutine, and must not panic.
 func TestStartPprofServer_EmptyAddrIsNoOp(t *testing.T) {
+	t.Parallel()
 	before := runtime.NumGoroutine()
 
 	require.NotPanics(t, func() {
@@ -58,6 +59,7 @@ func TestStartPprofServer_EmptyAddrIsNoOp(t *testing.T) {
 // actually reachable there. A debug surface that silently fails to serve is
 // the same defect as one that never existed.
 func TestStartPprofServer_ServesWhenAddrSet(t *testing.T) {
+	t.Parallel()
 	addr := freePort(t)
 	startPprofServer(addr)
 
@@ -87,6 +89,7 @@ func TestStartPprofServer_ServesWhenAddrSet(t *testing.T) {
 // there would kill the whole test binary rather than fail an assertion; the
 // proof of survival is that the process goes on to serve a later profiler.
 func TestStartPprofServer_BindFailureIsNotFatal(t *testing.T) {
+	t.Parallel()
 	// Hold the address ourselves so the pprof listener is guaranteed to lose.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)

--- a/internal/streaming/coalesce_test.go
+++ b/internal/streaming/coalesce_test.go
@@ -17,6 +17,7 @@ func contentDelta(thread string, block int, text string) StreamingDelta {
 }
 
 func TestCoalescible(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		delta StreamingDelta
@@ -51,6 +52,7 @@ func TestCoalescible(t *testing.T) {
 }
 
 func TestCanCoalesceWith(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		a, b StreamingDelta
@@ -91,6 +93,7 @@ func TestCanCoalesceWith(t *testing.T) {
 }
 
 func TestCoalesce_ConcatenatesText(t *testing.T) {
+	t.Parallel()
 	a := contentDelta("t", 0, "Hello, ")
 	b := contentDelta("t", 0, "world")
 
@@ -136,6 +139,7 @@ func TestCoalesce_KeepsExistingTokenCountWhenNewerHasNone(t *testing.T) {
 // A long run of same-block content deltas folds into one, mirroring what the
 // consume loop does while a consumer is behind.
 func TestCoalesce_FoldsRun(t *testing.T) {
+	t.Parallel()
 	acc := contentDelta("t", 0, "")
 	for _, chunk := range []string{"The ", "quick ", "brown ", "fox"} {
 		next := contentDelta("t", 0, chunk)

--- a/internal/streaming/hub_test.go
+++ b/internal/streaming/hub_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestNewStreamingHub_UnknownDriver(t *testing.T) {
+	t.Parallel()
 	_, err := NewStreamingHub(StreamingConfig{Driver: "redis"})
 	if err == nil {
 		t.Fatal("expected error for unknown driver")
@@ -12,6 +13,7 @@ func TestNewStreamingHub_UnknownDriver(t *testing.T) {
 }
 
 func TestParseStreamingDriver(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    string
 		expected StreamingDriver

--- a/internal/streaming/types_test.go
+++ b/internal/streaming/types_test.go
@@ -21,6 +21,7 @@ func identifiedDelta(msgID string, seq int64, thread string, block int, text str
 }
 
 func TestCanCoalesceWith_MessageID(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		a, b StreamingDelta
@@ -67,6 +68,7 @@ func TestCanCoalesceWith_MessageID(t *testing.T) {
 }
 
 func TestCoalesce_KeepsLaterStreamSeq(t *testing.T) {
+	t.Parallel()
 	a := identifiedDelta("m1", 3, "t", 0, "hello ")
 	b := identifiedDelta("m1", 7, "t", 0, "world")
 
@@ -83,6 +85,7 @@ func TestCoalesce_KeepsLaterStreamSeq(t *testing.T) {
 }
 
 func TestCoalesce_ZeroSeqDoesNotClobber(t *testing.T) {
+	t.Parallel()
 	// Legacy id-less deltas carry StreamSeq 0; merging them must not reset an
 	// existing seq (can only happen when both are id-less, but pin it anyway).
 	a := identifiedDelta("", 5, "t", 0, "x")

--- a/internal/streaming/update_hub_test.go
+++ b/internal/streaming/update_hub_test.go
@@ -12,6 +12,7 @@ type testUpdate struct {
 // --- UpdateEvent JSON round-trip ---
 
 func TestUpdateEvent_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
 	original := UpdateEvent[testUpdate]{
 		Key:            "user-123",
 		SequenceNumber: 42,

--- a/internal/workflow/builtin/agent_contract_test.go
+++ b/internal/workflow/builtin/agent_contract_test.go
@@ -40,6 +40,7 @@ const (
 )
 
 func TestContractExpressionsMatchAgentYAML(t *testing.T) {
+	t.Parallel()
 	data, err := builtin.BuiltinWorkflowsFS.ReadFile("agent.yaml")
 	if err != nil {
 		t.Fatalf("failed to read agent.yaml: %v", err)
@@ -133,6 +134,7 @@ func TestContractExpressionsMatchAgentYAML(t *testing.T) {
 // This ensures that if the YAML expressions change, they remain evaluable
 // (no syntax or type errors).
 func TestContractAgentYAMLExpressionsEvaluate(t *testing.T) {
+	t.Parallel()
 	data, err := builtin.BuiltinWorkflowsFS.ReadFile("agent.yaml")
 	if err != nil {
 		t.Fatalf("failed to read agent.yaml: %v", err)

--- a/internal/workflow/builtin/agent_test.go
+++ b/internal/workflow/builtin/agent_test.go
@@ -13,6 +13,7 @@ import (
 
 // TestAgentWorkflowValidation verifies that agent.yaml parses and validates correctly.
 func TestAgentWorkflowValidation(t *testing.T) {
+	t.Parallel()
 	data, err := builtin.BuiltinWorkflowsFS.ReadFile("agent.yaml")
 	if err != nil {
 		t.Fatalf("Failed to read agent.yaml: %v", err)
@@ -73,6 +74,7 @@ func TestAgentWorkflowValidation(t *testing.T) {
 
 // TestCompactWorkflowValidation verifies that the hardcoded compact workflow is valid.
 func TestCompactWorkflowValidation(t *testing.T) {
+	t.Parallel()
 	// Compact is now a hardcoded internal workflow YAML, not a YAML file
 	data := builtin.GetInternalWorkflowYAML("compact")
 	if data == nil {
@@ -112,6 +114,7 @@ func TestCompactWorkflowValidation(t *testing.T) {
 
 // TestAgentSpawnPresets verifies that the spawn_presets input is correctly configured.
 func TestAgentSpawnPresets(t *testing.T) {
+	t.Parallel()
 	data, err := builtin.BuiltinWorkflowsFS.ReadFile("agent.yaml")
 	if err != nil {
 		t.Fatalf("Failed to read agent.yaml: %v", err)
@@ -161,6 +164,7 @@ func TestAgentSpawnPresets(t *testing.T) {
 
 // TestParseBuiltinWorkflow tests loading builtin workflows by name.
 func TestParseBuiltinWorkflow(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		workflowName string

--- a/internal/workflow/builtin/auditing_agent_test.go
+++ b/internal/workflow/builtin/auditing_agent_test.go
@@ -17,6 +17,7 @@ import (
 
 // TestAuditingAgentWorkflowInputs tests the input structure for auditing-agent.
 func TestAuditingAgentWorkflowInputs(t *testing.T) {
+	t.Parallel()
 	data, err := builtin.BuiltinWorkflowsFS.ReadFile("auditing-agent.yaml")
 	require.NoError(t, err, "Should read auditing-agent.yaml")
 
@@ -49,6 +50,7 @@ func TestAuditingAgentWorkflowInputs(t *testing.T) {
 
 // TestAuditCheckNodeHasModel verifies audit_check references the top-level auditor inputs.
 func TestAuditCheckNodeHasModel(t *testing.T) {
+	t.Parallel()
 	data, err := builtin.BuiltinWorkflowsFS.ReadFile("auditing-agent.yaml")
 	require.NoError(t, err)
 
@@ -94,6 +96,7 @@ func TestAuditCheckNodeHasModel(t *testing.T) {
 // TestPresetsOnCallLLMRejected verifies that v2 validation rejects
 // presets on call_llm nodes (presets only work on workflow/loop nodes).
 func TestPresetsOnCallLLMRejected(t *testing.T) {
+	t.Parallel()
 	yamlData := []byte(`
 name: test-invalid
 apiVersion: "0.0.5"

--- a/internal/workflow/builtin/forge_one_shot_facts_test.go
+++ b/internal/workflow/builtin/forge_one_shot_facts_test.go
@@ -56,6 +56,7 @@ import (
 // of forge's internals that reliant cannot import and cannot execute here, so
 // they stay substrings until something exports them.
 func TestForgeOneShotCharterFacts(t *testing.T) {
+	t.Parallel()
 	data, err := builtin.BuiltinWorkflowsFS.ReadFile("forge-one-shot.yaml")
 	require.NoError(t, err)
 	charter := string(data)
@@ -190,6 +191,7 @@ func commentedFKClaims(text string) []string {
 //     foreign keys" all trip it. Rewording the TRUE claim cannot trip it,
 //     because the true claim has no reason to mention commenting near an FK.
 func TestForgeOneShotDoesNotCallBirthsForeignKeysCommented(t *testing.T) {
+	t.Parallel()
 	// The producer half: forge's own db skill is the authority the charter
 	// is paraphrasing, and it says the reference is APPLIED.
 	skill, err := forgecli.LoadSkill("", "db")
@@ -246,6 +248,7 @@ func TestForgeOneShotDoesNotCallBirthsForeignKeysCommented(t *testing.T) {
 // back (an agent sent to split a file forge no longer births hunts for
 // something that does not exist), and the per-RPC spelling must stay named.
 func TestForgeOneShotNamesThePerRPCScaffoldTestFile(t *testing.T) {
+	t.Parallel()
 	data, err := builtin.BuiltinWorkflowsFS.ReadFile("forge-one-shot.yaml")
 	require.NoError(t, err)
 	charter := string(data)
@@ -282,6 +285,7 @@ func TestForgeOneShotNamesThePerRPCScaffoldTestFile(t *testing.T) {
 // pattern-matching pkill in a shared dev environment is how an agent takes out
 // processes it does not own.
 func TestForgeOneShotStartsAndStopsTheDevServerTheWayForgeActuallyBehaves(t *testing.T) {
+	t.Parallel()
 	data, err := builtin.BuiltinWorkflowsFS.ReadFile("forge-one-shot.yaml")
 	require.NoError(t, err)
 	charter := string(data)
@@ -319,6 +323,7 @@ func TestForgeOneShotStartsAndStopsTheDevServerTheWayForgeActuallyBehaves(t *tes
 // the stub lands in its own `rpc_<snake>.go`; declared in the proto first, the
 // next `forge generate` APPENDS it to the one shared handlers.go.
 func TestForgeOneShotSaysScaffoldRPCDoesNotWriteTheProto(t *testing.T) {
+	t.Parallel()
 	data, err := builtin.BuiltinWorkflowsFS.ReadFile("forge-one-shot.yaml")
 	require.NoError(t, err)
 	charter := string(data)
@@ -353,6 +358,7 @@ func TestForgeOneShotSaysScaffoldRPCDoesNotWriteTheProto(t *testing.T) {
 // struct). The subordinate rule is resolvability, and it has exactly two legal
 // answers, which is what this guard pins.
 func TestForgeOneShotResolvesTheDepsSurfaceContradiction(t *testing.T) {
+	t.Parallel()
 	data, err := builtin.BuiltinWorkflowsFS.ReadFile("forge-one-shot.yaml")
 	require.NoError(t, err)
 	charter := string(data)
@@ -392,6 +398,7 @@ func TestForgeOneShotResolvesTheDepsSurfaceContradiction(t *testing.T) {
 // which phase it was measured at, and that the ~19-minute figure is never
 // restored as an unqualified claim.
 func TestForgeOneShotCommandCostsAreMeasuredOnAFinishedApp(t *testing.T) {
+	t.Parallel()
 	data, err := builtin.BuiltinWorkflowsFS.ReadFile("forge-one-shot.yaml")
 	require.NoError(t, err)
 	charter := string(data)
@@ -441,6 +448,7 @@ func TestForgeOneShotCommandCostsAreMeasuredOnAFinishedApp(t *testing.T) {
 // actually declared (a rename would otherwise make every lane bullet silently
 // evaluate to nothing, restoring the original bug without a word changing).
 func TestGetItRightRetryPromptNamesTheFailingLane(t *testing.T) {
+	t.Parallel()
 	data, err := builtin.BuiltinWorkflowsFS.ReadFile("get-it-right.yaml")
 	require.NoError(t, err)
 	wf := string(data)

--- a/internal/workflow/builtin/get_it_right_gate_authority_test.go
+++ b/internal/workflow/builtin/get_it_right_gate_authority_test.go
@@ -112,6 +112,7 @@ func evalStrategy(t *testing.T, nodes map[string]interface{}) string {
 
 // TestRedGateCannotYieldPass is the regression test for the lost guarantee.
 func TestRedGateCannotYieldPass(t *testing.T) {
+	t.Parallel()
 	for _, lane := range []struct {
 		name              string
 		lint, test, build int
@@ -140,6 +141,7 @@ func TestRedGateCannotYieldPass(t *testing.T) {
 // because the gate is red would silently drop that escalation and re-run the
 // implementer against a blocker only a human can clear.
 func TestRedGatePreservesStuck(t *testing.T) {
+	t.Parallel()
 	require.Equal(t, "stuck", evalStrategy(t, withReview(gateNodes(1, 0, 1), "stuck")),
 		"a red gate must not convert `stuck` into `continue` — `stuck` means the REVIEW was "+
 			"blocked, and the human's answer is addressed to the reviewer")
@@ -149,6 +151,7 @@ func TestRedGatePreservesStuck(t *testing.T) {
 // constraint is one-way: exit codes cannot see a blank page or a wrong API
 // shape, so a green gate settles nothing on its own.
 func TestReviewerKeepsAuthorityOverAGreenGate(t *testing.T) {
+	t.Parallel()
 	for _, strategy := range []string{"continue", "refactor", "stuck"} {
 		t.Run("reviewer says "+strategy, func(t *testing.T) {
 			require.Equal(t, strategy, evalStrategy(t, withReview(gateNodes(0, 0, 0), strategy)),
@@ -170,6 +173,7 @@ func TestReviewerKeepsAuthorityOverAGreenGate(t *testing.T) {
 // read an absent or empty lane as "failed", those four pipelines could never
 // reach `pass` and would burn max_retries on every run.
 func TestUnconfiguredGateIsNotAFailure(t *testing.T) {
+	t.Parallel()
 	t.Run("no commands configured, reviewer passes", func(t *testing.T) {
 		require.Equal(t, "pass", evalStrategy(t, withReview(skippedGateNodes(), "pass")),
 			"a consumer that configures no gate commands has nothing that can fail; its "+
@@ -191,6 +195,7 @@ func TestUnconfiguredGateIsNotAFailure(t *testing.T) {
 // which is the behaviour the merge was supposed to preserve. With no review node
 // the exit codes are the whole verdict.
 func TestReviewDisabledStillGatesOnExitCodes(t *testing.T) {
+	t.Parallel()
 	require.Equal(t, "pass", evalStrategy(t, gateNodes(0, 0, 0)),
 		"no reviewer and a green gate is the deterministic pass")
 	require.Equal(t, "continue", evalStrategy(t, gateNodes(0, 1, 0)),
@@ -212,6 +217,7 @@ func TestReviewDisabledStillGatesOnExitCodes(t *testing.T) {
 // `outputs.gate_failed`: loop outputs carry the PREVIOUS iteration's values, and
 // the gate is re-measured before the reviewer runs.
 func TestReviewerIsToldTheGateIsAuthoritative(t *testing.T) {
+	t.Parallel()
 	template := injectContent(t, "get-it-right.yaml", "attempt", "review")
 
 	render := func(t *testing.T, nodes map[string]interface{}) string {
@@ -248,6 +254,7 @@ func TestReviewerIsToldTheGateIsAuthoritative(t *testing.T) {
 // GREEN") while `eval_strategy` drives CONTROL FLOW; if they ever disagree about
 // what red means, the agent is told one thing and routed by another.
 func TestGateFailedOutputAgreesWithEvalStrategy(t *testing.T) {
+	t.Parallel()
 	gateFailedExpr := loopOutputExpr(t, "get-it-right.yaml", "attempt", "gate_failed")
 
 	for _, tc := range []struct {

--- a/internal/workflow/builtin/get_it_right_review_loop_test.go
+++ b/internal/workflow/builtin/get_it_right_review_loop_test.go
@@ -135,6 +135,7 @@ func toolsNamedIn(text string) []string {
 // A required field with no reachable way to fill it is not a strict schema, it is
 // a dead end. Every prompt that names a tool must be able to reach it.
 func TestReviewerHoldsEveryToolItsInstructionsName(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name  string
 		text  string
@@ -193,6 +194,7 @@ func sortedKeys(m map[string]bool) []string {
 // prompt, the membership check BITES when the grant is missing them, and prose that
 // merely contains a tool word is not mistaken for an order to use it.
 func TestToolNameExtractionIsNotVacuous(t *testing.T) {
+	t.Parallel()
 	named := toolsNamedIn(injectContent(t, "get-it-right.yaml", "attempt", "review"))
 	require.NotEmpty(t, named,
 		"the reviewer's prompt names shell-family tools; an extractor that returns nothing "+
@@ -308,6 +310,7 @@ func gateInputs() map[string]interface{} {
 // the `gate_failed` loop output, and on a green gate the prompt leads with the
 // verdict that really did drive the retry.
 func TestGetItRightRetryPromptTellsTheTruthAboutAGreenGate(t *testing.T) {
+	t.Parallel()
 	template := injectContent(t, "get-it-right.yaml", "attempt", "implement")
 
 	const reviewerVerdict = "The deviation-state page renders an empty table where it should render the terminal-state banner."
@@ -378,6 +381,7 @@ func TestGetItRightRetryPromptTellsTheTruthAboutAGreenGate(t *testing.T) {
 // that actually owns process lifecycle — and the command is interpolated into its
 // prompt verbatim rather than paraphrased.
 func TestGetItRightHandsTheReviewerTheStartCommandInsteadOfAPort(t *testing.T) {
+	t.Parallel()
 	reviewInject := injectContent(t, "get-it-right.yaml", "attempt", "review")
 
 	require.NotContains(t, reviewInject, "The application was started via the phase start command",
@@ -458,6 +462,7 @@ func TestGetItRightHandsTheReviewerTheStartCommandInsteadOfAPort(t *testing.T) {
 // stuck_feedback_rereviews_without_reimplementing scenario; this holds the shape
 // the scenario depends on.
 func TestGetItRightReEntersAtReviewWhenTheREVIEWIsWhatWasStuck(t *testing.T) {
+	t.Parallel()
 	doc := loadWorkflowYAML(t, "get-it-right.yaml")
 	inline := mapAt(t, nodeByID(t, doc, "attempt"), "inline")
 
@@ -530,6 +535,7 @@ func TestGetItRightReEntersAtReviewWhenTheREVIEWIsWhatWasStuck(t *testing.T) {
 // without the shell: nothing can be in `bash_list` for an agent that cannot start
 // a process.
 func TestShellTagCarriesTheToolsTheShellToolTellsAgentsToUse(t *testing.T) {
+	t.Parallel()
 	granted := make(map[string]bool)
 	for _, name := range tools.ExpandToolFilter([]string{"tag:shell"}, nil) {
 		granted[name] = true

--- a/internal/workflow/builtin/loop_debug_test.go
+++ b/internal/workflow/builtin/loop_debug_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestLoopDebug(t *testing.T) {
+	t.Parallel()
 	// DISABLED: This test was for the old one-ring workflow structure that had
 	// nested loops (one_ring_loop → review loop). The workflow has been restructured
 	// to a linear flow with only implement_loop, so this test no longer applies.

--- a/internal/workflow/builtin/loop_output_debug_test.go
+++ b/internal/workflow/builtin/loop_output_debug_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestLoopOutputPropagation(t *testing.T) {
+	t.Parallel()
 	// DISABLED: This test was for the old one-ring workflow structure that had
 	// a one_ring_loop node with nested review loop. The workflow has been restructured
 	// to a linear flow with only implement_loop, so this test no longer applies.

--- a/internal/workflow/builtin/one_ring_test.go
+++ b/internal/workflow/builtin/one_ring_test.go
@@ -25,6 +25,7 @@ import (
 //   - Implementation loop: implement → lint/test/build → evaluate
 //   - Loop exits on success or max_retries
 func TestOneRingWorkflowScenarios(t *testing.T) {
+	t.Parallel()
 	workflowData, err := builtin.BuiltinWorkflowsFS.ReadFile("one-ring.yaml")
 	require.NoError(t, err, "Failed to read one-ring.yaml")
 
@@ -106,6 +107,7 @@ var bugScenarios = map[string]bool{}
 // TestOneRingWorkflowScenarios_Passing runs only the scenarios expected to pass.
 // Use this for CI.
 func TestOneRingWorkflowScenarios_Passing(t *testing.T) {
+	t.Parallel()
 	workflowData, err := builtin.BuiltinWorkflowsFS.ReadFile("one-ring.yaml")
 	require.NoError(t, err)
 
@@ -148,6 +150,7 @@ func TestOneRingWorkflowScenarios_Passing(t *testing.T) {
 
 // TestOneRingWorkflowScenarios_BugDemonstration documents known limitations.
 func TestOneRingWorkflowScenarios_BugDemonstration(t *testing.T) {
+	t.Parallel()
 	workflowData, err := builtin.BuiltinWorkflowsFS.ReadFile("one-ring.yaml")
 	require.NoError(t, err)
 

--- a/internal/workflow/builtin/scenarios_test.go
+++ b/internal/workflow/builtin/scenarios_test.go
@@ -31,6 +31,7 @@ import (
 //
 // Scenario files can contain multiple YAML documents separated by ---.
 func TestBuiltinWorkflowScenarios(t *testing.T) {
+	t.Parallel()
 	// Get all builtin workflows
 	entries, err := builtin.BuiltinWorkflowsFS.ReadDir(".")
 	require.NoError(t, err, "Failed to read builtin workflows directory")
@@ -182,6 +183,7 @@ func parseMultiDocYAML(data []byte) ([]*simulator.Scenario, error) {
 // TestScenarioFilesAreValid validates that all scenario files parse correctly
 // without actually running them. This catches YAML syntax errors early.
 func TestScenarioFilesAreValid(t *testing.T) {
+	t.Parallel()
 	err := fs.WalkDir(builtin.BuiltinScenariosFS, "testdata", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			// If testdata directory doesn't exist, that's OK
@@ -224,6 +226,7 @@ func TestScenarioFilesAreValid(t *testing.T) {
 // are dead tests that can never run — they must be updated or removed when a
 // workflow is renamed or deleted.
 func TestScenarioDirsMapToWorkflows(t *testing.T) {
+	t.Parallel()
 	entries, err := builtin.BuiltinScenarioDirsFS.ReadDir("scenarios")
 	if err != nil {
 		t.Skip("no scenarios directory embedded")
@@ -243,6 +246,7 @@ func TestScenarioDirsMapToWorkflows(t *testing.T) {
 // TestAllWorkflowsHaveScenarios checks that each workflow has a corresponding
 // scenario file. This is informational - not all workflows require scenarios.
 func TestAllWorkflowsHaveScenarios(t *testing.T) {
+	t.Parallel()
 	entries, err := builtin.BuiltinWorkflowsFS.ReadDir(".")
 	require.NoError(t, err)
 

--- a/internal/workflow/builtin/skill_references_test.go
+++ b/internal/workflow/builtin/skill_references_test.go
@@ -62,6 +62,7 @@ func newBuiltinSkillResolver(t *testing.T) *validation.SkillResolver {
 // params.skills the same way — the two together cover both surfaces that name
 // a skill statically.
 func TestBuiltinWorkflowSkillsResolve(t *testing.T) {
+	t.Parallel()
 	resolver := newBuiltinSkillResolver(t)
 
 	entries, err := builtin.BuiltinWorkflowsFS.ReadDir(".")
@@ -173,6 +174,7 @@ func proseSkillNames(text string) []string {
 // a charter grew a new one. The anchor is the text convention, so the text is
 // what it reads.
 func TestBuiltinWorkflowProseSkillsResolve(t *testing.T) {
+	t.Parallel()
 	resolver := newBuiltinSkillResolver(t)
 
 	entries, err := builtin.BuiltinWorkflowsFS.ReadDir(".")
@@ -213,6 +215,7 @@ func TestBuiltinWorkflowProseSkillsResolve(t *testing.T) {
 // "forge/service-layer" does not — which is not obvious, is exactly what the
 // charter got wrong, and is the property the guard depends on.
 func TestBuiltinSkillResolverRejectsNamespacedBareSkill(t *testing.T) {
+	t.Parallel()
 	resolver := newBuiltinSkillResolver(t)
 
 	// emit:both — addressable bare, NOT under the synthetic namespace.

--- a/internal/workflow/builtin/unattended_charter_test.go
+++ b/internal/workflow/builtin/unattended_charter_test.go
@@ -42,6 +42,7 @@ func scaffoldInputs(unattended bool) map[string]interface{} {
 // inside get-it-right's loop, and scaffold_and_verify sets review_enabled: false,
 // so the edge is unreachable. Setting ask=false changed nothing.
 func TestScaffoldCharterDoesNotOpenWithAGateWhenNobodyIsWatching(t *testing.T) {
+	t.Parallel()
 	template := topLevelInjectContent(t, "forge-one-shot.yaml", "build_app")
 
 	unattended := renderPrompt(t, template, scaffoldInputs(true), nil, nil, 0)
@@ -60,6 +61,7 @@ func TestScaffoldCharterDoesNotOpenWithAGateWhenNobodyIsWatching(t *testing.T) {
 
 // The interactive path must be unchanged when the input is off.
 func TestScaffoldCharterStillOpensTheConversationWhenAHumanIsThere(t *testing.T) {
+	t.Parallel()
 	template := topLevelInjectContent(t, "forge-one-shot.yaml", "build_app")
 
 	interactive := renderPrompt(t, template, scaffoldInputs(false), nil, nil, 0)
@@ -83,6 +85,7 @@ func TestScaffoldCharterStillOpensTheConversationWhenAHumanIsThere(t *testing.T)
 // specific instruction to open by asking. The escape has to say plainly that an
 // explicit instruction overrides the directive to ask.
 func TestScaffoldCharterNeverAsksWhatTheOpeningMessageAlreadyAnswered(t *testing.T) {
+	t.Parallel()
 	template := topLevelInjectContent(t, "forge-one-shot.yaml", "build_app")
 	interactive := renderPrompt(t, template, scaffoldInputs(false), nil, nil, 0)
 
@@ -108,6 +111,7 @@ func TestScaffoldCharterNeverAsksWhatTheOpeningMessageAlreadyAnswered(t *testing
 // every existing caller: `ask` decides whether a PRESENT human is paused for
 // between iterations, `unattended` says there is no human at all.
 func TestUnattendedIsDeclaredSeparatelyFromAsk(t *testing.T) {
+	t.Parallel()
 	for _, file := range []string{"forge-one-shot.yaml", "get-it-right.yaml"} {
 		doc := loadWorkflowYAML(t, file)
 		inputs := mapAt(t, doc, "inputs")

--- a/internal/workflow/builtin/workflow_started_event_test.go
+++ b/internal/workflow/builtin/workflow_started_event_test.go
@@ -19,6 +19,7 @@ import (
 // - Example: role: "{{inputs.message.role}}"
 // - All data access is explicit via inputs.*, workflow.*, or nodes.*
 func TestWorkflowStartedEventData(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		event         *core.WorkflowEvent
@@ -112,6 +113,7 @@ func TestWorkflowStartedEventData(t *testing.T) {
 // - Example: role: "{{inputs.message.role}}"
 // - No implicit passthrough - all data access is explicit
 func TestWorkflowStartedToSaveMessageFlow(t *testing.T) {
+	t.Parallel()
 	// Create workflow inputs with message data (as chat.go does)
 	// This is what gets put into inputs namespace
 	workflowInputs := map[string]interface{}{

--- a/internal/workflow/builtin/workflows_test.go
+++ b/internal/workflow/builtin/workflows_test.go
@@ -28,6 +28,7 @@ import (
 // - CEL expression errors
 // - Missing required fields
 func TestValidateBuiltinWorkflows(t *testing.T) {
+	t.Parallel()
 	entries, err := builtin.BuiltinWorkflowsFS.ReadDir(".")
 	require.NoError(t, err, "Should be able to read builtin workflows directory")
 
@@ -71,6 +72,7 @@ func TestValidateBuiltinWorkflows(t *testing.T) {
 
 // TestAllBuiltinWorkflowsDiscoverable ensures all .yaml files in builtin/ can be read from embedded FS
 func TestAllBuiltinWorkflowsDiscoverable(t *testing.T) {
+	t.Parallel()
 	entries, err := builtin.BuiltinWorkflowsFS.ReadDir(".")
 	require.NoError(t, err, "Should be able to read builtin workflows directory")
 
@@ -103,6 +105,7 @@ func TestAllBuiltinWorkflowsDiscoverable(t *testing.T) {
 
 // TestStructuredAgentWorkflowExists tests that structured-agent workflow exists and can be loaded
 func TestStructuredAgentWorkflowExists(t *testing.T) {
+	t.Parallel()
 	// Test that the file exists in embedded FS
 	data, err := builtin.BuiltinWorkflowsFS.ReadFile("structured-agent.yaml")
 	require.NoError(t, err, "structured-agent.yaml should exist in builtin workflows")
@@ -126,6 +129,7 @@ func TestStructuredAgentWorkflowExists(t *testing.T) {
 // TestBuiltinWorkflowLoading simulates how the runtime loads builtin workflows
 // This tests the same code path that would be used when a user selects builtin://agent
 func TestBuiltinWorkflowLoading(t *testing.T) {
+	t.Parallel()
 	testCases := []string{
 		"agent",
 		"auditing-agent",
@@ -170,6 +174,7 @@ func TestBuiltinWorkflowLoading(t *testing.T) {
 // can be loaded via ResolveAndParseWorkflow without errors.
 // This originally caught a bug where trigger templates inside nodes were being resolved too early.
 func TestBuiltinWorkflowTemplateResolution(t *testing.T) {
+	t.Parallel()
 	// Complex workflows with nested structures and CEL expressions
 	workflowsToTest := []string{
 		"parallel-compete", // Complex parallel workflow with worktrees
@@ -194,6 +199,7 @@ func TestBuiltinWorkflowTemplateResolution(t *testing.T) {
 // reference valid, registered model IDs. This catches mismatches like using "claude-sonnet-4.5"
 // when the registered model ID is "claude-4.5-sonnet".
 func TestBuiltinWorkflowModelIDsAreValid(t *testing.T) {
+	t.Parallel()
 	entries, err := builtin.BuiltinWorkflowsFS.ReadDir(".")
 	require.NoError(t, err, "Should be able to read builtin workflows directory")
 
@@ -282,6 +288,7 @@ func validateNodesForModels(t *testing.T, nodes []*reliantv1.Node, filename, pat
 // - Presets with params that don't exist in the target workflow
 // - Type mismatches between preset params and workflow inputs
 func TestBuiltinPresetsValidateAgainstWorkflows(t *testing.T) {
+	t.Parallel()
 	// Load all builtin workflows
 	var workflows []*reliantv1.Workflow
 	entries, err := builtin.BuiltinWorkflowsFS.ReadDir(".")
@@ -389,6 +396,7 @@ func protoInputNames(inputs map[string]*reliantv1.Input) []string {
 // - References to deleted presets
 // - Missing presets that should exist
 func TestBuiltinWorkflowNodePresetReferencesExist(t *testing.T) {
+	t.Parallel()
 	// Load all builtin preset names
 	presetEntries, err := builtin.BuiltinPresetsFS.ReadDir("presets")
 	require.NoError(t, err, "Should be able to read builtin presets directory")

--- a/internal/workflow/runtime/apply_defaults_test.go
+++ b/internal/workflow/runtime/apply_defaults_test.go
@@ -16,6 +16,7 @@ import (
 // as missing and applies schema defaults. This prevents CEL "no such overload"
 // errors when comparing nil against numeric types.
 func TestApplyDefaultsNilValues(t *testing.T) {
+	t.Parallel()
 	intDefault := int64(185000)
 	strDefault := "default_value"
 
@@ -147,6 +148,7 @@ func TestApplyDefaultsNilValues(t *testing.T) {
 // TestApplyDefaultsWithGroupInputs verifies that ApplyDefaults creates nested
 // structures for group inputs, enabling CEL access like inputs.agent.model.
 func TestApplyDefaultsWithGroupInputs(t *testing.T) {
+	t.Parallel()
 	strDefault := "gpt-4"
 	numDefault := 0.7
 	intDefault := int64(10)

--- a/internal/workflow/runtime/ask_question_test.go
+++ b/internal/workflow/runtime/ask_question_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestDynamicWorkflowAskQuestionDoesNotScheduleUnregisteredActivity(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 

--- a/internal/workflow/runtime/ask_user_test.go
+++ b/internal/workflow/runtime/ask_user_test.go
@@ -8,12 +8,14 @@ import (
 )
 
 func TestFormatAskUserResponse_SingleQuestion(t *testing.T) {
+	t.Parallel()
 	responseData := `{"answers":[{"question":"Which auth?","selected":["JWT"],"freetext":""}]}`
 	result := formatAskUserResponse("reply", responseData)
 	assert.Equal(t, "Q: Which auth?\nA: JWT", result)
 }
 
 func TestFormatAskUserResponse_MultipleQuestions(t *testing.T) {
+	t.Parallel()
 	responseData := `{"answers":[{"question":"Which auth?","selected":["JWT"]},{"question":"Which DB?","selected":["Postgres"]}]}`
 	result := formatAskUserResponse("reply", responseData)
 	assert.Contains(t, result, "Q: Which auth?\nA: JWT")
@@ -21,28 +23,33 @@ func TestFormatAskUserResponse_MultipleQuestions(t *testing.T) {
 }
 
 func TestFormatAskUserResponse_WithFreetext(t *testing.T) {
+	t.Parallel()
 	responseData := `{"answers":[{"question":"Which auth?","selected":["JWT"],"freetext":"But also consider OAuth"}]}`
 	result := formatAskUserResponse("reply", responseData)
 	assert.Equal(t, "Q: Which auth?\nA: JWT (note: But also consider OAuth)", result)
 }
 
 func TestFormatAskUserResponse_FreetextOnly(t *testing.T) {
+	t.Parallel()
 	responseData := `{"answers":[{"question":"Any preferences?","selected":[],"freetext":"I want something custom"}]}`
 	result := formatAskUserResponse("reply", responseData)
 	assert.Equal(t, "Q: Any preferences?\nA: (note: I want something custom)", result)
 }
 
 func TestFormatAskUserResponse_EmptyResponseReply(t *testing.T) {
+	t.Parallel()
 	result := formatAskUserResponse("reply", "")
 	assert.Equal(t, "The user replied via chat message. Check the conversation for their response.", result)
 }
 
 func TestFormatAskUserResponse_EmptyResponseContinue(t *testing.T) {
+	t.Parallel()
 	result := formatAskUserResponse("continue", "")
 	assert.Equal(t, "The user continued without providing a specific answer.", result)
 }
 
 func TestFormatAskUserResponse_MalformedJSON(t *testing.T) {
+	t.Parallel()
 	result := formatAskUserResponse("reply", "{bad json")
 	assert.Equal(t, "{bad json", result)
 }

--- a/internal/workflow/runtime/cel_env_test.go
+++ b/internal/workflow/runtime/cel_env_test.go
@@ -16,6 +16,7 @@ import (
 
 // TestCELEnvConfigs verifies all CEL environment configs can be created
 func TestCELEnvConfigs(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		config wfcel.CELEnvConfig
@@ -37,6 +38,7 @@ func TestCELEnvConfigs(t *testing.T) {
 
 // TestNewCELEnvFromContext verifies auto-detection of namespaces
 func TestNewCELEnvFromContext(t *testing.T) {
+	t.Parallel()
 	ctx := map[string]interface{}{
 		"inputs":   map[string]interface{}{"mode": "auto"},
 		"workflow": map[string]interface{}{"id": "test"},
@@ -54,6 +56,7 @@ func TestNewCELEnvFromContext(t *testing.T) {
 
 // TestEnsureNamespaceDefaults verifies namespace defaults are set
 func TestEnsureNamespaceDefaults(t *testing.T) {
+	t.Parallel()
 	ctx := map[string]interface{}{
 		"inputs": map[string]interface{}{"x": 1},
 	}
@@ -69,6 +72,7 @@ func TestEnsureNamespaceDefaults(t *testing.T) {
 // TestBuiltinWorkflowCELExpressions validates ALL CEL expressions from builtin workflows
 // compile against the runtime CEL environment. This test would catch namespace mismatches.
 func TestBuiltinWorkflowCELExpressions(t *testing.T) {
+	t.Parallel()
 	// Find builtin workflow directory
 	builtinDir := filepath.Join(".", "..", "builtin")
 	if _, err := os.Stat(builtinDir); os.IsNotExist(err) {
@@ -143,6 +147,7 @@ func TestBuiltinWorkflowCELExpressions(t *testing.T) {
 
 // TestTemplateResolutionCELNamespace verifies that template resolution uses correct namespaces
 func TestTemplateResolutionCELNamespace(t *testing.T) {
+	t.Parallel()
 	config := wfcel.TemplateResolutionCELEnvConfig()
 	env, err := wfcel.NewEnv(config)
 	require.NoError(t, err)
@@ -155,6 +160,7 @@ func TestTemplateResolutionCELNamespace(t *testing.T) {
 
 // TestCELContextBuilder_WithExecContext verifies execution context is set
 func TestCELContextBuilder_WithExecContext(t *testing.T) {
+	t.Parallel()
 	builder := NewCELContextBuilder().
 		WithWorkflow("wf-1", "test-workflow").
 		WithExecContext(&ExecutionContext{
@@ -173,6 +179,7 @@ func TestCELContextBuilder_WithExecContext(t *testing.T) {
 
 // TestCELContextBuilder_WorkflowContext verifies workflow context is properly built
 func TestCELContextBuilder_WorkflowContext(t *testing.T) {
+	t.Parallel()
 	builder := NewCELContextBuilder().
 		WithWorkflow("wf-1", "test-workflow").
 		WithEnvironment("/workspace", "main").
@@ -189,6 +196,7 @@ func TestCELContextBuilder_WorkflowContext(t *testing.T) {
 
 // TestCELContextBuilder_ImplementsCELEvaluator verifies the interface is satisfied
 func TestCELContextBuilder_ImplementsCELEvaluator(t *testing.T) {
+	t.Parallel()
 	builder := NewCELContextBuilder().
 		WithWorkflow("wf-1", "test-workflow").
 		WithInputs(map[string]interface{}{"mode": "auto", "count": float64(5)})
@@ -217,6 +225,7 @@ func TestCELContextBuilder_ImplementsCELEvaluator(t *testing.T) {
 // content string, including substituting a concrete port via CEL's string
 // .replace (ext.Strings) — the shape a workflow author writes.
 func TestPreviewURLTemplateResolvesInInject(t *testing.T) {
+	t.Parallel()
 	builder := NewCELContextBuilder().
 		WithWorkflow("wf-1", "test-workflow").
 		WithInputs(map[string]interface{}{

--- a/internal/workflow/runtime/cel_eval_test.go
+++ b/internal/workflow/runtime/cel_eval_test.go
@@ -15,6 +15,7 @@ import (
 // =============================================================================
 
 func TestWhileConditionViaV2celAPI(t *testing.T) {
+	t.Parallel()
 	// -------------------------------------------------------------------------
 	// The exact agent.yaml while condition
 	// -------------------------------------------------------------------------
@@ -247,6 +248,7 @@ func TestWhileConditionViaV2celAPI(t *testing.T) {
 // =============================================================================
 
 func TestCELTypeSafety(t *testing.T) {
+	t.Parallel()
 	t.Run("workflow CEL EvaluateBool with typed IterContext works", func(t *testing.T) {
 		ctx := &wfcel.LoopEvalContext{
 			Outputs: map[string]interface{}{"exit_code": int64(1)},
@@ -291,6 +293,7 @@ func TestCELTypeSafety(t *testing.T) {
 // =============================================================================
 
 func TestCELRealWorldPatterns(t *testing.T) {
+	t.Parallel()
 	t.Run("TDD loop: exit when tests fail", func(t *testing.T) {
 		expr := "outputs.exit_code != 0"
 

--- a/internal/workflow/runtime/cel_multiplication_test.go
+++ b/internal/workflow/runtime/cel_multiplication_test.go
@@ -20,6 +20,7 @@ import (
 // The hypothesis is that CEL may fail with "no such overload" when the integer type from the
 // Go map doesn't match the expected CEL type declaration.
 func TestCELMultiplicationWithMapIntegerValues(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		nodeOutputs    map[string]interface{}
@@ -155,6 +156,7 @@ func TestCELMultiplicationWithMapIntegerValues(t *testing.T) {
 // TestCELMultiplicationRealWorldScenario tests the exact scenario from agent.yaml
 // where save_tool_results.thread_token_count is compared to determine if compaction is needed.
 func TestCELMultiplicationRealWorldScenario(t *testing.T) {
+	t.Parallel()
 	// This simulates the actual step outputs from the save_tool_results step
 	// ThreadTokenCount is returned as an int from SaveMessageOutput
 	nodeOutputs := map[string]interface{}{
@@ -213,6 +215,7 @@ func TestCELMultiplicationRealWorldScenario(t *testing.T) {
 // but has issues with floating point numbers and unsigned integers when performing
 // arithmetic operations like multiplication.
 func TestCELTypeCoercion(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		value       interface{}

--- a/internal/workflow/runtime/cel_new_functions_test.go
+++ b/internal/workflow/runtime/cel_new_functions_test.go
@@ -47,6 +47,7 @@ func evalCEL(t *testing.T, env *cel.Env, expr string, vars map[string]interface{
 // ============================================================================
 
 func TestCelCoalesce_ReturnsFirstNonNull(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	tests := []struct {
@@ -114,6 +115,7 @@ func TestCelCoalesce_ReturnsFirstNonNull(t *testing.T) {
 }
 
 func TestCelCoalesce_AllNull_ReturnsNull(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	// When all values are null, coalesce returns the CEL null type
@@ -132,6 +134,7 @@ func TestCelCoalesce_AllNull_ReturnsNull(t *testing.T) {
 // ============================================================================
 
 func TestCelGetOrDefault_KeyExists(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	result := evalCEL(t, env, `getOrDefault(data, "name", "unknown")`, map[string]interface{}{
@@ -144,6 +147,7 @@ func TestCelGetOrDefault_KeyExists(t *testing.T) {
 }
 
 func TestCelGetOrDefault_KeyMissing(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	result := evalCEL(t, env, `getOrDefault(data, "missing", "default_value")`, map[string]interface{}{
@@ -156,6 +160,7 @@ func TestCelGetOrDefault_KeyMissing(t *testing.T) {
 }
 
 func TestCelGetOrDefault_ValueIsNull(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	result := evalCEL(t, env, `getOrDefault(data, "value", "fallback")`, map[string]interface{}{
@@ -168,6 +173,7 @@ func TestCelGetOrDefault_ValueIsNull(t *testing.T) {
 }
 
 func TestCelGetOrDefault_MapIsNull(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	result := evalCEL(t, env, `getOrDefault(data, "key", "default")`, map[string]interface{}{
@@ -178,6 +184,7 @@ func TestCelGetOrDefault_MapIsNull(t *testing.T) {
 }
 
 func TestCelGetOrDefault_NumericValue(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	result := evalCEL(t, env, `getOrDefault(data, "count", 0)`, map[string]interface{}{
@@ -190,6 +197,7 @@ func TestCelGetOrDefault_NumericValue(t *testing.T) {
 }
 
 func TestCelGetOrDefault_NestedMap(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	result := evalCEL(t, env, `getOrDefault(data.nested, "key", "default")`, map[string]interface{}{
@@ -208,6 +216,7 @@ func TestCelGetOrDefault_NestedMap(t *testing.T) {
 // ============================================================================
 
 func TestCelParseDuration_ParsesMinutes(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	result := evalCEL(t, env, `parseDuration("5m")`, map[string]interface{}{})
@@ -216,6 +225,7 @@ func TestCelParseDuration_ParsesMinutes(t *testing.T) {
 }
 
 func TestCelParseDuration_ParsesHours(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	result := evalCEL(t, env, `parseDuration("2h")`, map[string]interface{}{})
@@ -224,6 +234,7 @@ func TestCelParseDuration_ParsesHours(t *testing.T) {
 }
 
 func TestCelParseDuration_ParsesComplex(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	result := evalCEL(t, env, `parseDuration("1h30m")`, map[string]interface{}{})
@@ -232,6 +243,7 @@ func TestCelParseDuration_ParsesComplex(t *testing.T) {
 }
 
 func TestCelParseDuration_ParsesSeconds(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	result := evalCEL(t, env, `parseDuration("45s")`, map[string]interface{}{})
@@ -240,6 +252,7 @@ func TestCelParseDuration_ParsesSeconds(t *testing.T) {
 }
 
 func TestCelParseDuration_ParsesMilliseconds(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	result := evalCEL(t, env, `parseDuration("500ms")`, map[string]interface{}{})
@@ -248,6 +261,7 @@ func TestCelParseDuration_ParsesMilliseconds(t *testing.T) {
 }
 
 func TestCelParseDuration_ParsesFractional(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	result := evalCEL(t, env, `parseDuration("1.5h")`, map[string]interface{}{})
@@ -256,6 +270,7 @@ func TestCelParseDuration_ParsesFractional(t *testing.T) {
 }
 
 func TestCelParseDuration_InvalidFormat(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	ast, issues := env.Compile(`parseDuration("invalid")`)
@@ -274,6 +289,7 @@ func TestCelParseDuration_InvalidFormat(t *testing.T) {
 // ============================================================================
 
 func TestCelJoin_JoinsStrings(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	result := evalCEL(t, env, `["a", "b", "c"].join(",")`, map[string]interface{}{})
@@ -281,6 +297,7 @@ func TestCelJoin_JoinsStrings(t *testing.T) {
 }
 
 func TestCelJoin_EmptyList(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	result := evalCEL(t, env, `items.join(",")`, map[string]interface{}{"items": []string{}})
@@ -288,6 +305,7 @@ func TestCelJoin_EmptyList(t *testing.T) {
 }
 
 func TestCelJoin_SingleElement(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	result := evalCEL(t, env, `["only"].join(",")`, map[string]interface{}{})
@@ -295,6 +313,7 @@ func TestCelJoin_SingleElement(t *testing.T) {
 }
 
 func TestCelJoin_CustomDelimiter(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	result := evalCEL(t, env, `["a", "b", "c"].join(" | ")`, map[string]interface{}{})
@@ -302,6 +321,7 @@ func TestCelJoin_CustomDelimiter(t *testing.T) {
 }
 
 func TestCelJoin_FromVariable(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	result := evalCEL(t, env, `items.join(",")`, map[string]interface{}{
@@ -311,6 +331,7 @@ func TestCelJoin_FromVariable(t *testing.T) {
 }
 
 func TestCelJoin_MixedTypes(t *testing.T) {
+	t.Parallel()
 	// ext.Strings().join() only supports string lists; mixed-type lists are not supported.
 	// Verify that join on a string-coerced list works by converting each element to string first.
 	env := newTestCELEnv(t)
@@ -324,6 +345,7 @@ func TestCelJoin_MixedTypes(t *testing.T) {
 // ============================================================================
 
 func TestCelNewFunctions_Integration(t *testing.T) {
+	t.Parallel()
 	env := newTestCELEnv(t)
 
 	// Test coalesce with getOrDefault

--- a/internal/workflow/runtime/cel_parse_json_test.go
+++ b/internal/workflow/runtime/cel_parse_json_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestCelParseJsonFunction(t *testing.T) {
+	t.Parallel()
 	t.Run("parses simple object", func(t *testing.T) {
 		env, err := cel.NewEnv(
 			append([]cel.EnvOption{cel.StdLib()}, wfcel.CustomFunctions()...)...,
@@ -243,6 +244,7 @@ func TestCelParseJsonFunction(t *testing.T) {
 }
 
 func TestParseJsonWithMemberFunctions(t *testing.T) {
+	t.Parallel()
 	// Note: last() and first() are member overloads (myList.last(), not last(myList))
 	t.Run("parseJson result with array indexing", func(t *testing.T) {
 		env, err := cel.NewEnv(

--- a/internal/workflow/runtime/cel_to_json_test.go
+++ b/internal/workflow/runtime/cel_to_json_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestCelToJsonFunction(t *testing.T) {
+	t.Parallel()
 	t.Run("serializes simple object", func(t *testing.T) {
 		env, err := cel.NewEnv(
 			append([]cel.EnvOption{cel.StdLib(), cel.Variable("data", cel.DynType)}, wfcel.CustomFunctions()...)...,
@@ -190,6 +191,7 @@ func TestCelToJsonFunction(t *testing.T) {
 }
 
 func TestToJsonAndParseJsonRoundTrip(t *testing.T) {
+	t.Parallel()
 	t.Run("parseJson(toJson(data)) returns original structure", func(t *testing.T) {
 		env, err := cel.NewEnv(
 			append([]cel.EnvOption{cel.StdLib(), cel.Variable("data", cel.DynType)}, wfcel.CustomFunctions()...)...,

--- a/internal/workflow/runtime/cel_while_test.go
+++ b/internal/workflow/runtime/cel_while_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestWhileConditionWithToolCalls(t *testing.T) {
+	t.Parallel()
 	// Simulate what the loop while condition gets: outputs from EvaluateWorkflowOutputs
 	// tool_calls is []interface{} containing map[string]interface{} (from JSON deserialization)
 	outputs := map[string]interface{}{

--- a/internal/workflow/runtime/child_workflow_init_test.go
+++ b/internal/workflow/runtime/child_workflow_init_test.go
@@ -36,6 +36,7 @@ import (
 // `initChildWorkflow(ChildWorkflowInitOpts{...})` in this package), never from
 // a hand-maintained list of files, and an empty set fails loudly.
 func TestEveryChildWorkflowInitPassesParentThread(t *testing.T) {
+	t.Parallel()
 	fset := token.NewFileSet()
 	pkgs, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
 		return !strings.HasSuffix(fi.Name(), "_test.go")
@@ -99,6 +100,7 @@ func (nopLogger) Warn(string, ...interface{})  {}
 func (nopLogger) Error(string, ...interface{}) {}
 
 func TestBuildInjectMessageConfig(t *testing.T) {
+	t.Parallel()
 	logger := nopLogger{}
 
 	t.Run("defaults role and display style", func(t *testing.T) {
@@ -127,6 +129,7 @@ func TestBuildInjectMessageConfig(t *testing.T) {
 }
 
 func TestResolveInjectAttachments(t *testing.T) {
+	t.Parallel()
 	logger := nopLogger{}
 
 	t.Run("nil inject config fields", func(t *testing.T) {

--- a/internal/workflow/runtime/content_free_assistant_save_test.go
+++ b/internal/workflow/runtime/content_free_assistant_save_test.go
@@ -80,6 +80,7 @@ func runInlineSave(
 // The skip itself: role=assistant with no content, no tool calls and no
 // thinking must return cleanly without dispatching anything.
 func TestInlineSave_ContentFreeAssistantIsSkipped(t *testing.T) {
+	t.Parallel()
 	dispatched, err := runInlineSave(t,
 		&reliantv1.SaveMessageConfig{Role: celLit("assistant")},
 		map[string]interface{}{},
@@ -95,6 +96,7 @@ func TestInlineSave_ContentFreeAssistantIsSkipped(t *testing.T) {
 // (strings.EqualFold), so the spelling must not decide whether poison is
 // written.
 func TestInlineSave_ContentFreeAssistantSkipIsCaseInsensitive(t *testing.T) {
+	t.Parallel()
 	for _, role := range []string{"Assistant", "ASSISTANT"} {
 		t.Run(role, func(t *testing.T) {
 			dispatched, err := runInlineSave(t,
@@ -111,6 +113,7 @@ func TestInlineSave_ContentFreeAssistantSkipIsCaseInsensitive(t *testing.T) {
 // enough to make the message real — the skip must not swallow a turn that had
 // something to say.
 func TestInlineSave_AnyContentStillDispatches(t *testing.T) {
+	t.Parallel()
 	t.Run("text", func(t *testing.T) {
 		dispatched, err := runInlineSave(t,
 			&reliantv1.SaveMessageConfig{
@@ -169,6 +172,7 @@ func TestInlineSave_AnyContentStillDispatches(t *testing.T) {
 // message is a different question with a different validator, and must not be
 // swept up by this gate.
 func TestInlineSave_NonAssistantRolesAreUnaffected(t *testing.T) {
+	t.Parallel()
 	for _, role := range []string{"user", "tool", "system"} {
 		t.Run(role, func(t *testing.T) {
 			dispatched, err := runInlineSave(t,

--- a/internal/workflow/runtime/context_test.go
+++ b/internal/workflow/runtime/context_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestNewExecutionContext(t *testing.T) {
+	t.Parallel()
 	ctx := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0")
 
 	assert.Equal(t, "wf-123", ctx.WorkflowID)
@@ -22,6 +23,7 @@ func TestNewExecutionContext(t *testing.T) {
 }
 
 func TestExecutionContext_WithThreadMode(t *testing.T) {
+	t.Parallel()
 	ctx := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0").
 		WithThreadMode(model.ThreadModeFork, "parent-thread")
 
@@ -30,6 +32,7 @@ func TestExecutionContext_WithThreadMode(t *testing.T) {
 }
 
 func TestExecutionContext_WithParent(t *testing.T) {
+	t.Parallel()
 	ctx := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0").
 		WithParent("parent-wf", "step-path")
 
@@ -39,6 +42,7 @@ func TestExecutionContext_WithParent(t *testing.T) {
 }
 
 func TestExecutionContext_WithLoop(t *testing.T) {
+	t.Parallel()
 	ctx := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0").
 		WithLoop("agent_loop", 5)
 
@@ -48,6 +52,7 @@ func TestExecutionContext_WithLoop(t *testing.T) {
 }
 
 func TestExecutionContext_ForIteration_StaticKey(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0").
 		WithLoop("agent_loop", 0)
 
@@ -67,6 +72,7 @@ func TestExecutionContext_ForIteration_StaticKey(t *testing.T) {
 }
 
 func TestExecutionContext_ForChild_Inherit(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0")
 
 	child := parent.ForChild("call_llm", model.ThreadModeInherit, "sub-workflow", true)
@@ -81,6 +87,7 @@ func TestExecutionContext_ForChild_Inherit(t *testing.T) {
 }
 
 func TestExecutionContext_ForChild_Own(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0")
 
 	child := parent.ForChild("new_thread_step", model.ThreadModeNew, "sub-workflow", true)
@@ -91,6 +98,7 @@ func TestExecutionContext_ForChild_Own(t *testing.T) {
 }
 
 func TestExecutionContext_ForChild_Fork(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0")
 
 	child := parent.ForChild("fork_step", model.ThreadModeFork, "sub-workflow", true)
@@ -101,6 +109,7 @@ func TestExecutionContext_ForChild_Fork(t *testing.T) {
 }
 
 func TestExecutionContext_ForChild_DeterministicThreads(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0")
 
 	// Same step + mode should produce same thread
@@ -115,6 +124,7 @@ func TestExecutionContext_ForChild_DeterministicThreads(t *testing.T) {
 }
 
 func TestExecutionContext_ForChildWorkflow(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0")
 
 	child := parent.ForChildWorkflow("child-wf-789", "spawn_step", model.ThreadModeInherit, "child-workflow", true)
@@ -128,6 +138,7 @@ func TestExecutionContext_ForChildWorkflow(t *testing.T) {
 }
 
 func TestExecutionContext_Helpers(t *testing.T) {
+	t.Parallel()
 	ctx := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0")
 
 	assert.False(t, ctx.IsInLoop())
@@ -141,6 +152,7 @@ func TestExecutionContext_Helpers(t *testing.T) {
 }
 
 func TestExecutionContext_WithProjectPath(t *testing.T) {
+	t.Parallel()
 	ctx := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0").
 		WithProjectPath("/path/to/worktree")
 
@@ -149,6 +161,7 @@ func TestExecutionContext_WithProjectPath(t *testing.T) {
 }
 
 func TestExecutionContext_HasProjectPath_Empty(t *testing.T) {
+	t.Parallel()
 	ctx := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0")
 
 	assert.Empty(t, ctx.ProjectPath)
@@ -156,6 +169,7 @@ func TestExecutionContext_HasProjectPath_Empty(t *testing.T) {
 }
 
 func TestExecutionContext_ForIteration_PropagatesProjectPath(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0").
 		WithProjectPath("/path/to/worktree").
 		WithLoop("agent_loop", 0)
@@ -168,6 +182,7 @@ func TestExecutionContext_ForIteration_PropagatesProjectPath(t *testing.T) {
 }
 
 func TestExecutionContext_ForChild_PropagatesProjectPath(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0").
 		WithProjectPath("/path/to/worktree")
 
@@ -179,6 +194,7 @@ func TestExecutionContext_ForChild_PropagatesProjectPath(t *testing.T) {
 }
 
 func TestExecutionContext_ForChildWorkflow_PropagatesProjectPath(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0").
 		WithProjectPath("/path/to/worktree")
 
@@ -223,6 +239,7 @@ func TestExecutionContext_Clone(t *testing.T) {
 }
 
 func TestForChild_MemoFalse_InLoop_Fork(t *testing.T) {
+	t.Parallel()
 	parent := &ExecutionContext{
 		WorkflowID: "wf-1",
 		Thread:     "parent-thread",
@@ -248,6 +265,7 @@ func TestForChild_MemoFalse_InLoop_Fork(t *testing.T) {
 }
 
 func TestForChild_MemoTrue_InLoop_Fork(t *testing.T) {
+	t.Parallel()
 	parent := &ExecutionContext{
 		WorkflowID: "wf-1",
 		Thread:     "parent-thread",
@@ -264,6 +282,7 @@ func TestForChild_MemoTrue_InLoop_Fork(t *testing.T) {
 }
 
 func TestForChild_MemoFalse_NotInLoop(t *testing.T) {
+	t.Parallel()
 	parent := &ExecutionContext{
 		WorkflowID: "wf-1",
 		Thread:     "parent-thread",
@@ -278,6 +297,7 @@ func TestForChild_MemoFalse_NotInLoop(t *testing.T) {
 }
 
 func TestForChild_MemoFalse_InLoop_New(t *testing.T) {
+	t.Parallel()
 	parent := &ExecutionContext{
 		WorkflowID: "wf-1",
 		Thread:     "parent-thread",
@@ -293,6 +313,7 @@ func TestForChild_MemoFalse_InLoop_New(t *testing.T) {
 }
 
 func TestForChild_MemoFalse_InLoop_Inherit(t *testing.T) {
+	t.Parallel()
 	parent := &ExecutionContext{
 		WorkflowID: "wf-1",
 		Thread:     "parent-thread",

--- a/internal/workflow/runtime/continue_as_new_test.go
+++ b/internal/workflow/runtime/continue_as_new_test.go
@@ -20,6 +20,7 @@ import (
 const oneMB = 1024 * 1024
 
 func TestHistoryNeedsContinueAsNew(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		length    int
@@ -58,6 +59,7 @@ func TestHistoryNeedsContinueAsNew(t *testing.T) {
 // over 73 turns of real history. Event density: 517–1,157 bytes/event across
 // sampled production runs.
 func TestThresholdsLeaveHeadroomForWorstCaseTurns(t *testing.T) {
+	t.Parallel()
 	const (
 		countCap          = 51200      // limit.historyCount.error
 		sizeCap           = 50 * oneMB // limit.historySize.error
@@ -81,6 +83,7 @@ func TestThresholdsLeaveHeadroomForWorstCaseTurns(t *testing.T) {
 // Neither threshold may sit at or above the limit it protects against — that
 // would mean handing off only once the run is already dead.
 func TestThresholdsStayBelowTemporalLimits(t *testing.T) {
+	t.Parallel()
 	require.Less(t, continueAsNewEventThreshold, 51200,
 		"count threshold must be below limit.historyCount.error")
 	require.Less(t, continueAsNewSizeThreshold, 50*oneMB,
@@ -93,6 +96,7 @@ func TestThresholdsStayBelowTemporalLimits(t *testing.T) {
 // always trips first. This pins the decision to ignore it: a history well past
 // the server's hint but short of ours must NOT trigger a handoff.
 func TestServerSuggestionThresholdIsNotUsed(t *testing.T) {
+	t.Parallel()
 	const (
 		serverCountHint = 4096
 		serverSizeHint  = 4 * oneMB
@@ -108,6 +112,7 @@ func TestServerSuggestionThresholdIsNotUsed(t *testing.T) {
 // =========================================================================
 
 func TestQuiescentForContinueAsNew(t *testing.T) {
+	t.Parallel()
 	trackerWithSpawn := func() *ChildWorkflowTracker {
 		tracker := &ChildWorkflowTracker{}
 		tracker.registerDetachedSpawn(&detachedSpawnRecord{
@@ -164,6 +169,7 @@ type ContinueAsNewInputTestSuite struct {
 }
 
 func TestContinueAsNewInput(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(ContinueAsNewInputTestSuite))
 }
 
@@ -209,6 +215,7 @@ func (s *ContinueAsNewInputTestSuite) TestCarriesResumePositionAndInputs() {
 // predecessor stopped at. This is the round trip that makes the continuation
 // correct, and it goes through the same resolver the coarse restart uses.
 func TestContinuationPositionResolvesBackToLoop(t *testing.T) {
+	t.Parallel()
 	wf := resumeTestWorkflow(t, `
 name: single-loop
 entry: [agent_loop]
@@ -256,6 +263,7 @@ type ContinueAsNewClassifyTestSuite struct {
 }
 
 func TestContinueAsNewClassify(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(ContinueAsNewClassifyTestSuite))
 }
 
@@ -282,6 +290,7 @@ func (s *ContinueAsNewClassifyTestSuite) TestIsContinueAsNew() {
 // verbatim. Anything less exact means the successor either redoes work or
 // skips it.
 func TestLoopBoundaryCheckOrdering(t *testing.T) {
+	t.Parallel()
 	var events []string
 
 	executor := &InlineLoopExecutor{}
@@ -312,6 +321,7 @@ func TestLoopBoundaryCheckOrdering(t *testing.T) {
 // DynamicWorkflow's top-level wiring sets the check. An executor without it
 // runs its boundary unchanged.
 func TestNestedLoopHasNoContinueAsNewCheck(t *testing.T) {
+	t.Parallel()
 	executor := &InlineLoopExecutor{}
 	require.Nil(t, executor.continueAsNewCheck,
 		"a bare executor must not continue as new; only top-level loops opt in")
@@ -330,6 +340,7 @@ type ContinueAsNewCompletionTestSuite struct {
 }
 
 func TestContinueAsNewCompletion(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(ContinueAsNewCompletionTestSuite))
 }
 

--- a/internal/workflow/runtime/core_runtime_bridge_inputs_test.go
+++ b/internal/workflow/runtime/core_runtime_bridge_inputs_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestInlineWorkflowExecutor_BuildSubWorkflowInputs_UsesCoreInputPolicy(t *testing.T) {
+	t.Parallel()
 	t.Run("inline policy shares parent map reference", func(t *testing.T) {
 		parentInputs := map[string]interface{}{"model": "gpt-5", "mode": "auto"}
 		executor := &InlineWorkflowExecutor{
@@ -108,6 +109,7 @@ func (l *runtimeBridgeNoopLogger) Warn(string, ...interface{})  {}
 func (l *runtimeBridgeNoopLogger) Error(string, ...interface{}) {}
 
 func TestInlineLoopExecutor_BuildIterationInputs_UsesCoreInputPolicy(t *testing.T) {
+	t.Parallel()
 	loopNode := &reliantv1.Node{
 		Id:   "loop_node",
 		Type: "loop",

--- a/internal/workflow/runtime/core_runtime_bridge_test.go
+++ b/internal/workflow/runtime/core_runtime_bridge_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestCompileRuntimeSemantics_SubWorkflowContracts(t *testing.T) {
+	t.Parallel()
 	workflowDef := &reliantv1.Workflow{
 		Name: "root",
 		Nodes: []*reliantv1.Node{
@@ -81,6 +82,7 @@ func TestCompileRuntimeSemantics_SubWorkflowContracts(t *testing.T) {
 }
 
 func TestSimplifiedStateMachine_FindTriggeredNodes_PropagatesCoreProcessorErrors(t *testing.T) {
+	t.Parallel()
 	workflowDef := &reliantv1.Workflow{
 		Nodes: []*reliantv1.Node{
 			{Id: "call_llm", Type: "call_llm"},
@@ -112,6 +114,7 @@ func TestSimplifiedStateMachine_FindTriggeredNodes_PropagatesCoreProcessorErrors
 }
 
 func TestCompileRuntimeSemantics_CompileErrorsIncludeBridgeContext(t *testing.T) {
+	t.Parallel()
 	workflowDef := &reliantv1.Workflow{
 		Name: "broken",
 		Nodes: []*reliantv1.Node{{

--- a/internal/workflow/runtime/daemon_offline_tracker_test.go
+++ b/internal/workflow/runtime/daemon_offline_tracker_test.go
@@ -96,6 +96,7 @@ func callLLMEvent() *StepEvent {
 // ============================================================================
 
 func TestDaemonOfflineCircuitBreaker_NilSafe(t *testing.T) {
+	t.Parallel()
 	var b *DaemonOfflineCircuitBreaker
 	// Must be no-ops on nil receiver, never panic.
 	b.ObserveStep(nil, "ExecuteTools", offlineToolResultsEvent())
@@ -110,6 +111,7 @@ func TestDaemonOfflineCircuitBreaker_NilSafe(t *testing.T) {
 }
 
 func TestDaemonOfflineCircuitBreaker_CounterAndPauseSemantics(t *testing.T) {
+	t.Parallel()
 	type step struct {
 		activityName string
 		event        *StepEvent
@@ -272,6 +274,7 @@ func TestDaemonOfflineCircuitBreaker_CounterAndPauseSemantics(t *testing.T) {
 }
 
 func TestDaemonOfflineCircuitBreaker_NilPauseCallbackOnlyCounts(t *testing.T) {
+	t.Parallel()
 	b := NewDaemonOfflineCircuitBreaker(DaemonOfflinePauseThreshold, nil)
 	for i := 0; i < 5; i++ {
 		b.ObserveStep(nil, "ExecuteTools", offlineToolResultsEvent())
@@ -291,6 +294,7 @@ type DaemonOfflinePauseSuite struct {
 }
 
 func TestDaemonOfflinePause(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(DaemonOfflinePauseSuite))
 }
 

--- a/internal/workflow/runtime/defaults_trace_test.go
+++ b/internal/workflow/runtime/defaults_trace_test.go
@@ -11,6 +11,7 @@ import (
 // TestDefaultsTraceE2E traces the full flow from parsing to buildWorkflowContext
 // to verify defaults are preserved through the entire path
 func TestDefaultsTraceE2E(t *testing.T) {
+	t.Parallel()
 	yamlData := []byte(`
 name: test-loop-workflow
 apiVersion: "0.0.6"
@@ -105,6 +106,7 @@ nodes:
 
 // TestDefaultsJSONRoundTrip tests that defaults survive the YAML->proto round trip
 func TestDefaultsJSONRoundTrip(t *testing.T) {
+	t.Parallel()
 	yamlData := []byte(`
 name: test-roundtrip-workflow
 apiVersion: "0.0.6"

--- a/internal/workflow/runtime/edge_routing_test.go
+++ b/internal/workflow/runtime/edge_routing_test.go
@@ -14,6 +14,7 @@ import (
 // multiple cases: one with a condition and one default (no condition).
 // This pattern was failing in the context-reducing-turn workflow.
 func TestEdgeRoutingWithConditionalAndDefault(t *testing.T) {
+	t.Parallel()
 	// Workflow with conditional + default edge cases from a single step
 	wfJSON := `{
 		"name": "test-conditional-default",
@@ -118,6 +119,7 @@ func TestEdgeRoutingWithConditionalAndDefault(t *testing.T) {
 // when numbers have been through JSON serialization (int -> float64).
 // This is important because Temporal serializes activity outputs as JSON.
 func TestEdgeRoutingWithJSONSerializedNumbers(t *testing.T) {
+	t.Parallel()
 	wfJSON := `{
 		"name": "test-json-numbers",
 		"nodes": [
@@ -237,6 +239,7 @@ func TestEdgeRoutingWithJSONSerializedNumbers(t *testing.T) {
 // TestEdgeRoutingWithMissingField tests behavior when the condition references
 // a field that doesn't exist in the step output.
 func TestEdgeRoutingWithMissingField(t *testing.T) {
+	t.Parallel()
 	wfJSON := `{
 		"name": "test-missing-field",
 		"nodes": [
@@ -290,6 +293,7 @@ func TestEdgeRoutingWithMissingField(t *testing.T) {
 // TestEdgeRoutingWithNullValue tests behavior when the condition references
 // a field that is explicitly null.
 func TestEdgeRoutingWithNullValue(t *testing.T) {
+	t.Parallel()
 	wfJSON := `{
 		"name": "test-null-value",
 		"nodes": [
@@ -389,6 +393,7 @@ func TestEdgeRoutingWithNullValue(t *testing.T) {
 
 // TestEdgeRoutingMultipleCases tests edge routing with more than two cases.
 func TestEdgeRoutingMultipleCases(t *testing.T) {
+	t.Parallel()
 	wfJSON := `{
 		"name": "test-multiple-cases",
 		"nodes": [
@@ -464,6 +469,7 @@ func TestEdgeRoutingMultipleCases(t *testing.T) {
 // TestEdgeRoutingContextReducingPattern tests the exact pattern that was used
 // in context-reducing-turn workflow before simplification.
 func TestEdgeRoutingContextReducingPattern(t *testing.T) {
+	t.Parallel()
 	// This is the pattern that was failing in runtime:
 	// execute_tools -> filter_results (if total_result_chars > 4000)
 	// execute_tools -> save_tool_results (default)
@@ -639,6 +645,7 @@ func TestEdgeRoutingContextReducingPattern(t *testing.T) {
 
 // TestEdgeRoutingWithNestedMapAccess tests conditions that access nested map fields.
 func TestEdgeRoutingWithNestedMapAccess(t *testing.T) {
+	t.Parallel()
 	wfJSON := `{
 		"name": "test-nested-access",
 		"nodes": [
@@ -721,6 +728,7 @@ func TestEdgeRoutingWithNestedMapAccess(t *testing.T) {
 
 // TestEdgeRoutingNoMatchingEdge tests behavior when no edge matches the event source.
 func TestEdgeRoutingNoMatchingEdge(t *testing.T) {
+	t.Parallel()
 	wfJSON := `{
 		"name": "test-no-edge",
 		"nodes": [
@@ -764,6 +772,7 @@ func TestEdgeRoutingNoMatchingEdge(t *testing.T) {
 // TestEdgeRoutingAllConditionsFail tests behavior when all conditional cases fail
 // and there's no default case.
 func TestEdgeRoutingAllConditionsFail(t *testing.T) {
+	t.Parallel()
 	wfJSON := `{
 		"name": "test-all-fail",
 		"nodes": [
@@ -818,6 +827,7 @@ func TestEdgeRoutingAllConditionsFail(t *testing.T) {
 // for edge condition evaluation. This is important for workflows like thread-demo
 // that use conditions like: has(inputs.message.role) ? inputs.message.role == "user" : true
 func TestEdgeRoutingWithInputsNamespace(t *testing.T) {
+	t.Parallel()
 	wfJSON := `{
 		"name": "test-inputs-namespace",
 		"nodes": [

--- a/internal/workflow/runtime/edge_tool_calls_test.go
+++ b/internal/workflow/runtime/edge_tool_calls_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestEdgeCondition_ToolCallsNotNull(t *testing.T) {
+	t.Parallel()
 	// Simulate what happens when call_llm returns tool calls
 	// After Temporal serialization/deserialization, tool_calls becomes []interface{}{...}
 	nodeOutputs := map[string]interface{}{

--- a/internal/workflow/runtime/empty_prompt_runtime_test.go
+++ b/internal/workflow/runtime/empty_prompt_runtime_test.go
@@ -9,6 +9,7 @@ import (
 // for empty prompts in agent nodes. The actual runtime behavior is tested via integration
 // tests that run real workflows.
 func TestEmptyPromptRuntimeValidation_Documentation(t *testing.T) {
+	t.Parallel()
 	t.Run("Runtime validation prevents empty prompts", func(t *testing.T) {
 		t.Log("")
 		t.Log("╔══════════════════════════════════════════════════════════════════╗")

--- a/internal/workflow/runtime/engine_load_workflow_test.go
+++ b/internal/workflow/runtime/engine_load_workflow_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestLoadWorkflow_ProtoJSONRoundTrip_PreservesSaveMessageNode(t *testing.T) {
+	t.Parallel()
 	yamlData := []byte(`
 name: save-message-regression
 apiVersion: v2
@@ -41,6 +42,7 @@ nodes:
 }
 
 func TestLoadWorkflow_LegacyJSONFallback_StillSupportsArgsShape(t *testing.T) {
+	t.Parallel()
 	legacyJSON := []byte(`{
   "name": "legacy-shape",
   "entry": ["save"],

--- a/internal/workflow/runtime/engine_node_type_test.go
+++ b/internal/workflow/runtime/engine_node_type_test.go
@@ -3,6 +3,7 @@ package runtime
 import "testing"
 
 func TestIsActivityType_KnownActivityTypes(t *testing.T) {
+	t.Parallel()
 	activityTypes := []string{
 		"call_llm",
 		"execute_tools",
@@ -19,6 +20,7 @@ func TestIsActivityType_KnownActivityTypes(t *testing.T) {
 }
 
 func TestIsActivityType_StructuralTypes(t *testing.T) {
+	t.Parallel()
 	structuralTypes := []string{
 		"run",
 		"workflow",
@@ -34,6 +36,7 @@ func TestIsActivityType_StructuralTypes(t *testing.T) {
 }
 
 func TestIsActivityType_RejectsUnknownTypes(t *testing.T) {
+	t.Parallel()
 	// These are the critical cases: unknown strings that previously would
 	// have been dispatched as Temporal activities, causing ActivityNotRegisteredError.
 	unknownTypes := []string{
@@ -52,6 +55,7 @@ func TestIsActivityType_RejectsUnknownTypes(t *testing.T) {
 }
 
 func TestNodeTypeToActivityName_KnownTypes(t *testing.T) {
+	t.Parallel()
 	tests := map[string]string{
 		"call_llm":        "CallLLM",
 		"execute_tools":   "ExecuteTools",
@@ -69,6 +73,7 @@ func TestNodeTypeToActivityName_KnownTypes(t *testing.T) {
 }
 
 func TestNodeTypeToActivityName_EmptyReturnsEmpty(t *testing.T) {
+	t.Parallel()
 	if got := nodeTypeToActivityName(""); got != "" {
 		t.Errorf("nodeTypeToActivityName(\"\") = %q, want empty", got)
 	}
@@ -78,6 +83,7 @@ func TestNodeTypeToActivityName_EmptyReturnsEmpty(t *testing.T) {
 // must reject unknown types: snakeToPascal("null") produces "Null", which is
 // not a registered activity name.
 func TestNodeTypeToActivityName_NullProducesBadName(t *testing.T) {
+	t.Parallel()
 	got := nodeTypeToActivityName("null")
 	if got != "Null" {
 		t.Fatalf("expected nodeTypeToActivityName(\"null\") = \"Null\", got %q", got)

--- a/internal/workflow/runtime/entry_execution_test.go
+++ b/internal/workflow/runtime/entry_execution_test.go
@@ -15,6 +15,7 @@ import (
 // ============================================================================
 
 func TestEntryExecution_SingleEntry(t *testing.T) {
+	t.Parallel()
 	t.Run("workflow with single entry triggers correct node on start", func(t *testing.T) {
 		wfJSON := `{
 			"name": "test-workflow",
@@ -92,6 +93,7 @@ func TestEntryExecution_SingleEntry(t *testing.T) {
 // ============================================================================
 
 func TestEntryExecution_MultipleEntryPoints(t *testing.T) {
+	t.Parallel()
 	t.Run("workflow with multiple entries triggers all nodes in parallel", func(t *testing.T) {
 		wfJSON := `{
 			"name": "parallel-start-workflow",
@@ -159,6 +161,7 @@ func TestEntryExecution_MultipleEntryPoints(t *testing.T) {
 // ============================================================================
 
 func TestEntryExecution_EntryFieldHelpers(t *testing.T) {
+	t.Parallel()
 	t.Run("workflow without entry field", func(t *testing.T) {
 		wfJSON := `{
 			"name": "missing-entry-workflow",
@@ -200,6 +203,7 @@ func TestEntryExecution_EntryFieldHelpers(t *testing.T) {
 // ============================================================================
 
 func TestEntryExecution_EdgeCases(t *testing.T) {
+	t.Parallel()
 	t.Run("GetEntryNodes handles different Entry values", func(t *testing.T) {
 		// Test single entry
 		wf1JSON := `{"name":"t1","entry": ["single_node"],"nodes":[{"id":"single_node","type":"a"}],"edges":[]}`

--- a/internal/workflow/runtime/entry_points_test.go
+++ b/internal/workflow/runtime/entry_points_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestFindTriggeredNodes_WithEntryPoints(t *testing.T) {
+	t.Parallel()
 	t.Run("workflow with entry field from JSON", func(t *testing.T) {
 		wfJSON := `{
             "name": "test",
@@ -48,6 +49,7 @@ func TestFindTriggeredNodes_WithEntryPoints(t *testing.T) {
 }
 
 func TestLoopExecutor_InlineWithEntry(t *testing.T) {
+	t.Parallel()
 	// Test that inline loop sub-workflows with entry fields work correctly.
 	// Use a direct proto workflow to avoid v3 type casting issues.
 	wfJSON := `{

--- a/internal/workflow/runtime/error_summary_test.go
+++ b/internal/workflow/runtime/error_summary_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestExtractLLMErrorSummary(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		errMsg   string
@@ -93,6 +94,7 @@ func TestExtractLLMErrorSummary(t *testing.T) {
 }
 
 func TestCleanTemporalError(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		errMsg   string

--- a/internal/workflow/runtime/evaluate_outputs_map_test.go
+++ b/internal/workflow/runtime/evaluate_outputs_map_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestEvaluateOutputsMap(t *testing.T) {
+	t.Parallel()
 	t.Run("basic field access via outputs namespace", func(t *testing.T) {
 		outputsMap := map[string]string{
 			"message": "outputs.response_text",

--- a/internal/workflow/runtime/inject_idempotency_test.go
+++ b/internal/workflow/runtime/inject_idempotency_test.go
@@ -45,6 +45,7 @@ func iter(n int64) *int64 { return &n }
 // the key must not vary with anything the run owns. Here the same logical frame
 // is keyed twice, as the original run and its resume would.
 func TestInjectKey_IsStableAcrossRuns(t *testing.T) {
+	t.Parallel()
 	frame := func() string {
 		return injectIdempotencyKey(injectOpts("wf-root", "thread-impl", "implement", iter(0)))
 	}
@@ -67,6 +68,7 @@ func TestInjectKey_IsStableAcrossRuns(t *testing.T) {
 // ForChild resolves them to different threads, so collapsing them here would
 // suppress a legitimate injection.
 func TestInjectKey_LoopPresenceIsDistinctFromIterationZero(t *testing.T) {
+	t.Parallel()
 	inLoop := injectIdempotencyKey(injectOpts("wf-root", "thread-a", "implement", iter(0)))
 	noLoop := injectIdempotencyKey(injectOpts("wf-root", "thread-a", "implement", nil))
 
@@ -78,6 +80,7 @@ func TestInjectKey_LoopPresenceIsDistinctFromIterationZero(t *testing.T) {
 // Each iteration of a retry loop is a genuinely new instruction ("Attempt 2 of
 // 4"), so each must inject.
 func TestInjectKey_EachIterationInjects(t *testing.T) {
+	t.Parallel()
 	seen := map[string]int{}
 	for i := int64(0); i < 4; i++ {
 		seen[injectIdempotencyKey(injectOpts("wf-root", "thread-a", "implement", iter(i)))]++
@@ -89,6 +92,7 @@ func TestInjectKey_EachIterationInjects(t *testing.T) {
 
 // Two different nodes seeding two different children must not share a key.
 func TestInjectKey_DistinctNodesAndThreads(t *testing.T) {
+	t.Parallel()
 	base := injectIdempotencyKey(injectOpts("wf-root", "thread-a", "implement", iter(1)))
 
 	assert.NotEqual(t, base,
@@ -144,6 +148,7 @@ func TestInjectKey_MemoIsCapturedViaThreadIdentity(t *testing.T) {
 // concatenating components, so a component that is empty or that contains the
 // separator could let two different frames render the same string.
 func TestInjectKey_ComponentsCannotCollideThroughFormatting(t *testing.T) {
+	t.Parallel()
 	// A node ID containing the separator must not be able to impersonate a
 	// different (thread, node) split.
 	a := injectIdempotencyKey(injectOpts("wf", "thread|implement", "review", iter(0)))

--- a/internal/workflow/runtime/inject_node_outputs_test.go
+++ b/internal/workflow/runtime/inject_node_outputs_test.go
@@ -321,6 +321,7 @@ func TestInjectWithMissingResponseTextKey(t *testing.T) {
 
 // TestLoopIterationNodeOutputIsolation verifies that each iteration has isolated nodeOutputs
 func TestLoopIterationNodeOutputIsolation(t *testing.T) {
+	t.Parallel()
 	t.Run("iteration outputs are isolated", func(t *testing.T) {
 		iter1Outputs := make(map[string]interface{})
 		iter1Outputs["step_a"] = map[string]interface{}{"value": "iteration-1-value"}

--- a/internal/workflow/runtime/inline_workflow_executor_test.go
+++ b/internal/workflow/runtime/inline_workflow_executor_test.go
@@ -48,6 +48,7 @@ func hasPresetLogMessage(entries []presetLogEntry, substr string) bool {
 }
 
 func TestApplyPresets(t *testing.T) {
+	t.Parallel()
 	t.Run("literal preset name still works", func(t *testing.T) {
 		logger := &presetTestLogger{}
 		subInputs := map[string]interface{}{}
@@ -170,6 +171,7 @@ func TestApplyPresets(t *testing.T) {
 }
 
 func TestMergePresetParams(t *testing.T) {
+	t.Parallel()
 	t.Run("default group flattens to top-level", func(t *testing.T) {
 		subInputs := map[string]interface{}{"keep": "me"}
 		mergePresetParams(subInputs, DefaultPresetGroup, map[string]interface{}{"a": 1, "b": 2})
@@ -198,6 +200,7 @@ func TestMergePresetParams(t *testing.T) {
 }
 
 func TestBuildSubWorkflowInputs_PassthroughNegative(t *testing.T) {
+	t.Parallel()
 	makeExecutor := func(parentInputs, subInputs map[string]interface{}, passthrough []string) *InlineWorkflowExecutor {
 		evalResult := &reliantv1.Node{
 			Id:   "child",
@@ -274,6 +277,7 @@ func TestBuildSubWorkflowInputs_PassthroughNegative(t *testing.T) {
 }
 
 func TestBuildSubWorkflowInputs_Passthrough(t *testing.T) {
+	t.Parallel()
 	// Helper to create an executor with minimal state for buildSubWorkflowInputs testing.
 	makeExecutor := func(parentInputs, subInputs map[string]interface{}, passthrough []string) *InlineWorkflowExecutor {
 		evalResult := &reliantv1.Node{

--- a/internal/workflow/runtime/interrupt_livelock_test.go
+++ b/internal/workflow/runtime/interrupt_livelock_test.go
@@ -51,6 +51,7 @@ import (
 // SDK resolves the future with ErrCanceled, which carries no details.
 // (go.temporal.io/sdk/internal/context.go: ErrCanceled = NewCanceledError())
 func TestInterruptedStep_BareCancelCannotSettle_ForcesRedispatch(t *testing.T) {
+	t.Parallel()
 	err := temporal.NewCanceledError()
 
 	var canceledErr *temporal.CanceledError
@@ -71,6 +72,7 @@ func TestInterruptedStep_BareCancelCannotSettle_ForcesRedispatch(t *testing.T) {
 // A CallLLM-shaped cancellation, by contrast, settles — which is why an
 // interrupted LLM turn advances the loop instead of repeating it.
 func TestInterruptedStep_CancelWithDetailsSettles_AdvancesLoop(t *testing.T) {
+	t.Parallel()
 	partial := map[string]interface{}{
 		"message":       map[string]interface{}{"role": "assistant", "text": "partial answer"},
 		"pending_inbox": true,

--- a/internal/workflow/runtime/join_test.go
+++ b/internal/workflow/runtime/join_test.go
@@ -21,6 +21,7 @@ func loadTestWorkflow(t *testing.T, wfJSON string) *reliantv1.Workflow {
 }
 
 func TestJoinState_InitializeJoins(t *testing.T) {
+	t.Parallel()
 	workflow := loadTestWorkflow(t, `{
 		"name": "test-join",
 		"entry": ["started"],
@@ -55,6 +56,7 @@ func TestJoinState_InitializeJoins(t *testing.T) {
 }
 
 func TestJoinState_RecordCompletion(t *testing.T) {
+	t.Parallel()
 	workflow := loadTestWorkflow(t, `{
 		"name": "test-join",
 		"entry": ["task_a"],
@@ -90,6 +92,7 @@ func TestJoinState_RecordCompletion(t *testing.T) {
 }
 
 func TestJoinState_IsJoinSatisfied_All(t *testing.T) {
+	t.Parallel()
 	workflow := loadTestWorkflow(t, `{
 		"name": "test-join",
 		"entry": ["task_a"],
@@ -120,6 +123,7 @@ func TestJoinState_IsJoinSatisfied_All(t *testing.T) {
 }
 
 func TestJoinState_IsJoinSatisfied_Any(t *testing.T) {
+	t.Parallel()
 	workflow := loadTestWorkflow(t, `{
 		"name": "test-join",
 		"entry": ["task_a"],
@@ -146,6 +150,7 @@ func TestJoinState_IsJoinSatisfied_Any(t *testing.T) {
 }
 
 func TestJoinState_MarkTriggered(t *testing.T) {
+	t.Parallel()
 	workflow := loadTestWorkflow(t, `{
 		"name": "test-join",
 		"entry": ["task_a"],
@@ -172,6 +177,7 @@ func TestJoinState_MarkTriggered(t *testing.T) {
 }
 
 func TestJoinState_GetJoinOutput(t *testing.T) {
+	t.Parallel()
 	workflow := loadTestWorkflow(t, `{
 		"name": "test-join",
 		"entry": ["task_a"],
@@ -212,6 +218,7 @@ func TestJoinState_GetJoinOutput(t *testing.T) {
 }
 
 func TestJoinState_DuplicateEdges(t *testing.T) {
+	t.Parallel()
 	// Test that duplicate edges to same join don't create duplicate sources
 	workflow := loadTestWorkflow(t, `{
 		"name": "test-join",
@@ -235,6 +242,7 @@ func TestJoinState_DuplicateEdges(t *testing.T) {
 }
 
 func TestJoinState_NonJoinStep(t *testing.T) {
+	t.Parallel()
 	// Test that non-join steps don't create progress entries
 	workflow := loadTestWorkflow(t, `{
 		"name": "test-no-join",
@@ -264,6 +272,7 @@ func (l *testLogger) Info(msg string, keyvals ...interface{}) {
 }
 
 func TestProcessJoinEvents_ConditionAll(t *testing.T) {
+	t.Parallel()
 	workflow := loadTestWorkflow(t, `{
 		"name": "test-join",
 		"entry": ["task_a"],
@@ -330,6 +339,7 @@ func TestProcessJoinEvents_ConditionAll(t *testing.T) {
 }
 
 func TestProcessJoinEvents_ConditionAny(t *testing.T) {
+	t.Parallel()
 	workflow := loadTestWorkflow(t, `{
 		"name": "test-join",
 		"entry": ["task_a"],
@@ -374,6 +384,7 @@ func TestProcessJoinEvents_ConditionAny(t *testing.T) {
 }
 
 func TestProcessJoinEvents_SkipsWorkflowStartEvent(t *testing.T) {
+	t.Parallel()
 	workflow := loadTestWorkflow(t, `{
 		"name": "test-join",
 		"entry": ["task_a"],
@@ -404,6 +415,7 @@ func TestProcessJoinEvents_SkipsWorkflowStartEvent(t *testing.T) {
 }
 
 func TestExpandJoinCondition(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -424,6 +436,7 @@ func TestExpandJoinCondition(t *testing.T) {
 }
 
 func TestJoinState_SkippedSourcesSatisfyAllCondition(t *testing.T) {
+	t.Parallel()
 	workflow := loadTestWorkflow(t, `{
 		"name": "test-join-skipped",
 		"entry": ["task_a"],
@@ -454,6 +467,7 @@ func TestJoinState_SkippedSourcesSatisfyAllCondition(t *testing.T) {
 }
 
 func TestJoinState_SkippedSourcesSatisfyAnyCondition(t *testing.T) {
+	t.Parallel()
 	workflow := loadTestWorkflow(t, `{
 		"name": "test-join-skipped-any",
 		"entry": ["task_a"],
@@ -480,6 +494,7 @@ func TestJoinState_SkippedSourcesSatisfyAnyCondition(t *testing.T) {
 }
 
 func TestBuildJoinSources_SkippedTreatedAsCompleted(t *testing.T) {
+	t.Parallel()
 	progress := &JoinProgress{
 		Sources:   []string{"task_a", "task_b", "task_c"},
 		Completed: map[string]bool{"task_a": true},
@@ -516,6 +531,7 @@ func TestBuildJoinSources_SkippedTreatedAsCompleted(t *testing.T) {
 }
 
 func TestProcessJoinEvents_SkippedSourceTriggersJoin(t *testing.T) {
+	t.Parallel()
 	workflow := loadTestWorkflow(t, `{
 		"name": "test-join-skipped-event",
 		"entry": ["task_a"],

--- a/internal/workflow/runtime/local_activity_history_test.go
+++ b/internal/workflow/runtime/local_activity_history_test.go
@@ -70,6 +70,7 @@ func watchDispatch(env *testsuite.TestWorkflowEnvironment, name string) *dispatc
 // TestEmitStreamFinalized_DispatchedLocally pins the SUCCESS path — the hot
 // one, fired once per agent turn — as a local activity.
 func TestEmitStreamFinalized_DispatchedLocally(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 
@@ -115,6 +116,7 @@ func TestEmitStreamFinalized_DispatchedLocally(t *testing.T) {
 // context survives that. It is also rare (measured: one such call in a
 // 51,199-event history), so it costs nothing to leave durable.
 func TestEmitStreamFinalized_TerminalPathStaysRegular(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 

--- a/internal/workflow/runtime/loop_context_e2e_test.go
+++ b/internal/workflow/runtime/loop_context_e2e_test.go
@@ -30,6 +30,7 @@ import (
 
 // TestStepExecutorLoopContextInjection verifies that StepExecutor injects loop context
 func TestStepExecutorLoopContextInjection(t *testing.T) {
+	t.Parallel()
 	t.Run("StepExecutor has loop context fields", func(t *testing.T) {
 		// Verify the struct fields exist
 		executor := &StepExecutor{
@@ -97,6 +98,7 @@ func TestStepExecutorLoopContextInjection(t *testing.T) {
 
 // TestExtractActivityInputInfo verifies the extraction function used in activity wrapper
 func TestExtractActivityInputInfo(t *testing.T) {
+	t.Parallel()
 	t.Run("extracts loop context from map with float64 iteration", func(t *testing.T) {
 		// JSON numbers deserialize as float64
 		inputMap := map[string]interface{}{
@@ -180,6 +182,7 @@ func TestExtractActivityInputInfo(t *testing.T) {
 
 // TestLoopContextDatabasePersistence verifies loop context is stored correctly in DB
 func TestLoopContextDatabasePersistence(t *testing.T) {
+	t.Parallel()
 	// Create test database
 	repo := db.NewTestRepo(t)
 
@@ -354,6 +357,7 @@ func TestLoopContextDatabasePersistence(t *testing.T) {
 // =============================================================================
 
 func TestLoopContextIntegration(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/internal/workflow/runtime/loop_execution_test.go
+++ b/internal/workflow/runtime/loop_execution_test.go
@@ -13,6 +13,7 @@ import (
 
 // TestLoopExecution_LoopOutput tests proto-backed loop output structure.
 func TestLoopExecution_LoopOutput(t *testing.T) {
+	t.Parallel()
 	t.Run("loop output contains sub-workflow outputs", func(t *testing.T) {
 		protoOutputs, err := structpb.NewStruct(map[string]interface{}{
 			"exit_code": 0,
@@ -45,6 +46,7 @@ func TestLoopExecution_LoopOutput(t *testing.T) {
 
 // TestLoopExecution_StateMachineRouting tests state machine routing after loop completion
 func TestLoopExecution_StateMachineRouting(t *testing.T) {
+	t.Parallel()
 	t.Run("state machine routes based on loop output", func(t *testing.T) {
 		wfJSON := `{
 			"name": "test-routing",
@@ -88,6 +90,7 @@ func TestLoopExecution_StateMachineRouting(t *testing.T) {
 }
 
 func TestBackfillNodeOutputsFromEvents(t *testing.T) {
+	t.Parallel()
 	nodeOutputs := map[string]interface{}{}
 	events := []*core.WorkflowEvent{
 		nil,

--- a/internal/workflow/runtime/loop_outputs_null_test.go
+++ b/internal/workflow/runtime/loop_outputs_null_test.go
@@ -27,6 +27,7 @@ import (
 // loop (loop_executor.go). These tests drive the exact same path:
 // EvaluateWorkflowOutputs -> structpb.NewStruct.
 func TestLoopOutputsWithCELNull(t *testing.T) {
+	t.Parallel()
 	workflowContext := buildWorkflowContext("test-wf-id", "test-wf", "test-chat",
 		map[string]interface{}{"response_tool_name": "submit_response"})
 
@@ -138,6 +139,7 @@ func TestLoopOutputsWithCELNull(t *testing.T) {
 // shared normalizer prevents: the structpb.NullValue enum is rejected by
 // structpb.NewStruct/NewValue, so it must be normalized to Go nil.
 func TestConvertToNativeNormalizesNullValueEnum(t *testing.T) {
+	t.Parallel()
 	t.Run("structpb rejects the raw NullValue enum (the old failure)", func(t *testing.T) {
 		_, err := structpb.NewStruct(map[string]interface{}{
 			"response": structpb.NullValue(0),

--- a/internal/workflow/runtime/loop_sequential_items_test.go
+++ b/internal/workflow/runtime/loop_sequential_items_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestBuildIterCtx_WithResolvedItems(t *testing.T) {
+	t.Parallel()
 	executor := &InlineLoopExecutor{
 		iteration: 1,
 		resolvedItems: []interface{}{
@@ -28,6 +29,7 @@ func TestBuildIterCtx_WithResolvedItems(t *testing.T) {
 }
 
 func TestBuildIterCtx_WithoutResolvedItems(t *testing.T) {
+	t.Parallel()
 	executor := &InlineLoopExecutor{
 		iteration:     3,
 		resolvedItems: nil,
@@ -45,6 +47,7 @@ func TestBuildIterCtx_WithoutResolvedItems(t *testing.T) {
 }
 
 func TestBuildIterCtx_BoundsCheck(t *testing.T) {
+	t.Parallel()
 	executor := &InlineLoopExecutor{
 		iteration: 2,
 		resolvedItems: []interface{}{
@@ -65,6 +68,7 @@ func TestBuildIterCtx_BoundsCheck(t *testing.T) {
 }
 
 func TestBuildIterCtx_FirstItem(t *testing.T) {
+	t.Parallel()
 	executor := &InlineLoopExecutor{
 		iteration:     0,
 		resolvedItems: []interface{}{"alpha", "beta"},
@@ -80,6 +84,7 @@ func TestBuildIterCtx_FirstItem(t *testing.T) {
 }
 
 func TestBuildIterCtx_MapValueUnwrap(t *testing.T) {
+	t.Parallel()
 	// resolveIterItem unwraps _map_value from map items
 	executor := &InlineLoopExecutor{
 		iteration: 0,
@@ -97,6 +102,7 @@ func TestBuildIterCtx_MapValueUnwrap(t *testing.T) {
 }
 
 func TestBuildIterContextModel_WithResolvedItems(t *testing.T) {
+	t.Parallel()
 	executor := &InlineLoopExecutor{
 		iteration: 1,
 		resolvedItems: []interface{}{
@@ -116,6 +122,7 @@ func TestBuildIterContextModel_WithResolvedItems(t *testing.T) {
 }
 
 func TestBuildIterContextModel_WithoutResolvedItems(t *testing.T) {
+	t.Parallel()
 	executor := &InlineLoopExecutor{
 		iteration:     5,
 		resolvedItems: nil,
@@ -132,6 +139,7 @@ func TestBuildIterContextModel_WithoutResolvedItems(t *testing.T) {
 }
 
 func TestBuildIterContextModel_BoundsCheck(t *testing.T) {
+	t.Parallel()
 	executor := &InlineLoopExecutor{
 		iteration:     3,
 		resolvedItems: []interface{}{"a", "b"},
@@ -149,6 +157,7 @@ func TestBuildIterContextModel_BoundsCheck(t *testing.T) {
 }
 
 func TestBuildIterContextModel_MapValueUnwrap(t *testing.T) {
+	t.Parallel()
 	executor := &InlineLoopExecutor{
 		iteration: 0,
 		resolvedItems: []interface{}{
@@ -165,6 +174,7 @@ func TestBuildIterContextModel_MapValueUnwrap(t *testing.T) {
 }
 
 func TestSequentialLoopAutoStop(t *testing.T) {
+	t.Parallel()
 	// The auto-stop condition is: resolvedItems != nil && iteration >= len(resolvedItems)
 	// We test the condition directly since full loop execution requires Temporal context.
 
@@ -227,6 +237,7 @@ func TestSequentialLoopAutoStop(t *testing.T) {
 }
 
 func TestBuildIterCtx_ConsistentWithModel(t *testing.T) {
+	t.Parallel()
 	// Verify that buildIterCtx and buildIterContextModel produce consistent data
 	executor := &InlineLoopExecutor{
 		iteration: 1,
@@ -248,6 +259,7 @@ func TestBuildIterCtx_ConsistentWithModel(t *testing.T) {
 
 // Verify the model package helpers used by buildIterCtx produce expected shapes.
 func TestModelBuildIterContextHelpers(t *testing.T) {
+	t.Parallel()
 	t.Run("BuildIterContext basic", func(t *testing.T) {
 		ctx := model.BuildIterContext(7)
 		assert.Equal(t, 7, ctx["iteration"])

--- a/internal/workflow/runtime/loop_test.go
+++ b/internal/workflow/runtime/loop_test.go
@@ -12,6 +12,7 @@ import (
 
 // TestLoopOutputProtoBackedSemantics verifies proto-backed loop output preserves CEL map shape.
 func TestLoopOutputProtoBackedSemantics(t *testing.T) {
+	t.Parallel()
 	protoOutputs, err := structpb.NewStruct(map[string]interface{}{
 		"exit_code": 0,
 		"message":   "success",

--- a/internal/workflow/runtime/loop_while_condition_test.go
+++ b/internal/workflow/runtime/loop_while_condition_test.go
@@ -18,6 +18,7 @@ import (
 // This specifically tests CEL evaluation behavior. The `while` condition determines
 // whether the loop should continue (true = continue, false = exit).
 func TestLoopWhileConditionEvaluation(t *testing.T) {
+	t.Parallel()
 	t.Run("while: outputs.exit_code != 0 should exit when exit_code is 1", func(t *testing.T) {
 		outputs := map[string]interface{}{
 			"exit_code": 1,
@@ -182,6 +183,7 @@ func TestLoopWhileConditionEvaluation(t *testing.T) {
 // TestLoopExitConditionE2E tests the complete flow: output evaluation -> while condition
 // This simulates what happens inside InlineLoopExecutor when checking if the loop should exit.
 func TestLoopExitConditionE2E(t *testing.T) {
+	t.Parallel()
 	t.Run("loop exits when while condition becomes false", func(t *testing.T) {
 		outputDefs := map[string]string{
 			"exit_code": "{{has(nodes.verify_red) ? nodes.verify_red.exit_code : 0}}",
@@ -245,6 +247,7 @@ func TestLoopExitConditionE2E(t *testing.T) {
 // `inputs.max_iterations` in the while condition fails with "no such overload"
 // because the value comes through as a string instead of an integer.
 func TestLoopWhileConditionWithInputsMaxIterations(t *testing.T) {
+	t.Parallel()
 	t.Run("while with inputs.max_iterations as integer should work", func(t *testing.T) {
 		ctx := &wfcel.LoopEvalContext{
 			Inputs:  map[string]interface{}{"max_iterations": 3},
@@ -316,6 +319,7 @@ func TestLoopWhileConditionWithInputsMaxIterations(t *testing.T) {
 // TestLoopWhileConditionWithApplyDefaults tests the integration between
 // ApplyDefaults type coercion and while condition CEL evaluation.
 func TestLoopWhileConditionWithApplyDefaults(t *testing.T) {
+	t.Parallel()
 	t.Run("ApplyDefaults coerces float64 input to int64 for CEL arithmetic", func(t *testing.T) {
 		defaultVal := int64(10)
 		schema := map[string]*reliantv1.Input{
@@ -380,6 +384,7 @@ func TestLoopWhileConditionWithApplyDefaults(t *testing.T) {
 // TestLoopOutputsFromSubWorkflow tests that sub-workflow outputs are correctly
 // collected and passed to the while condition evaluation.
 func TestLoopOutputsFromSubWorkflow(t *testing.T) {
+	t.Parallel()
 	t.Run("EvaluateWorkflowOutputs with template delimiters", func(t *testing.T) {
 		outputDefs := map[string]string{
 			"exit_code": "{{has(nodes.verify_red) ? nodes.verify_red.exit_code : 0}}",

--- a/internal/workflow/runtime/native_types_test.go
+++ b/internal/workflow/runtime/native_types_test.go
@@ -10,6 +10,7 @@ import (
 // TestNativeTypeValidation verifies that native types enable compile-time field validation.
 // Invalid field access like workflow.typo, iter.previous should fail at compile time.
 func TestNativeTypeValidation(t *testing.T) {
+	t.Parallel()
 	config := wfcel.DefaultCELEnvConfig()
 	env, err := wfcel.NewEnv(config)
 	assert.NoError(t, err)

--- a/internal/workflow/runtime/nested_pause_resume_test.go
+++ b/internal/workflow/runtime/nested_pause_resume_test.go
@@ -174,6 +174,7 @@ func nestedPauseInput(chatID string) WorkflowInput {
 // THE REGRESSION. A pause during a nested step must resume that step, not
 // re-enter the node that dispatched it.
 func TestNestedPause_ResumesInPlaceWithoutReEnteringTheNode(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 
@@ -217,6 +218,7 @@ func TestNestedPause_ResumesInPlaceWithoutReEnteringTheNode(t *testing.T) {
 // rather than depending on the pause coordinator's behavior under a cancelled
 // root. If it is ever removed, the failure mode is a spin, not a wrong answer.
 func TestNestedPause_GenuineCancelStillUnwinds(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 

--- a/internal/workflow/runtime/node_condition_loop_scope_test.go
+++ b/internal/workflow/runtime/node_condition_loop_scope_test.go
@@ -35,6 +35,7 @@ func conditionNode(id, expr string) *reliantv1.Node {
 // get-it-right's re-review entry is that expression: `implement` is skipped only on
 // the iteration after the REVIEWER declared itself stuck and a human answered.
 func TestNodeConditionSeesIterAndPreviousIterationOutputs(t *testing.T) {
+	t.Parallel()
 	inputs := map[string]interface{}{"max_retries": 5}
 
 	t.Run("outputs carries the previous iteration", func(t *testing.T) {

--- a/internal/workflow/runtime/node_condition_test.go
+++ b/internal/workflow/runtime/node_condition_test.go
@@ -12,6 +12,7 @@ import (
 
 // TestEvaluateNodeCondition tests the node condition evaluation logic
 func TestEvaluateNodeCondition(t *testing.T) {
+	t.Parallel()
 	t.Run("empty condition returns true", func(t *testing.T) {
 		node := &reliantv1.Node{Id: "test", Type: "run"}
 		result, err := evaluateNodeCondition(node, nil, nil, nil, nil)
@@ -166,6 +167,7 @@ func TestEvaluateNodeCondition(t *testing.T) {
 
 // TestSkippedRunNodeOutputs tests that skipped run nodes have type-aware outputs
 func TestSkippedRunNodeOutputs(t *testing.T) {
+	t.Parallel()
 	t.Run("skipped run node has exit_code accessible in downstream CEL", func(t *testing.T) {
 		nodeOutputs := map[string]interface{}{
 			"lint": model.SkippedRunOutputMap(),
@@ -214,6 +216,7 @@ func TestSkippedRunNodeOutputs(t *testing.T) {
 }
 
 func TestSkippedNodeNegativeEdgeCases(t *testing.T) {
+	t.Parallel()
 	t.Run("skipped non-run node does NOT have exit_code field", func(t *testing.T) {
 		// SkippedOutputMap() only has {"skipped": true}.
 		// Accessing exit_code should fail or return false with has().
@@ -288,6 +291,7 @@ func TestSkippedNodeNegativeEdgeCases(t *testing.T) {
 
 // TestNodeConditionInWorkflow tests that conditions are correctly parsed from workflow YAML
 func TestNodeConditionInWorkflow(t *testing.T) {
+	t.Parallel()
 	t.Run("parse workflow with condition", func(t *testing.T) {
 		yamlData := []byte(`
 name: test-workflow

--- a/internal/workflow/runtime/node_output_store_test.go
+++ b/internal/workflow/runtime/node_output_store_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestNodeOutputStore_Basic(t *testing.T) {
+	t.Parallel()
 	store := NewNodeOutputStore("test-workflow")
 
 	// Initially empty
@@ -30,6 +31,7 @@ func TestNodeOutputStore_Basic(t *testing.T) {
 }
 
 func TestNodeOutputStore_NilOutput(t *testing.T) {
+	t.Parallel()
 	store := NewNodeOutputStore("test-workflow")
 
 	// Setting nil output should still mark step as having output
@@ -42,6 +44,7 @@ func TestNodeOutputStore_NilOutput(t *testing.T) {
 }
 
 func TestNodeOutputStore_FromExistingMap(t *testing.T) {
+	t.Parallel()
 	existingData := map[string]interface{}{
 		"step1": map[string]interface{}{"result": "ok"},
 		"step2": "simple string",
@@ -59,12 +62,14 @@ func TestNodeOutputStore_FromExistingMap(t *testing.T) {
 }
 
 func TestNodeOutputStore_FromNilMap(t *testing.T) {
+	t.Parallel()
 	store := NewNodeOutputStoreFrom(nil, "test-workflow")
 	assert.NotNil(t, store)
 	assert.Equal(t, 0, store.Count())
 }
 
 func TestNodeOutputStore_Keys(t *testing.T) {
+	t.Parallel()
 	store := NewNodeOutputStore("test-workflow")
 	store.Set("step_a", "a")
 	store.Set("step_b", "b")
@@ -78,6 +83,7 @@ func TestNodeOutputStore_Keys(t *testing.T) {
 }
 
 func TestNodeOutputStore_AsMap(t *testing.T) {
+	t.Parallel()
 	store := NewNodeOutputStore("test-workflow")
 	store.Set("step1", "value1")
 	store.Set("step2", "value2")
@@ -93,6 +99,7 @@ func TestNodeOutputStore_AsMap(t *testing.T) {
 }
 
 func TestNodeOutputStore_Clone(t *testing.T) {
+	t.Parallel()
 	store := NewNodeOutputStore("test-workflow")
 	store.Set("step1", map[string]interface{}{"key": "value"})
 
@@ -108,6 +115,7 @@ func TestNodeOutputStore_Clone(t *testing.T) {
 }
 
 func TestNodeOutputStore_Merge(t *testing.T) {
+	t.Parallel()
 	store1 := NewNodeOutputStore("test-workflow")
 	store1.Set("step1", "value1")
 
@@ -124,6 +132,7 @@ func TestNodeOutputStore_Merge(t *testing.T) {
 }
 
 func TestNodeOutputStore_MergeNil(t *testing.T) {
+	t.Parallel()
 	store := NewNodeOutputStore("test-workflow")
 	store.Set("step1", "value1")
 
@@ -133,6 +142,7 @@ func TestNodeOutputStore_MergeNil(t *testing.T) {
 }
 
 func TestNodeOutputStore_MergeMap(t *testing.T) {
+	t.Parallel()
 	store := NewNodeOutputStore("test-workflow")
 	store.Set("step1", "value1")
 
@@ -145,6 +155,7 @@ func TestNodeOutputStore_MergeMap(t *testing.T) {
 }
 
 func TestNodeOutputStore_Clear(t *testing.T) {
+	t.Parallel()
 	store := NewNodeOutputStore("test-workflow")
 	store.Set("step1", "value1")
 	store.Set("step2", "value2")
@@ -156,6 +167,7 @@ func TestNodeOutputStore_Clear(t *testing.T) {
 }
 
 func TestNodeOutputStore_GetMap(t *testing.T) {
+	t.Parallel()
 	store := NewNodeOutputStore("test-workflow")
 
 	// Map output
@@ -173,6 +185,7 @@ func TestNodeOutputStore_GetMap(t *testing.T) {
 }
 
 func TestNodeOutputStore_GetString(t *testing.T) {
+	t.Parallel()
 	store := NewNodeOutputStore("test-workflow")
 	store.Set("step1", map[string]interface{}{
 		"message": "hello",
@@ -193,6 +206,7 @@ func TestNodeOutputStore_GetString(t *testing.T) {
 }
 
 func TestNodeOutputStore_GetBool(t *testing.T) {
+	t.Parallel()
 	store := NewNodeOutputStore("test-workflow")
 	store.Set("step1", map[string]interface{}{
 		"success": true,
@@ -208,6 +222,7 @@ func TestNodeOutputStore_GetBool(t *testing.T) {
 }
 
 func TestNodeOutputStore_GetInt(t *testing.T) {
+	t.Parallel()
 	store := NewNodeOutputStore("test-workflow")
 	store.Set("step1", map[string]interface{}{
 		"count":     42,
@@ -225,6 +240,7 @@ func TestNodeOutputStore_GetInt(t *testing.T) {
 }
 
 func TestNodeOutputStore_EnableDebug(t *testing.T) {
+	t.Parallel()
 	store := NewNodeOutputStore("test-workflow").EnableDebug()
 
 	// Just verify it doesn't panic

--- a/internal/workflow/runtime/node_router_test.go
+++ b/internal/workflow/runtime/node_router_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestBuildNodeRoutingSystemPrompt(t *testing.T) {
+	t.Parallel()
 	t.Run("uses default prompt when custom is empty", func(t *testing.T) {
 		candidates := []*reliantv1.NodeRouterCandidate{
 			{Id: "summarize", Description: "Summarize content"},
@@ -81,6 +82,7 @@ func TestBuildNodeRoutingSystemPrompt(t *testing.T) {
 }
 
 func TestBuildNodeRoutingResponseSchema(t *testing.T) {
+	t.Parallel()
 	t.Run("schema has correct structure", func(t *testing.T) {
 		candidates := []*reliantv1.NodeRouterCandidate{
 			{Id: "summarize"},
@@ -144,6 +146,7 @@ func TestBuildNodeRoutingResponseSchema(t *testing.T) {
 }
 
 func TestParseNodeRoutingDecision(t *testing.T) {
+	t.Parallel()
 	newExecutor := func() *RouterExecutor {
 		return &RouterExecutor{
 			logger: nilLogger{},

--- a/internal/workflow/runtime/numeric_type_test.go
+++ b/internal/workflow/runtime/numeric_type_test.go
@@ -25,6 +25,7 @@ import (
 
 // TestYAMLNumericParsing verifies YAML parsing behavior for numeric values
 func TestYAMLNumericParsing(t *testing.T) {
+	t.Parallel()
 	t.Run("unquoted_numbers_are_parsed_as_integers", func(t *testing.T) {
 		yamlContent := `
 input_tokens: 0
@@ -102,6 +103,7 @@ type SaveMessageInputTest struct {
 // TestSaveMessageInputNumericTypes verifies that SaveMessageInput correctly
 // deserializes numeric fields from workflow config
 func TestSaveMessageInputNumericTypes(t *testing.T) {
+	t.Parallel()
 	t.Run("integer_values_deserialize_correctly", func(t *testing.T) {
 		// Simulate config with proper integer types
 		config := map[string]interface{}{

--- a/internal/workflow/runtime/outcome_test.go
+++ b/internal/workflow/runtime/outcome_test.go
@@ -64,6 +64,7 @@ func terminalStatus(t *testing.T, rec *resumeEnvRecorder) map[string]interface{}
 }
 
 func TestDynamicWorkflow_FailureTerminalRecordsTheVerdict(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 	rec := setupResumeEnv(t, env, terminalOutcomeYAML)
@@ -82,6 +83,7 @@ func TestDynamicWorkflow_FailureTerminalRecordsTheVerdict(t *testing.T) {
 }
 
 func TestDynamicWorkflow_SuccessTerminalRecordsTheVerdict(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 	rec := setupResumeEnv(t, env, successOutcomeYAML)
@@ -97,6 +99,7 @@ func TestDynamicWorkflow_SuccessTerminalRecordsTheVerdict(t *testing.T) {
 // TestDynamicWorkflow_UndeclaredOutcomeStaysUndeclared: most workflows declare
 // nothing, and absence must never be recorded as a verdict in either direction.
 func TestDynamicWorkflow_UndeclaredOutcomeStaysUndeclared(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 	rec := setupResumeEnv(t, env, noOutcomeYAML)
@@ -113,6 +116,7 @@ func TestDynamicWorkflow_UndeclaredOutcomeStaysUndeclared(t *testing.T) {
 // TestDynamicWorkflow_SkippedTerminalStampsNothing: a node whose condition is
 // false never runs, so it must not stamp its verdict on the run.
 func TestDynamicWorkflow_SkippedTerminalStampsNothing(t *testing.T) {
+	t.Parallel()
 	const skippedYAML = `
 name: resume-test
 entry: [work]

--- a/internal/workflow/runtime/pause_signal_test.go
+++ b/internal/workflow/runtime/pause_signal_test.go
@@ -19,6 +19,7 @@ type PauseSignalTestSuite struct {
 }
 
 func TestPauseSignal(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(PauseSignalTestSuite))
 }
 

--- a/internal/workflow/runtime/preallocated_id_redispatch_test.go
+++ b/internal/workflow/runtime/preallocated_id_redispatch_test.go
@@ -31,6 +31,7 @@ import (
 // matters for interrupt — is a workflow-level RE-DISPATCH: StepExecutor.Start
 // called again after a CanceledError, which issues a NEW SideEffect command.
 func TestPreallocatedMessageID_FreshPerDispatch(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 

--- a/internal/workflow/runtime/preflight_test.go
+++ b/internal/workflow/runtime/preflight_test.go
@@ -47,12 +47,14 @@ func testPreflightConfig() *PreflightConfig {
 }
 
 func TestRequiresDaemon_Nil(t *testing.T) {
+	t.Parallel()
 	if RequiresDaemon(nil, testPreflightConfig()) {
 		t.Error("nil workflow should not require daemon")
 	}
 }
 
 func TestRequiresDaemon_EmptyWorkflow(t *testing.T) {
+	t.Parallel()
 	wf := &reliantv1.Workflow{}
 	if RequiresDaemon(wf, testPreflightConfig()) {
 		t.Error("empty workflow should not require daemon")
@@ -60,6 +62,7 @@ func TestRequiresDaemon_EmptyWorkflow(t *testing.T) {
 }
 
 func TestRequiresDaemon_WorkflowLevelDaemon(t *testing.T) {
+	t.Parallel()
 	wf := &reliantv1.Workflow{
 		Daemon: &reliantv1.CelDaemonSelector{
 			Value: &reliantv1.CelDaemonSelector_Literal{
@@ -73,6 +76,7 @@ func TestRequiresDaemon_WorkflowLevelDaemon(t *testing.T) {
 }
 
 func TestRequiresDaemon_RunNode(t *testing.T) {
+	t.Parallel()
 	wf := &reliantv1.Workflow{
 		Nodes: []*reliantv1.Node{
 			{Id: "build", Type: "run"},
@@ -84,6 +88,7 @@ func TestRequiresDaemon_RunNode(t *testing.T) {
 }
 
 func TestRequiresDaemon_NodeWithDaemonField(t *testing.T) {
+	t.Parallel()
 	wf := &reliantv1.Workflow{
 		Nodes: []*reliantv1.Node{
 			{
@@ -103,6 +108,7 @@ func TestRequiresDaemon_NodeWithDaemonField(t *testing.T) {
 }
 
 func TestRequiresDaemon_ServerOnlyWorkflow(t *testing.T) {
+	t.Parallel()
 	wf := &reliantv1.Workflow{
 		Nodes: []*reliantv1.Node{
 			{
@@ -130,6 +136,7 @@ func TestRequiresDaemon_ServerOnlyWorkflow(t *testing.T) {
 }
 
 func TestRequiresDaemon_CallLLMWithDefaultTools(t *testing.T) {
+	t.Parallel()
 	// tag:default includes bash (ToolRunsOnDaemon)
 	wf := &reliantv1.Workflow{
 		Nodes: []*reliantv1.Node{
@@ -158,6 +165,7 @@ func TestRequiresDaemon_CallLLMWithDefaultTools(t *testing.T) {
 }
 
 func TestRequiresDaemon_CELToolFilter(t *testing.T) {
+	t.Parallel()
 	// CEL expressions can't be statically evaluated — conservatively require daemon
 	wf := &reliantv1.Workflow{
 		Nodes: []*reliantv1.Node{
@@ -184,6 +192,7 @@ func TestRequiresDaemon_CELToolFilter(t *testing.T) {
 }
 
 func TestRequiresDaemon_InlineSubWorkflow(t *testing.T) {
+	t.Parallel()
 	wf := &reliantv1.Workflow{
 		Nodes: []*reliantv1.Node{
 			{
@@ -207,6 +216,7 @@ func TestRequiresDaemon_InlineSubWorkflow(t *testing.T) {
 }
 
 func TestRequiresDaemon_InlineLoop(t *testing.T) {
+	t.Parallel()
 	wf := &reliantv1.Workflow{
 		Nodes: []*reliantv1.Node{
 			{
@@ -230,6 +240,7 @@ func TestRequiresDaemon_InlineLoop(t *testing.T) {
 }
 
 func TestRequiresDaemon_CallLLMNoToolFilter(t *testing.T) {
+	t.Parallel()
 	wf := &reliantv1.Workflow{
 		Nodes: []*reliantv1.Node{
 			{
@@ -248,6 +259,7 @@ func TestRequiresDaemon_CallLLMNoToolFilter(t *testing.T) {
 }
 
 func TestRequiresDaemon_NilConfig(t *testing.T) {
+	t.Parallel()
 	// With nil config, tool filter analysis should be conservative
 	wf := &reliantv1.Workflow{
 		Nodes: []*reliantv1.Node{
@@ -276,6 +288,7 @@ func TestRequiresDaemon_NilConfig(t *testing.T) {
 }
 
 func TestRequiresDaemon_ReadOnlyToolsOnly(t *testing.T) {
+	t.Parallel()
 	wf := &reliantv1.Workflow{
 		Nodes: []*reliantv1.Node{
 			{

--- a/internal/workflow/runtime/preset_resolve_test.go
+++ b/internal/workflow/runtime/preset_resolve_test.go
@@ -12,6 +12,7 @@ import (
 // TestResolvePresetName_Literal verifies literal preset names pass through untouched.
 // Regression: the existing literal-preset-name behavior must not change.
 func TestResolvePresetName_Literal(t *testing.T) {
+	t.Parallel()
 	evalCtx := &wfcel.EdgeEvalContext{
 		Inputs: map[string]interface{}{"foo": "bar"},
 	}
@@ -23,6 +24,7 @@ func TestResolvePresetName_Literal(t *testing.T) {
 
 // TestResolvePresetName_LiteralEmpty verifies empty literal stays empty.
 func TestResolvePresetName_LiteralEmpty(t *testing.T) {
+	t.Parallel()
 	got, err := ResolvePresetName("", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "", got)
@@ -30,6 +32,7 @@ func TestResolvePresetName_LiteralEmpty(t *testing.T) {
 
 // TestResolvePresetName_FromInputs verifies templated preset name resolves via inputs.*.
 func TestResolvePresetName_FromInputs(t *testing.T) {
+	t.Parallel()
 	evalCtx := &wfcel.EdgeEvalContext{
 		Inputs: map[string]interface{}{
 			"implementer_preset": "codex-high",
@@ -46,6 +49,7 @@ func TestResolvePresetName_FromInputs(t *testing.T) {
 // NOTE: Sequential loops do not expose iter.item; this test uses inputs keyed
 // by iteration to model per-iteration variation.
 func TestResolvePresetName_PerIteration_Sequential(t *testing.T) {
+	t.Parallel()
 	iterations := []struct {
 		iter     int
 		expected string
@@ -78,6 +82,7 @@ func TestResolvePresetName_PerIteration_Sequential(t *testing.T) {
 // TestResolvePresetName_PerIteration_Parallel simulates the parallel loop
 // case: preset name driven by iter.item.preset where item is a map.
 func TestResolvePresetName_PerIteration_Parallel(t *testing.T) {
+	t.Parallel()
 	items := []map[string]interface{}{
 		{"name": "auth", "preset": "claude-default"},
 		{"name": "billing", "preset": "codex-high"},
@@ -103,6 +108,7 @@ func TestResolvePresetName_PerIteration_Parallel(t *testing.T) {
 // TestResolvePresetName_FailedEval ensures missing references return an error
 // (so callers can log + skip rather than crash the loop).
 func TestResolvePresetName_FailedEval(t *testing.T) {
+	t.Parallel()
 	evalCtx := &wfcel.EdgeEvalContext{
 		Inputs: map[string]interface{}{},
 	}
@@ -114,6 +120,7 @@ func TestResolvePresetName_FailedEval(t *testing.T) {
 // TestResolvePresetName_EmptyStringFromEval verifies that a template resolving
 // to an empty string yields "" (caller will skip).
 func TestResolvePresetName_EmptyStringFromEval(t *testing.T) {
+	t.Parallel()
 	evalCtx := &wfcel.EdgeEvalContext{
 		Inputs: map[string]interface{}{
 			"preset_name": "",
@@ -128,6 +135,7 @@ func TestResolvePresetName_EmptyStringFromEval(t *testing.T) {
 // TestResolvePresetName_EmbeddedTemplateInterpolates verifies that a mixed
 // string with {{...}} is interpolated into the surrounding literal text.
 func TestResolvePresetName_EmbeddedTemplateInterpolates(t *testing.T) {
+	t.Parallel()
 	evalCtx := &wfcel.EdgeEvalContext{
 		Inputs: map[string]interface{}{
 			"variant": "fast",
@@ -142,6 +150,7 @@ func TestResolvePresetName_EmbeddedTemplateInterpolates(t *testing.T) {
 // TestResolvePresetName_PureNonStringReturnsError verifies a pure template
 // resolving to a non-string returns an error (callers will skip).
 func TestResolvePresetName_PureNonStringReturnsError(t *testing.T) {
+	t.Parallel()
 	evalCtx := &wfcel.EdgeEvalContext{
 		Inputs: map[string]interface{}{
 			"idx": int64(42),

--- a/internal/workflow/runtime/rate_limit_autopause_test.go
+++ b/internal/workflow/runtime/rate_limit_autopause_test.go
@@ -30,6 +30,7 @@ type HandleWorkflowCompletionSuite struct {
 }
 
 func TestHandleWorkflowCompletion(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(HandleWorkflowCompletionSuite))
 }
 
@@ -125,6 +126,7 @@ type StepExecutorRetrySuite struct {
 }
 
 func TestStepExecutorRetry(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(StepExecutorRetrySuite))
 }
 
@@ -238,6 +240,7 @@ func (s *StepExecutorRetrySuite) TestSuccessfulActivity_DoesNotSetRetryExhausted
 // =============================================================================
 
 func TestPauseController_DoRequestPause_Integration(t *testing.T) {
+	t.Parallel()
 	t.Run("RequestPause sets pause flag and cancels activities", func(t *testing.T) {
 		var pauseRequested bool
 		var cancelCalled bool
@@ -302,6 +305,7 @@ func TestPauseController_DoRequestPause_Integration(t *testing.T) {
 // =============================================================================
 
 func TestStepEvent_RetryExhausted_CancelledErrorNotExhausted(t *testing.T) {
+	t.Parallel()
 	event := &StepEvent{
 		StepID:         "test-step",
 		Error:          temporal.NewCanceledError("context cancelled"),
@@ -312,6 +316,7 @@ func TestStepEvent_RetryExhausted_CancelledErrorNotExhausted(t *testing.T) {
 }
 
 func TestStepEvent_RetryExhausted_TimeoutErrorIsExhausted(t *testing.T) {
+	t.Parallel()
 	event := &StepEvent{
 		StepID:         "test-step",
 		Error:          errors.New("activity timed out"),
@@ -322,6 +327,7 @@ func TestStepEvent_RetryExhausted_TimeoutErrorIsExhausted(t *testing.T) {
 }
 
 func TestStepEvent_RetryExhausted_ApplicationErrorIsExhausted(t *testing.T) {
+	t.Parallel()
 	event := &StepEvent{
 		StepID:         "test-step",
 		Error:          errors.New("429 Too Many Requests"),
@@ -344,6 +350,7 @@ type RateLimitAutoPauseSuite struct {
 }
 
 func TestRateLimitAutoPause(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(RateLimitAutoPauseSuite))
 }
 

--- a/internal/workflow/runtime/redact_test.go
+++ b/internal/workflow/runtime/redact_test.go
@@ -22,6 +22,7 @@ var liveSecrets = []string{
 }
 
 func TestRedactString_ScrubsKnownSecretPrefixes(t *testing.T) {
+	t.Parallel()
 	for _, secret := range liveSecrets {
 		line := "API key is " + secret + " trailing"
 		out := redactString(line)
@@ -34,6 +35,7 @@ func TestRedactString_ScrubsKnownSecretPrefixes(t *testing.T) {
 }
 
 func TestRedactString_ScrubsEnvAssignments(t *testing.T) {
+	t.Parallel()
 	cases := []string{
 		"STRIPE_SECRET=plain-random-value-no-prefix",
 		"DATABASE_PASSWORD: aGVsbG8td29ybGQtc3VwZXItc2VjcmV0",
@@ -50,6 +52,7 @@ func TestRedactString_ScrubsEnvAssignments(t *testing.T) {
 }
 
 func TestRedactString_LeavesNonSecretsAlone(t *testing.T) {
+	t.Parallel()
 	// Includes keys that merely contain a signal word as a substring (tokens,
 	// total_tokens, author) — these must NOT be redacted, or useful debug logging
 	// (token counts, etc.) would be destroyed.
@@ -68,6 +71,7 @@ func TestRedactString_LeavesNonSecretsAlone(t *testing.T) {
 // tool_results[].content, and that map is logged. After redaction, no secret
 // byte may appear in the emitted log line.
 func TestRedactValue_NodeOutputWithToolResults(t *testing.T) {
+	t.Parallel()
 	envFileContents := strings.Join([]string{
 		"STRIPE_SECRET_KEY=" + liveSecrets[0],
 		"STRIPE_WEBHOOK_SECRET=" + liveSecrets[2],

--- a/internal/workflow/runtime/registry_error_test.go
+++ b/internal/workflow/runtime/registry_error_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestClassifyError(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		err        error
@@ -126,6 +127,7 @@ func TestClassifyError(t *testing.T) {
 }
 
 func TestTerminalError(t *testing.T) {
+	t.Parallel()
 	cause := errors.New("original error")
 	termErr := &TerminalError{
 		Message: "validation failed",
@@ -154,6 +156,7 @@ func TestTerminalError(t *testing.T) {
 }
 
 func TestDefaultTransient(t *testing.T) {
+	t.Parallel()
 	// Unknown errors should default to transient (retryable)
 	unknownErr := errors.New("some random error")
 	classified := classifyError(unknownErr)
@@ -170,6 +173,7 @@ func TestDefaultTransient(t *testing.T) {
 }
 
 func TestMalformedJSONErrorsAreTransient(t *testing.T) {
+	t.Parallel()
 	// These tests verify that malformed JSON errors from streaming are treated as transient
 	// They should NOT be terminal because they typically succeed on retry
 
@@ -223,6 +227,7 @@ func TestMalformedJSONErrorsAreTransient(t *testing.T) {
 }
 
 func TestClassifyError_DNS(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		err        error
@@ -273,6 +278,7 @@ func TestClassifyError_DNS(t *testing.T) {
 }
 
 func TestRegularMalformedErrorsAreStillTerminal(t *testing.T) {
+	t.Parallel()
 	// Verify that regular "malformed" errors (not JSON streaming) are still terminal
 	// For example, validation errors
 
@@ -308,6 +314,7 @@ func TestRegularMalformedErrorsAreStillTerminal(t *testing.T) {
 // advance in place ("Retrying (Attempt 1/3)" → "Attempt 3/3") instead of
 // stacking three rows for one failure.
 func TestActivityErrorEventID(t *testing.T) {
+	t.Parallel()
 	const workflowID = "wf-1"
 
 	t.Run("retries of one activity share an id", func(t *testing.T) {

--- a/internal/workflow/runtime/registry_error_thread_test.go
+++ b/internal/workflow/runtime/registry_error_thread_test.go
@@ -33,6 +33,7 @@ func (r *capturingRepo) CreateChatUpdate(_ context.Context, _ string, _ db.Updat
 // DrainAgentMessages failures rendered at the top of a spawn thread that did
 // not exist when those failures happened.
 func TestExtractThread(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    interface{}
@@ -116,6 +117,7 @@ func TestExtractThread(t *testing.T) {
 // The helper test above can pass while the wiring is missing — which is
 // exactly the state that produced the reported bug.
 func TestWriteErrorEventCarriesThread(t *testing.T) {
+	t.Parallel()
 	repo := &capturingRepo{}
 	wrapper := NewActivityWrapper(
 		"DrainAgentMessages",
@@ -159,6 +161,7 @@ func TestWriteErrorEventCarriesThread(t *testing.T) {
 // branches on presence, so an empty string would be a thread that matches no
 // thread — the error would vanish instead of showing everywhere.
 func TestWriteErrorEventOmitsAbsentThread(t *testing.T) {
+	t.Parallel()
 	repo := &capturingRepo{}
 	wrapper := NewActivityWrapper(
 		"ChatScoped",
@@ -200,6 +203,7 @@ func TestWriteErrorEventOmitsAbsentThread(t *testing.T) {
 // invalid, and an activity error is exactly the moment we cannot afford a
 // second failure while reporting the first.
 func TestExtractThreadNilPointer(t *testing.T) {
+	t.Parallel()
 	var input *types.DrainAgentMessagesInput
 	if got := extractThread(input); got != "" {
 		t.Errorf("extractThread(nil pointer) = %q, want empty", got)

--- a/internal/workflow/runtime/registry_heartbeat_cancel_test.go
+++ b/internal/workflow/runtime/registry_heartbeat_cancel_test.go
@@ -16,6 +16,7 @@ import (
 // Temporal server kills a healthy activity and the workflow treats the
 // resulting context.Canceled as a pause.
 func TestSpuriousHeartbeatCancel(t *testing.T) {
+	t.Parallel()
 	closedWorkerStop := func() <-chan struct{} {
 		ch := make(chan struct{})
 		close(ch)

--- a/internal/workflow/runtime/registry_test.go
+++ b/internal/workflow/runtime/registry_test.go
@@ -11,6 +11,7 @@ import (
 // handles various input/output patterns correctly. This tests what Temporal does
 // under the hood - no manual conversion code needed!
 func TestTemporalJSONSerialization(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    interface{}
@@ -128,6 +129,7 @@ func TestTemporalJSONSerialization(t *testing.T) {
 // TestActivityWrapperSupportsVariousTypes verifies that the wrapper signature
 // allows activities to return various types (slices, structs, primitives)
 func TestActivityWrapperSupportsVariousTypes(t *testing.T) {
+	t.Parallel()
 	// This test verifies that we can create wrappers for activities with different output types.
 	// Temporal handles all serialization - we just need typed functions.
 
@@ -192,6 +194,7 @@ func TestActivityWrapperSupportsVariousTypes(t *testing.T) {
 
 // TestExtractChatID verifies that chat_id is correctly extracted from various input formats
 func TestExtractChatID(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    interface{}

--- a/internal/workflow/runtime/registry_v3_input_test.go
+++ b/internal/workflow/runtime/registry_v3_input_test.go
@@ -28,12 +28,14 @@ func v3Input(chatID, thread string) types.ActivityInput {
 }
 
 func TestExtractChatID_ReadsV3ActivityInput(t *testing.T) {
+	t.Parallel()
 	if got := extractChatID(v3Input("chat-58cc003f", "thread-58cc003f")); got != "chat-58cc003f" {
 		t.Errorf("extractChatID() = %q, want %q — without it no activity error reaches the chat", got, "chat-58cc003f")
 	}
 }
 
 func TestExtractThread_ReadsV3ActivityInput(t *testing.T) {
+	t.Parallel()
 	if got := extractThread(v3Input("chat-58cc003f", "thread-58cc003f")); got != "thread-58cc003f" {
 		t.Errorf("extractThread() = %q, want %q", got, "thread-58cc003f")
 	}
@@ -42,6 +44,7 @@ func TestExtractThread_ReadsV3ActivityInput(t *testing.T) {
 // The end-to-end assertion, in the shape the helper tests cannot make: a
 // failing v3 activity must actually write the error event.
 func TestWriteErrorEventReachesChatForV3Input(t *testing.T) {
+	t.Parallel()
 	repo := &capturingRepo{}
 	wrapper := NewActivityWrapper(
 		"SaveMessage",
@@ -83,6 +86,7 @@ func TestWriteErrorEventReachesChatForV3Input(t *testing.T) {
 // ZERO rows for chats the v3 runtime ran. A chat that stopped then has no
 // durable record of the step it stopped on.
 func TestExtractActivityInputInfo_ReadsV3ActivityInput(t *testing.T) {
+	t.Parallel()
 	info := extractActivityInputInfo(types.ActivityInput{
 		Runtime: types.RuntimeContext{
 			ChatID:        "chat-58cc003f",
@@ -114,6 +118,7 @@ func TestExtractActivityInputInfo_ReadsV3ActivityInput(t *testing.T) {
 // A field the input carries itself always wins over one found in a nested
 // struct — the descent adds answers, it must never replace them.
 func TestExtractInputString_OwnFieldWinsOverNested(t *testing.T) {
+	t.Parallel()
 	type nested struct {
 		ChatID string `json:"chat_id"`
 	}

--- a/internal/workflow/runtime/response_data_test.go
+++ b/internal/workflow/runtime/response_data_test.go
@@ -15,6 +15,7 @@ import (
 // This validates that nested response_data structures can be accessed correctly,
 // such as: {{nodes.execute_filter.response_data.filtered_results.results}}
 func TestResponseDataCELAccess(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		responseData  map[string]interface{}
@@ -166,6 +167,7 @@ func TestResponseDataCELAccess(t *testing.T) {
 // TestResponseDataStructureFromExecuteTools tests the actual structure returned by ExecuteTools
 // This validates what execute_tools.go lines 354-364 produce
 func TestResponseDataStructureFromExecuteTools(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		toolName     string
@@ -256,6 +258,7 @@ func TestResponseDataStructureFromExecuteTools(t *testing.T) {
 // TestResponseToolMetadataFlow tests the complete flow from ResponseTool to CEL evaluation
 // This is an integration test that validates the entire chain
 func TestResponseToolMetadataFlow(t *testing.T) {
+	t.Parallel()
 	// Step 1: Simulate LLM calling filtered_results tool
 	llmInput := map[string]interface{}{
 		"results": []interface{}{
@@ -312,6 +315,7 @@ func TestResponseToolMetadataFlow(t *testing.T) {
 
 // TestResponseDataNestedAccess validates nested response_data structure access
 func TestResponseDataNestedAccess(t *testing.T) {
+	t.Parallel()
 	t.Run("correct_implementation", func(t *testing.T) {
 		responseData := map[string]interface{}{
 			"filtered_results": map[string]interface{}{

--- a/internal/workflow/runtime/response_tool_helpers_test.go
+++ b/internal/workflow/runtime/response_tool_helpers_test.go
@@ -17,6 +17,7 @@ func loadTestNodes(t *testing.T, wfJSON string) []*reliantv1.Node {
 }
 
 func Test_detectResponseToolsFromWorkflow(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		toolCallsArg   string
@@ -237,6 +238,7 @@ func Test_detectResponseToolsFromWorkflow(t *testing.T) {
 // TestDetectResponseTools_SchemaContent verifies the actual schema content
 // is correct after sentinel resolution, not just that schemas exist.
 func TestDetectResponseTools_SchemaContent(t *testing.T) {
+	t.Parallel()
 	wfJSON := `{
 		"name": "test", "entry": ["call_llm"],
 		"nodes": [{
@@ -283,6 +285,7 @@ func TestDetectResponseTools_SchemaContent(t *testing.T) {
 }
 
 func TestExtractToolCallsSourceNode(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		expr string
@@ -351,6 +354,7 @@ func TestExtractToolCallsSourceNode(t *testing.T) {
 }
 
 func TestResolveSimpleInputExpr(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		expr   string

--- a/internal/workflow/runtime/response_tool_schema_integration_test.go
+++ b/internal/workflow/runtime/response_tool_schema_integration_test.go
@@ -26,6 +26,7 @@ func celStringLiteral(s string) *reliantv1.CelString {
 // "__cel_expr__" key. The resulting schema was {"__cel_expr__": {actual schema}}
 // instead of just {actual schema}.
 func TestResponseToolSchema_CELResolution_Integration(t *testing.T) {
+	t.Parallel()
 	// This is the schema the user passes as a workflow input
 	inputSchema := map[string]interface{}{
 		"type":     "object",
@@ -109,6 +110,7 @@ func TestResponseToolSchema_CELResolution_Integration(t *testing.T) {
 // TestResponseToolSchema_InlineSchema_NotMutated verifies that a normal inline
 // schema (not a CEL expression) passes through EvaluateNodeConfig unchanged.
 func TestResponseToolSchema_InlineSchema_NotMutated(t *testing.T) {
+	t.Parallel()
 	inlineSchema, err := structpb.NewStruct(map[string]interface{}{
 		"type":     "object",
 		"required": []interface{}{"verdict"},

--- a/internal/workflow/runtime/resume_test.go
+++ b/internal/workflow/runtime/resume_test.go
@@ -28,6 +28,7 @@ func resumeTestWorkflow(t *testing.T, yamlStr string) *reliantv1.Workflow {
 }
 
 func TestResolveResumeTarget(t *testing.T) {
+	t.Parallel()
 	seqWf := resumeTestWorkflow(t, `
 name: seq
 entry: [plan]
@@ -298,6 +299,7 @@ nodes:
 `
 
 func TestDynamicWorkflow_FreshStart_ChecksNodeEntryCheckpoints(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 	rec := setupResumeEnv(t, env, resumeSeqYAML)
@@ -313,6 +315,7 @@ func TestDynamicWorkflow_FreshStart_ChecksNodeEntryCheckpoints(t *testing.T) {
 }
 
 func TestDynamicWorkflow_Resume_EntersAtCheckpointNode(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 	rec := setupResumeEnv(t, env, resumeSeqYAML)
@@ -326,6 +329,7 @@ func TestDynamicWorkflow_Resume_EntersAtCheckpointNode(t *testing.T) {
 }
 
 func TestDynamicWorkflow_Resume_YAMLOverrideWins(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 	yamlWithOverride := resumeSeqYAML + "resume_node: final\n"
@@ -339,6 +343,7 @@ func TestDynamicWorkflow_Resume_YAMLOverrideWins(t *testing.T) {
 }
 
 func TestDynamicWorkflow_Resume_EmptyCheckpointFallsBackToGraphStart(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 	rec := setupResumeEnv(t, env, resumeSeqYAML)
@@ -352,6 +357,7 @@ func TestDynamicWorkflow_Resume_EmptyCheckpointFallsBackToGraphStart(t *testing.
 }
 
 func TestDynamicWorkflow_FreshLoop_ChecksIterationCheckpoints(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 	rec := setupResumeEnv(t, env, resumeLoopYAML)
@@ -368,6 +374,7 @@ func TestDynamicWorkflow_FreshLoop_ChecksIterationCheckpoints(t *testing.T) {
 }
 
 func TestDynamicWorkflow_ResumeLoop_ReentersAtCheckpointedIteration(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 	rec := setupResumeEnv(t, env, resumeLoopYAML)
@@ -436,6 +443,7 @@ func workIterations(rec *resumeEnvRecorder) []int {
 // is what reset-and-replay is for, and Temporal already provides it. A position
 // table that tried to describe the nesting was the wrong answer to it.
 func TestDynamicWorkflow_NestedLoop_FlatCheckpointOmitsNestedIteration(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 	rec := setupResumeEnv(t, env, resumeNestedLoopYAML)
@@ -461,6 +469,7 @@ func TestDynamicWorkflow_NestedLoop_FlatCheckpointOmitsNestedIteration(t *testin
 // the nested iteration instead; this test pins the coarse path's limitation that
 // motivated the fix.
 func TestDynamicWorkflow_NestedLoop_CoarseResumeRestartsNestedAtZero(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 	rec := setupResumeEnv(t, env, resumeNestedLoopYAML)
@@ -499,6 +508,7 @@ nodes:
 `
 
 func TestDynamicWorkflow_GenericNestedLoop_FlatCheckpointOmitsInnerIteration(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 	rec := setupResumeEnv(t, env, resumeGenericNestedLoopYAML)

--- a/internal/workflow/runtime/retry_exhaustion_test.go
+++ b/internal/workflow/runtime/retry_exhaustion_test.go
@@ -14,6 +14,7 @@ import (
 // The RetryExhausted flag should NOT prevent routing — the caller is
 // responsible for checking it before calling EnsureStepEventRoutable.
 func TestStepEvent_RetryExhausted_FlagBehavior(t *testing.T) {
+	t.Parallel()
 	t.Run("RetryExhausted event with error is routable error", func(t *testing.T) {
 		event := &StepEvent{
 			StepID:         "call_llm",
@@ -65,6 +66,7 @@ func TestStepEvent_RetryExhausted_FlagBehavior(t *testing.T) {
 // TestPauseController_RequestPause verifies the RequestPause callback works
 // and is nil-safe when not set.
 func TestPauseController_RequestPause(t *testing.T) {
+	t.Parallel()
 	t.Run("DoRequestPause with nil receiver", func(t *testing.T) {
 		var pc *PauseController
 		// Should not panic

--- a/internal/workflow/runtime/root_thread_mailbox_drain_e2e_test.go
+++ b/internal/workflow/runtime/root_thread_mailbox_drain_e2e_test.go
@@ -253,6 +253,7 @@ type RootThreadMailboxDrainSuite struct {
 }
 
 func TestRootThreadMailboxDrainE2E(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(RootThreadMailboxDrainSuite))
 }
 

--- a/internal/workflow/runtime/router_context_test.go
+++ b/internal/workflow/runtime/router_context_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestBuildRoutingSystemPrompt(t *testing.T) {
+	t.Parallel()
 	t.Run("custom system prompt override", func(t *testing.T) {
 		candidates := []routerWorkflowInfo{
 			{
@@ -133,6 +134,7 @@ func TestBuildRoutingSystemPrompt(t *testing.T) {
 }
 
 func TestBuildRoutingResponseSchema(t *testing.T) {
+	t.Parallel()
 	t.Run("schema contains workflow enum with all candidate refs", func(t *testing.T) {
 		candidates := []routerWorkflowInfo{
 			{
@@ -224,6 +226,7 @@ func TestBuildRoutingResponseSchema(t *testing.T) {
 }
 
 func TestGetInputDescription(t *testing.T) {
+	t.Parallel()
 	t.Run("string input", func(t *testing.T) {
 		input := &reliantv1.Input{
 			Type: "string",
@@ -271,6 +274,7 @@ func TestGetInputDescription(t *testing.T) {
 }
 
 func TestFilterPresetsByAllowed(t *testing.T) {
+	t.Parallel()
 	allPresets := []*preset.Preset{
 		{Name: "general", Description: "General purpose"},
 		{Name: "researcher", Description: "Research specialist"},

--- a/internal/workflow/runtime/router_executor_test.go
+++ b/internal/workflow/runtime/router_executor_test.go
@@ -27,6 +27,7 @@ func (nilLogger) Warn(string, ...interface{})  {}
 func (nilLogger) Error(string, ...interface{}) {}
 
 func TestRouterThreadMode(t *testing.T) {
+	t.Parallel()
 	t.Run("returns new when no thread config", func(t *testing.T) {
 		node := &reliantv1.Node{
 			Id:   "route",
@@ -82,6 +83,7 @@ func TestRouterThreadMode(t *testing.T) {
 }
 
 func TestRouterWorkflowIdentity(t *testing.T) {
+	t.Parallel()
 	t.Run("returns router with candidate refs", func(t *testing.T) {
 		node := &reliantv1.Node{
 			Id:   "route",
@@ -136,6 +138,7 @@ func TestRouterWorkflowIdentity(t *testing.T) {
 }
 
 func TestNodeRoutingCallLLMUsesExecutionContextThread(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 
@@ -195,6 +198,7 @@ func TestNodeRoutingCallLLMUsesExecutionContextThread(t *testing.T) {
 }
 
 func TestDynamicWorkflowNodeRoutingPassesThreadToCallLLM(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 
@@ -290,6 +294,7 @@ func buildTestNodeRoutingRouter() *reliantv1.Node {
 }
 
 func TestParseRoutingDecision(t *testing.T) {
+	t.Parallel()
 	newExecutor := func(fallback string) *RouterExecutor {
 		evalResult := &reliantv1.Node{
 			Id:   "route",
@@ -406,6 +411,7 @@ type saveMessageCall struct {
 }
 
 func TestExecuteSelectedWorkflow_SavesInjectMessage(t *testing.T) {
+	t.Parallel()
 	// emptyWorkflowJSON is a minimal valid workflow with no nodes.
 	emptyWorkflowJSON, err := json.Marshal(map[string]interface{}{
 		"name":  "test-workflow",

--- a/internal/workflow/runtime/save_message_test.go
+++ b/internal/workflow/runtime/save_message_test.go
@@ -22,6 +22,7 @@ func celExpr(s string) *reliantv1.CelString {
 }
 
 func TestEvaluateSaveMessageConfig_NullAttachments(t *testing.T) {
+	t.Parallel()
 	// This test verifies that CEL expressions returning null for attachments
 	// are handled correctly. The expression:
 	//   "{{has(inputs.attachments) ? inputs.attachments : null}}"
@@ -145,6 +146,7 @@ func TestEvaluateSaveMessageConfig_NullAttachments(t *testing.T) {
 // 'iter'"). After the fix iter resolves from the loop iteration (or a zero default
 // when not in a loop).
 func TestEvaluateSaveMessageConfig_IterInContent(t *testing.T) {
+	t.Parallel()
 	config := &reliantv1.SaveMessageConfig{
 		Role:    celLiteral("assistant"),
 		Content: celExpr("## Implementation Notes (Attempt {{iter.iteration + 1}})"),
@@ -193,6 +195,7 @@ func TestEvaluateSaveMessageConfig_IterInContent(t *testing.T) {
 }
 
 func TestEvaluateSaveMessageConfig_ThreadField(t *testing.T) {
+	t.Parallel()
 	// Thread is now always inherited from execution context (workflowThread parameter)
 	// No explicit thread field in SaveMessageConfig anymore
 	t.Run("thread is always inherited from workflow context", func(t *testing.T) {
@@ -227,6 +230,7 @@ func TestEvaluateSaveMessageConfig_ThreadField(t *testing.T) {
 }
 
 func TestEvaluateCELTemplate_MultilineYAML(t *testing.T) {
+	t.Parallel()
 	// This test verifies that multi-line YAML strings (using | operator) are
 	// correctly handled when they contain pure CEL expressions.
 	// YAML's | operator preserves whitespace, which was causing pure expressions
@@ -321,6 +325,7 @@ func TestEvaluateCELTemplate_MultilineYAML(t *testing.T) {
 }
 
 func TestConvertToToolCalls_TypeAssertions(t *testing.T) {
+	t.Parallel()
 	// Test that type assertion failures are caught and reported, not silently ignored
 	tests := []struct {
 		name        string
@@ -425,6 +430,7 @@ func TestConvertToToolCalls_TypeAssertions(t *testing.T) {
 }
 
 func TestConvertToToolResults_TypeAssertions(t *testing.T) {
+	t.Parallel()
 	// Test that type assertion failures are caught and reported, not silently ignored
 	tests := []struct {
 		name        string
@@ -494,6 +500,7 @@ func TestConvertToToolResults_TypeAssertions(t *testing.T) {
 }
 
 func TestEvaluateSaveMessageConfig_ThinkingOutput(t *testing.T) {
+	t.Parallel()
 	// Test that thinking output is correctly extracted from activity output
 	// and included in the SaveMessageInput for proper persistence.
 
@@ -608,6 +615,7 @@ func TestEvaluateSaveMessageConfig_ThinkingOutput(t *testing.T) {
 // identity from the workflow context, so messages.model / messages.agent are
 // populated for assistant messages.
 func TestEvaluateSaveMessageConfig_ModelAndAgent(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		activityOutput  map[string]interface{}

--- a/internal/workflow/runtime/semantic_parity_fixtures_test.go
+++ b/internal/workflow/runtime/semantic_parity_fixtures_test.go
@@ -603,6 +603,7 @@ func TestLoadSemanticParityFixtures_FailureBehavior(t *testing.T) {
 }
 
 func TestFindNodeBySlashPath_FailureBehavior(t *testing.T) {
+	t.Parallel()
 	workflowDef := &reliantv1.Workflow{
 		Name: "root",
 		Nodes: []*reliantv1.Node{{

--- a/internal/workflow/runtime/simulator_core_parity_test.go
+++ b/internal/workflow/runtime/simulator_core_parity_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestWorkflowSimulator_WorkflowIdentityFromCoreContracts(t *testing.T) {
+	t.Parallel()
 	rootWorkflow := &reliantv1.Workflow{
 		Name: "builtin://agent",
 		Nodes: []*reliantv1.Node{{
@@ -48,6 +49,7 @@ func TestWorkflowSimulator_WorkflowIdentityFromCoreContracts(t *testing.T) {
 }
 
 func TestWorkflowSimulator_AssembleSubWorkflowInputs_InlineInheritsParentInputs(t *testing.T) {
+	t.Parallel()
 	rootWorkflow := &reliantv1.Workflow{
 		Name: "builtin://agent",
 		Nodes: []*reliantv1.Node{{
@@ -76,6 +78,7 @@ func TestWorkflowSimulator_AssembleSubWorkflowInputs_InlineInheritsParentInputs(
 }
 
 func TestWorkflowSimulator_AssembleSubWorkflowInputs_RefUsesArgsThenDefaults(t *testing.T) {
+	t.Parallel()
 	rootWorkflow := &reliantv1.Workflow{
 		Name: "builtin://agent",
 		Nodes: []*reliantv1.Node{{
@@ -137,6 +140,7 @@ func TestWorkflowSimulator_AssembleSubWorkflowInputs_RefUsesArgsThenDefaults(t *
 }
 
 func TestWorkflowSimulator_Run_PropagatesStateMachineRoutingErrors(t *testing.T) {
+	t.Parallel()
 	workflowDef := &reliantv1.Workflow{
 		Name:  "sim-routing-error",
 		Entry: []string{"call_llm"},
@@ -168,6 +172,7 @@ func TestWorkflowSimulator_Run_PropagatesStateMachineRoutingErrors(t *testing.T)
 }
 
 func TestWorkflowSimulator_CompileFailureFallsBackDeterministicallyToRootIdentity(t *testing.T) {
+	t.Parallel()
 	workflowDef := &reliantv1.Workflow{
 		Name: "builtin://root-fallback",
 		Nodes: []*reliantv1.Node{{
@@ -192,6 +197,7 @@ func TestWorkflowSimulator_CompileFailureFallsBackDeterministicallyToRootIdentit
 }
 
 func TestWorkflowSimulator_Run_FailsOnMalformedInlineLoopCondition(t *testing.T) {
+	t.Parallel()
 	workflowDef := &reliantv1.Workflow{
 		Name:  "sim-inline-loop-condition-error",
 		Entry: []string{"loop_node"},
@@ -225,6 +231,7 @@ func TestWorkflowSimulator_Run_FailsOnMalformedInlineLoopCondition(t *testing.T)
 }
 
 func TestWorkflowSimulator_Run_FailsOnMalformedLoopOutputExpression(t *testing.T) {
+	t.Parallel()
 	workflowDef := &reliantv1.Workflow{
 		Name:  "sim-loop-output-error",
 		Entry: []string{"loop_node"},
@@ -260,6 +267,7 @@ func TestWorkflowSimulator_Run_FailsOnMalformedLoopOutputExpression(t *testing.T
 }
 
 func TestWorkflowSimulator_Run_FailsOnMalformedRefLoopWhileExpression(t *testing.T) {
+	t.Parallel()
 	workflowDef := &reliantv1.Workflow{
 		Name:  "sim-ref-loop-while-error",
 		Entry: []string{"loop_node"},

--- a/internal/workflow/runtime/spawn_background_e2e_test.go
+++ b/internal/workflow/runtime/spawn_background_e2e_test.go
@@ -262,6 +262,7 @@ type SpawnBackgroundE2ESuite struct {
 }
 
 func TestSpawnBackgroundE2E(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(SpawnBackgroundE2ESuite))
 }
 

--- a/internal/workflow/runtime/spawn_background_lifetime_test.go
+++ b/internal/workflow/runtime/spawn_background_lifetime_test.go
@@ -27,6 +27,7 @@ type SpawnLifetimeSuite struct {
 }
 
 func TestSpawnLifetime(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(SpawnLifetimeSuite))
 }
 
@@ -393,6 +394,7 @@ func (s *SpawnLifetimeSuite) TestAwaitLiveDetachedSpawns_IgnoresOtherThreads() {
 }
 
 func TestChildWorkflowTracker_DetachedSpawnRegistry(t *testing.T) {
+	t.Parallel()
 	tracker := &ChildWorkflowTracker{}
 	assert.False(t, tracker.hasLiveDetachedSpawns("thread-a"))
 	assert.Equal(t, 0, tracker.detachedCompletionCount("thread-a"))
@@ -414,6 +416,7 @@ func TestChildWorkflowTracker_DetachedSpawnRegistry(t *testing.T) {
 }
 
 func TestChildWorkflowTracker_ListLiveDetachedSpawns_SortedByToolCallID(t *testing.T) {
+	t.Parallel()
 	// Regression for replay-safety: map iteration order is randomized, so
 	// listLiveDetachedSpawns must return a stable order.
 	tracker := &ChildWorkflowTracker{}

--- a/internal/workflow/runtime/spawn_cancel_e2e_test.go
+++ b/internal/workflow/runtime/spawn_cancel_e2e_test.go
@@ -242,6 +242,7 @@ type SpawnCancelE2ESuite struct {
 }
 
 func TestSpawnCancelE2E(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(SpawnCancelE2ESuite))
 }
 

--- a/internal/workflow/runtime/spawn_cancel_loop_test.go
+++ b/internal/workflow/runtime/spawn_cancel_loop_test.go
@@ -54,6 +54,7 @@ edges: []
 // TestSpawnCancel_LoopStopsWhenThreadCancelled pins that a cancelled thread's
 // loop stops instead of executing turns.
 func TestSpawnCancel_LoopStopsWhenThreadCancelled(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 

--- a/internal/workflow/runtime/spawn_cancel_parked_test.go
+++ b/internal/workflow/runtime/spawn_cancel_parked_test.go
@@ -35,6 +35,7 @@ type SpawnCancelParkedSuite struct {
 }
 
 func TestSpawnCancelParked(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(SpawnCancelParkedSuite))
 }
 

--- a/internal/workflow/runtime/spawn_test.go
+++ b/internal/workflow/runtime/spawn_test.go
@@ -25,6 +25,7 @@ import (
 // =========================================================================
 
 func TestSplitProtoToolCalls_AllRegular(t *testing.T) {
+	t.Parallel()
 	toolCalls := []*reliantv1.ToolCallMsg{
 		{Name: "bash", Id: "tc1", Input: "ls"},
 		{Name: "read_file", Id: "tc2", Input: "foo.go"},
@@ -37,6 +38,7 @@ func TestSplitProtoToolCalls_AllRegular(t *testing.T) {
 }
 
 func TestSplitProtoToolCalls_AllSpawn(t *testing.T) {
+	t.Parallel()
 	toolCalls := []*reliantv1.ToolCallMsg{
 		{Name: "spawn", Id: "tc1", Input: `{"preset":"researcher","prompt":"analyze"}`},
 		{Name: "spawn", Id: "tc2", Input: `{"preset":"tester","prompt":"test it"}`},
@@ -49,6 +51,7 @@ func TestSplitProtoToolCalls_AllSpawn(t *testing.T) {
 }
 
 func TestSplitProtoToolCalls_Mixed(t *testing.T) {
+	t.Parallel()
 	toolCalls := []*reliantv1.ToolCallMsg{
 		{Name: "bash", Id: "tc1", Input: "ls"},
 		{Name: "spawn", Id: "tc2", Input: `{"preset":"researcher","prompt":"do it"}`},
@@ -71,6 +74,7 @@ func TestSplitProtoToolCalls_Mixed(t *testing.T) {
 }
 
 func TestSplitProtoToolCalls_EmptyArray(t *testing.T) {
+	t.Parallel()
 	result := splitProtoToolCalls([]*reliantv1.ToolCallMsg{})
 
 	assert.Len(t, result.regularToolCalls, 0)
@@ -78,6 +82,7 @@ func TestSplitProtoToolCalls_EmptyArray(t *testing.T) {
 }
 
 func TestSplitProtoToolCalls_NoNameField(t *testing.T) {
+	t.Parallel()
 	toolCalls := []*reliantv1.ToolCallMsg{
 		{Id: "tc1", Input: "something"},
 	}
@@ -90,6 +95,7 @@ func TestSplitProtoToolCalls_NoNameField(t *testing.T) {
 }
 
 func TestSplitProtoToolCalls_AllAskUser(t *testing.T) {
+	t.Parallel()
 	toolCalls := []*reliantv1.ToolCallMsg{
 		{Name: "ask_user", Id: "tc1", Input: `{"question":"Which option?"}`},
 		{Name: "ask_user", Id: "tc2", Input: `{"question":"Are you sure?"}`},
@@ -105,6 +111,7 @@ func TestSplitProtoToolCalls_AllAskUser(t *testing.T) {
 }
 
 func TestSplitProtoToolCalls_MixedWithAskUser(t *testing.T) {
+	t.Parallel()
 	toolCalls := []*reliantv1.ToolCallMsg{
 		{Name: "bash", Id: "tc1", Input: "ls"},
 		{Name: "spawn", Id: "tc2", Input: `{"preset":"researcher","prompt":"do it"}`},
@@ -132,6 +139,7 @@ func TestSplitProtoToolCalls_MixedWithAskUser(t *testing.T) {
 }
 
 func TestSplitProtoToolCalls_EmptyHasNoAskUser(t *testing.T) {
+	t.Parallel()
 	result := splitProtoToolCalls([]*reliantv1.ToolCallMsg{})
 
 	assert.Len(t, result.regularToolCalls, 0)
@@ -140,6 +148,7 @@ func TestSplitProtoToolCalls_EmptyHasNoAskUser(t *testing.T) {
 }
 
 func TestBuildSpawnChildInputs_NoParentInputs(t *testing.T) {
+	t.Parallel()
 	result := buildSpawnChildInputs(nil)
 
 	assert.Equal(t, "manual", result["mode"])
@@ -148,6 +157,7 @@ func TestBuildSpawnChildInputs_NoParentInputs(t *testing.T) {
 }
 
 func TestBuildSpawnChildInputs_StringModelNotInherited(t *testing.T) {
+	t.Parallel()
 	// The parent's model must NOT be forwarded to the child. A spawned agent runs
 	// under its own preset, whose declared model must win; forwarding the parent
 	// model here would clobber the preset (node args override preset params).
@@ -164,6 +174,7 @@ func TestBuildSpawnChildInputs_StringModelNotInherited(t *testing.T) {
 }
 
 func TestBuildSpawnChildInputs_ObjectModelNotInherited(t *testing.T) {
+	t.Parallel()
 	// Same rule for a rich model selector (id/providers/thinking/etc.): the child
 	// inherits none of it, so its preset's model + thinking stay authoritative.
 	selector := map[string]interface{}{
@@ -184,6 +195,7 @@ func TestBuildSpawnChildInputs_ObjectModelNotInherited(t *testing.T) {
 }
 
 func TestBuildFinalToolResult_WithMessageAndResults(t *testing.T) {
+	t.Parallel()
 	results := []interface{}{
 		map[string]interface{}{"tool_call_id": "tc1", "content": "done"},
 		map[string]interface{}{"tool_call_id": "tc2", "content": "spawned"},
@@ -197,6 +209,7 @@ func TestBuildFinalToolResult_WithMessageAndResults(t *testing.T) {
 }
 
 func TestBuildFinalToolResult_NilMessage_CreatesDefault(t *testing.T) {
+	t.Parallel()
 	results := []interface{}{
 		map[string]interface{}{"tool_call_id": "tc1", "content": "spawned"},
 	}
@@ -211,6 +224,7 @@ func TestBuildFinalToolResult_NilMessage_CreatesDefault(t *testing.T) {
 }
 
 func TestBuildFinalToolResult_EmptyResults_NoMessage(t *testing.T) {
+	t.Parallel()
 	final := buildFinalToolResult([]interface{}{}, nil)
 
 	assert.Equal(t, []interface{}{}, final["tool_results"])
@@ -219,6 +233,7 @@ func TestBuildFinalToolResult_EmptyResults_NoMessage(t *testing.T) {
 }
 
 func TestDeterministicWorkflowID_IsDeterministic(t *testing.T) {
+	t.Parallel()
 	id1 := DeterministicWorkflowID("parent-wf-123", "tool-call-abc")
 	id2 := DeterministicWorkflowID("parent-wf-123", "tool-call-abc")
 
@@ -226,6 +241,7 @@ func TestDeterministicWorkflowID_IsDeterministic(t *testing.T) {
 }
 
 func TestDeterministicWorkflowID_DifferentKeys(t *testing.T) {
+	t.Parallel()
 	id1 := DeterministicWorkflowID("parent-wf-123", "tool-call-abc")
 	id2 := DeterministicWorkflowID("parent-wf-123", "tool-call-xyz")
 
@@ -233,6 +249,7 @@ func TestDeterministicWorkflowID_DifferentKeys(t *testing.T) {
 }
 
 func TestDeterministicWorkflowID_DifferentParents(t *testing.T) {
+	t.Parallel()
 	id1 := DeterministicWorkflowID("parent-wf-123", "tool-call-abc")
 	id2 := DeterministicWorkflowID("parent-wf-456", "tool-call-abc")
 
@@ -240,6 +257,7 @@ func TestDeterministicWorkflowID_DifferentParents(t *testing.T) {
 }
 
 func TestDeterministicThread_MatchesWorkflowID(t *testing.T) {
+	t.Parallel()
 	// DeterministicThread should produce the same value as DeterministicWorkflowID
 	threadID := DeterministicThread("parent-wf-123", "tool-call-abc")
 	workflowID := DeterministicWorkflowID("parent-wf-123", "tool-call-abc")
@@ -248,6 +266,7 @@ func TestDeterministicThread_MatchesWorkflowID(t *testing.T) {
 }
 
 func TestSpawnChildWorkflowConfig_Fields(t *testing.T) {
+	t.Parallel()
 	config := &spawnChildWorkflowConfig{
 		childWorkflowID: "child-123",
 		childThread:     "thread-456",
@@ -275,6 +294,7 @@ type SpawnTestSuite struct {
 }
 
 func TestSpawnSuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(SpawnTestSuite))
 }
 

--- a/internal/workflow/runtime/step_execution_row_test.go
+++ b/internal/workflow/runtime/step_execution_row_test.go
@@ -16,6 +16,7 @@ import (
 // NODE_EXECUTION_STATUS_SKIPPED existed in the proto and in db.models the whole
 // time with nothing ever assigning it.
 func TestSkippedNodeGetsSkippedStatus(t *testing.T) {
+	t.Parallel()
 	if got := nodeStatusFor("completed", true); got != db.NodeStatusSkipped {
 		t.Fatalf("a skipped node reports status %v, want %v — a check that never ran is indistinguishable from one that passed",
 			got, db.NodeStatusSkipped)
@@ -25,6 +26,7 @@ func TestSkippedNodeGetsSkippedStatus(t *testing.T) {
 // The lifecycle mapping for nodes that actually ran is unchanged: skipped is a
 // new state, not a reclassification of the existing ones.
 func TestNodeStatusForLifecycleEvents(t *testing.T) {
+	t.Parallel()
 	cases := map[string]db.NodeExecutionStatus{
 		"started":   db.NodeStatusRunning,
 		"completed": db.NodeStatusCompleted,

--- a/internal/workflow/runtime/step_executor_input_test.go
+++ b/internal/workflow/runtime/step_executor_input_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestNormalizeOutput_MergesSnakeCaseDefaults(t *testing.T) {
+	t.Parallel()
 	executor := &StepExecutor{}
 	rawOutput := map[string]interface{}{
 		"response_text": "hello",
@@ -36,6 +37,7 @@ func TestNormalizeOutput_MergesSnakeCaseDefaults(t *testing.T) {
 }
 
 func TestNormalizeOutput_CallLLMAddsMissingToolCallsField(t *testing.T) {
+	t.Parallel()
 	executor := &StepExecutor{}
 	rawOutput := map[string]interface{}{
 		"message":      map[string]interface{}{"role": "assistant", "text": "ok"},
@@ -51,6 +53,7 @@ func TestNormalizeOutput_CallLLMAddsMissingToolCallsField(t *testing.T) {
 }
 
 func TestEnsureStepEventRoutable(t *testing.T) {
+	t.Parallel()
 	t.Run("nil step event returns explicit error", func(t *testing.T) {
 		err := EnsureStepEventRoutable(nil)
 		require.Error(t, err)

--- a/internal/workflow/runtime/stream_finalized_test.go
+++ b/internal/workflow/runtime/stream_finalized_test.go
@@ -36,6 +36,7 @@ type StreamFinalizedSuite struct {
 }
 
 func TestStreamFinalized(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(StreamFinalizedSuite))
 }
 
@@ -337,6 +338,7 @@ func (s *StreamFinalizedSuite) TestSaveMessageFailure_MarkerStillFires() {
 
 // TestStreamIDTracker pins the tracker's bookkeeping.
 func TestStreamIDTracker(t *testing.T) {
+	t.Parallel()
 	tr := NewStreamIDTracker()
 	tr.Register("b", "chat-1", "t1")
 	tr.Register("a", "chat-1", "t1")

--- a/internal/workflow/runtime/structured_agent_test.go
+++ b/internal/workflow/runtime/structured_agent_test.go
@@ -26,6 +26,7 @@ func loadStructuredAgentWorkflow(t *testing.T) *reliantv1.Workflow {
 
 // TestStructuredAgentWorkflow tests the structured-agent builtin workflow
 func TestStructuredAgentWorkflow(t *testing.T) {
+	t.Parallel()
 	t.Run("validates successfully", func(t *testing.T) {
 		wf := loadStructuredAgentWorkflow(t)
 		require.NotNil(t, wf)
@@ -216,6 +217,7 @@ func TestStructuredAgentWorkflow(t *testing.T) {
 //
 // This is the regression test for: "CEL evaluation error: no such key: submit_review"
 func TestStructuredAgentOutputCEL(t *testing.T) {
+	t.Parallel()
 	wf := loadStructuredAgentWorkflow(t)
 
 	// Extract the inline workflow outputs from agent_loop
@@ -353,6 +355,7 @@ func assertCELNull(t *testing.T, val interface{}, msgAndArgs ...interface{}) {
 
 // TestFilterUnresolvedTemplates tests the helper that removes unresolved {{...}} templates.
 func TestFilterUnresolvedTemplates(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    []string
@@ -395,6 +398,7 @@ func TestFilterUnresolvedTemplates(t *testing.T) {
 
 // TestResponseToolDetectionInLoop tests that response tool detection works in loop contexts
 func TestResponseToolDetectionInLoop(t *testing.T) {
+	t.Parallel()
 	t.Run("inline workflow can detect response tools", func(t *testing.T) {
 		wfJSON := `{
 			"name": "test-inline",

--- a/internal/workflow/runtime/template_eval_save_message_test.go
+++ b/internal/workflow/runtime/template_eval_save_message_test.go
@@ -18,6 +18,7 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestPopulateSaveMessageResolved_ToolCalls(t *testing.T) {
+	t.Parallel()
 	toolCallsJSON := `[{"id":"toolu_abc","name":"grep","input":"{\"pattern\":\"test\"}"},{"id":"toolu_def","name":"write_file","input":"{\"path\":\"a.txt\"}"}]`
 
 	args := &reliantv1.SaveMessageNodeArgs{
@@ -42,6 +43,7 @@ func TestPopulateSaveMessageResolved_ToolCalls(t *testing.T) {
 }
 
 func TestPopulateSaveMessageResolved_ToolResults(t *testing.T) {
+	t.Parallel()
 	toolResultsJSON := `[{"tool_call_id":"toolu_abc","name":"grep","content":"found 5 matches","is_error":false},{"tool_call_id":"toolu_def","name":"write_file","content":"written","is_error":false}]`
 
 	args := &reliantv1.SaveMessageNodeArgs{
@@ -67,6 +69,7 @@ func TestPopulateSaveMessageResolved_ToolResults(t *testing.T) {
 }
 
 func TestPopulateSaveMessageResolved_ToolResultsWithError(t *testing.T) {
+	t.Parallel()
 	toolResultsJSON := `[{"tool_call_id":"toolu_err","name":"bash","content":"command not found","is_error":true}]`
 
 	args := &reliantv1.SaveMessageNodeArgs{
@@ -85,6 +88,7 @@ func TestPopulateSaveMessageResolved_ToolResultsWithError(t *testing.T) {
 }
 
 func TestPopulateSaveMessageResolved_Attachments(t *testing.T) {
+	t.Parallel()
 	attachmentsJSON := `["file1.txt","file2.png","image.jpg"]`
 
 	args := &reliantv1.SaveMessageNodeArgs{
@@ -102,6 +106,7 @@ func TestPopulateSaveMessageResolved_Attachments(t *testing.T) {
 }
 
 func TestPopulateSaveMessageResolved_EmptyToolCalls(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		args *reliantv1.SaveMessageNodeArgs
@@ -161,6 +166,7 @@ func TestPopulateSaveMessageResolved_EmptyToolCalls(t *testing.T) {
 }
 
 func TestPopulateSaveMessageResolved_InvalidJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		literal string

--- a/internal/workflow/runtime/template_nested_braces_test.go
+++ b/internal/workflow/runtime/template_nested_braces_test.go
@@ -11,6 +11,7 @@ import (
 // the regex-based template extraction. This correctly handles nested braces in
 // CEL expressions like map/object literals.
 func TestExtractTemplateExpressions(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name     string
 		template string

--- a/internal/workflow/runtime/thread_analysis_test.go
+++ b/internal/workflow/runtime/thread_analysis_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestRuntimeThreadMapping(t *testing.T) {
+	t.Parallel()
 	t.Run("basic operations", func(t *testing.T) {
 		m := NewRuntimeThreadMapping()
 
@@ -36,6 +37,7 @@ func TestRuntimeThreadMapping(t *testing.T) {
 }
 
 func TestThreadTracker(t *testing.T) {
+	t.Parallel()
 	t.Run("basic operations", func(t *testing.T) {
 		tracker := NewThreadTracker()
 
@@ -82,6 +84,7 @@ func TestThreadTracker(t *testing.T) {
 }
 
 func TestLogicalThreadName(t *testing.T) {
+	t.Parallel()
 	t.Run("ThreadRoot constant", func(t *testing.T) {
 		assert.Equal(t, "thread:root", string(ThreadRoot))
 	})

--- a/internal/workflow/runtime/thread_inputs_test.go
+++ b/internal/workflow/runtime/thread_inputs_test.go
@@ -18,6 +18,7 @@ import (
 // ==========================================================================
 
 func TestChildWorkflowTracker_RegisterThreadInputs(t *testing.T) {
+	t.Parallel()
 	tracker := &ChildWorkflowTracker{children: make(map[string]bool)}
 
 	inputs := map[string]interface{}{"model": "gpt-4", "temperature": 0.7}
@@ -31,6 +32,7 @@ func TestChildWorkflowTracker_RegisterThreadInputs(t *testing.T) {
 }
 
 func TestChildWorkflowTracker_GetThreadInputs_Unregistered(t *testing.T) {
+	t.Parallel()
 	tracker := &ChildWorkflowTracker{children: make(map[string]bool)}
 
 	got := tracker.GetThreadInputs("nonexistent")
@@ -38,6 +40,7 @@ func TestChildWorkflowTracker_GetThreadInputs_Unregistered(t *testing.T) {
 }
 
 func TestChildWorkflowTracker_GetThreadInputs_NilMap(t *testing.T) {
+	t.Parallel()
 	tracker := &ChildWorkflowTracker{children: make(map[string]bool)}
 	// threadInputs is nil by default
 	got := tracker.GetThreadInputs("anything")
@@ -45,6 +48,7 @@ func TestChildWorkflowTracker_GetThreadInputs_NilMap(t *testing.T) {
 }
 
 func TestChildWorkflowTracker_UnregisterThreadInputs(t *testing.T) {
+	t.Parallel()
 	tracker := &ChildWorkflowTracker{children: make(map[string]bool)}
 
 	inputs := map[string]interface{}{"model": "claude"}
@@ -56,6 +60,7 @@ func TestChildWorkflowTracker_UnregisterThreadInputs(t *testing.T) {
 }
 
 func TestChildWorkflowTracker_MultipleThreads(t *testing.T) {
+	t.Parallel()
 	tracker := &ChildWorkflowTracker{children: make(map[string]bool)}
 
 	inputs1 := map[string]interface{}{"model": "gpt-4"}
@@ -71,6 +76,7 @@ func TestChildWorkflowTracker_MultipleThreads(t *testing.T) {
 }
 
 func TestChildWorkflowTracker_GetAllThreadInputs(t *testing.T) {
+	t.Parallel()
 	tracker := &ChildWorkflowTracker{children: make(map[string]bool)}
 
 	inputs1 := map[string]interface{}{"a": 1}
@@ -85,6 +91,7 @@ func TestChildWorkflowTracker_GetAllThreadInputs(t *testing.T) {
 }
 
 func TestChildWorkflowTracker_SharedPointerMutation(t *testing.T) {
+	t.Parallel()
 	// Verify that mutating through the registry mutates the original map
 	tracker := &ChildWorkflowTracker{children: make(map[string]bool)}
 
@@ -109,6 +116,7 @@ type ThreadInputsSuite struct {
 }
 
 func TestThreadInputsSuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(ThreadInputsSuite))
 }
 
@@ -518,6 +526,7 @@ func (s *ThreadInputsSuite) TestSignal_ThreadScopedUpdate_DoesNotAffectOtherThre
 // TestChildWorkflowTracker_GlobalPropagation_Unit verifies that mutating all thread
 // inputs via GetAllThreadInputs (as the signal handler does) works correctly.
 func TestChildWorkflowTracker_GlobalPropagation_Unit(t *testing.T) {
+	t.Parallel()
 	tracker := &ChildWorkflowTracker{children: make(map[string]bool)}
 
 	inputs1 := map[string]interface{}{"model": "claude", "mode": "research"}
@@ -546,6 +555,7 @@ func TestChildWorkflowTracker_GlobalPropagation_Unit(t *testing.T) {
 // TestChildWorkflowTracker_GlobalPropagation_DoesNotAffectUnregistered verifies that
 // unregistered threads are not affected by global propagation.
 func TestChildWorkflowTracker_GlobalPropagation_DoesNotAffectUnregistered(t *testing.T) {
+	t.Parallel()
 	tracker := &ChildWorkflowTracker{children: make(map[string]bool)}
 
 	inputs1 := map[string]interface{}{"model": "claude"}
@@ -569,6 +579,7 @@ func TestChildWorkflowTracker_GlobalPropagation_DoesNotAffectUnregistered(t *tes
 // sub-workflows get the exact same map pointer as the parent, so signal updates
 // to the parent are visible immediately without any propagation.
 func TestInlineInheritedSubWorkflow_SharesParentMap(t *testing.T) {
+	t.Parallel()
 	parentInputs := map[string]interface{}{"model": "gpt-4", "ask": true}
 
 	executor := &InlineWorkflowExecutor{

--- a/internal/workflow/runtime/thread_interrupt_coordinator_test.go
+++ b/internal/workflow/runtime/thread_interrupt_coordinator_test.go
@@ -103,6 +103,7 @@ func parkedInterruptWorkflow(thread string, tracker *ChildWorkflowTracker) func(
 }
 
 func TestThreadInterrupt_WakesParkedDetachedWaitAndForcesNextTurn(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 	tracker := &ChildWorkflowTracker{}
@@ -129,6 +130,7 @@ func TestThreadInterrupt_WakesParkedDetachedWaitAndForcesNextTurn(t *testing.T) 
 }
 
 func TestThreadInterrupt_ParkedWaitIgnoresOtherThreads(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 	tracker := &ChildWorkflowTracker{}

--- a/internal/workflow/runtime/thread_memoization_test.go
+++ b/internal/workflow/runtime/thread_memoization_test.go
@@ -14,6 +14,7 @@ import (
 // causes all iterations to share the SAME thread ID.
 // Loops are passthrough — they always inherit the parent's thread.
 func TestMemoization_ReuseThread(t *testing.T) {
+	t.Parallel()
 	t.Run("multiple iterations get same thread ID", func(t *testing.T) {
 		parent := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0").
 			WithLoop("agent_loop", 0)
@@ -53,6 +54,7 @@ func TestMemoization_ReuseThread(t *testing.T) {
 
 // TestMemoization_LoopContext tests that LoopContext is properly set during iteration.
 func TestMemoization_LoopContext(t *testing.T) {
+	t.Parallel()
 	t.Run("LoopContext is set with correct iteration number", func(t *testing.T) {
 		parent := NewExecutionContext("wf-123", "chat-456", "agent", "thread-0").
 			WithLoop("test_loop", 0)
@@ -100,6 +102,7 @@ func TestMemoization_LoopContext(t *testing.T) {
 // TestMemoization_InheritedProperties tests that ForIteration correctly
 // inherits properties from the parent context.
 func TestMemoization_InheritedProperties(t *testing.T) {
+	t.Parallel()
 	t.Run("iteration inherits workflow metadata", func(t *testing.T) {
 		parent := NewExecutionContext("wf-parent", "chat-parent", "parent-workflow", "thread-parent").
 			WithLoop("loop", 0)

--- a/internal/workflow/runtime/thread_mode_test.go
+++ b/internal/workflow/runtime/thread_mode_test.go
@@ -15,6 +15,7 @@ import (
 // =============================================================================
 
 func TestThreadModeInherit_ChildGetsSameThreadAsParent(t *testing.T) {
+	t.Parallel()
 	// Create parent context with a specific thread
 	parent := NewExecutionContext("wf-parent-123", "chat-456", "parent-workflow", "parent-thread-uuid")
 
@@ -27,6 +28,7 @@ func TestThreadModeInherit_ChildGetsSameThreadAsParent(t *testing.T) {
 }
 
 func TestThreadModeInherit_ThreadModeIsSetCorrectly(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "parent", "thread-0")
 
 	child := parent.ForChild("step", model.ThreadModeInherit, "child", true)
@@ -35,6 +37,7 @@ func TestThreadModeInherit_ThreadModeIsSetCorrectly(t *testing.T) {
 }
 
 func TestThreadModeInherit_ForkedFromIsEmpty(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "parent", "thread-0")
 
 	child := parent.ForChild("step", model.ThreadModeInherit, "child", true)
@@ -44,6 +47,7 @@ func TestThreadModeInherit_ForkedFromIsEmpty(t *testing.T) {
 }
 
 func TestThreadModeInherit_ParentContextIsSet(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-parent-123", "chat-456", "parent", "thread-0")
 
 	child := parent.ForChild("my_child_step", model.ThreadModeInherit, "child-wf", true)
@@ -54,6 +58,7 @@ func TestThreadModeInherit_ParentContextIsSet(t *testing.T) {
 }
 
 func TestThreadModeInherit_MultipleChildrenShareSameThread(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "parent", "shared-thread")
 
 	child1 := parent.ForChild("step_a", model.ThreadModeInherit, "wf-a", true)
@@ -67,6 +72,7 @@ func TestThreadModeInherit_MultipleChildrenShareSameThread(t *testing.T) {
 }
 
 func TestThreadModeInherit_NestedInheritance(t *testing.T) {
+	t.Parallel()
 	// Create a chain: grandparent -> parent -> child
 	grandparent := NewExecutionContext("wf-gp", "chat", "gp", "original-thread")
 	parent := grandparent.ForChild("parent_step", model.ThreadModeInherit, "parent", true)
@@ -83,6 +89,7 @@ func TestThreadModeInherit_NestedInheritance(t *testing.T) {
 // =============================================================================
 
 func TestThreadModeNew_ChildGetsNewDeterministicThread(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "parent", "parent-thread")
 
 	child := parent.ForChild("new_thread_step", model.ThreadModeNew, "child-workflow", true)
@@ -94,6 +101,7 @@ func TestThreadModeNew_ChildGetsNewDeterministicThread(t *testing.T) {
 }
 
 func TestThreadModeNew_ThreadModeIsSetCorrectly(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "parent", "thread-0")
 
 	child := parent.ForChild("step", model.ThreadModeNew, "child", true)
@@ -102,6 +110,7 @@ func TestThreadModeNew_ThreadModeIsSetCorrectly(t *testing.T) {
 }
 
 func TestThreadModeNew_ForkedFromIsEmpty(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "parent", "thread-0")
 
 	child := parent.ForChild("step", model.ThreadModeNew, "child", true)
@@ -111,6 +120,7 @@ func TestThreadModeNew_ForkedFromIsEmpty(t *testing.T) {
 }
 
 func TestThreadModeNew_DeterministicThreadID_SameInputsSameOutput(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "parent", "thread-0")
 
 	// Call ForChild multiple times with the same parameters
@@ -122,6 +132,7 @@ func TestThreadModeNew_DeterministicThreadID_SameInputsSameOutput(t *testing.T) 
 }
 
 func TestThreadModeNew_DeterministicThreadID_DifferentStepIDsDifferentThreads(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "parent", "thread-0")
 
 	child1 := parent.ForChild("step_alpha", model.ThreadModeNew, "child", true)
@@ -132,6 +143,7 @@ func TestThreadModeNew_DeterministicThreadID_DifferentStepIDsDifferentThreads(t 
 }
 
 func TestThreadModeNew_DeterministicThreadID_DifferentParentWorkflowIDsDifferentThreads(t *testing.T) {
+	t.Parallel()
 	parent1 := NewExecutionContext("wf-111", "chat-456", "parent", "thread-0")
 	parent2 := NewExecutionContext("wf-222", "chat-456", "parent", "thread-0")
 
@@ -143,6 +155,7 @@ func TestThreadModeNew_DeterministicThreadID_DifferentParentWorkflowIDsDifferent
 }
 
 func TestThreadModeNew_MultipleChildrenGetUniqueThreads(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "parent", "shared-thread")
 
 	child1 := parent.ForChild("step_a", model.ThreadModeNew, "wf-a", true)
@@ -165,6 +178,7 @@ func TestThreadModeNew_MultipleChildrenGetUniqueThreads(t *testing.T) {
 // =============================================================================
 
 func TestThreadModeFork_ChildGetsNewThread(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "parent", "parent-thread")
 
 	child := parent.ForChild("fork_step", model.ThreadModeFork, "child-workflow", true)
@@ -175,6 +189,7 @@ func TestThreadModeFork_ChildGetsNewThread(t *testing.T) {
 }
 
 func TestThreadModeFork_ThreadModeIsSetCorrectly(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "parent", "thread-0")
 
 	child := parent.ForChild("step", model.ThreadModeFork, "child", true)
@@ -183,6 +198,7 @@ func TestThreadModeFork_ThreadModeIsSetCorrectly(t *testing.T) {
 }
 
 func TestThreadModeFork_ForkedFromIsSetToParentThread(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "parent", "the-parent-thread")
 
 	child := parent.ForChild("fork_step", model.ThreadModeFork, "child", true)
@@ -193,6 +209,7 @@ func TestThreadModeFork_ForkedFromIsSetToParentThread(t *testing.T) {
 }
 
 func TestThreadModeFork_DeterministicThreadID(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "parent", "thread-0")
 
 	child1 := parent.ForChild("fork_step", model.ThreadModeFork, "child", true)
@@ -203,6 +220,7 @@ func TestThreadModeFork_DeterministicThreadID(t *testing.T) {
 }
 
 func TestThreadModeFork_DifferentStepIDsDifferentThreads(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "parent", "thread-0")
 
 	child1 := parent.ForChild("fork_alpha", model.ThreadModeFork, "child", true)
@@ -213,6 +231,7 @@ func TestThreadModeFork_DifferentStepIDsDifferentThreads(t *testing.T) {
 }
 
 func TestThreadModeFork_ParentContextIsSet(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-parent-123", "chat-456", "parent", "thread-0")
 
 	child := parent.ForChild("my_fork_step", model.ThreadModeFork, "child-wf", true)
@@ -223,6 +242,7 @@ func TestThreadModeFork_ParentContextIsSet(t *testing.T) {
 }
 
 func TestThreadModeFork_MultipleForks(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "parent", "parent-thread")
 
 	// Fork multiple times (e.g., parallel reviewers)
@@ -245,6 +265,7 @@ func TestThreadModeFork_MultipleForks(t *testing.T) {
 // =============================================================================
 
 func TestDeterministicThread_SameInputsSameOutput(t *testing.T) {
+	t.Parallel()
 	thread1 := DeterministicThread("wf-123", "some-key")
 	thread2 := DeterministicThread("wf-123", "some-key")
 
@@ -252,6 +273,7 @@ func TestDeterministicThread_SameInputsSameOutput(t *testing.T) {
 }
 
 func TestDeterministicThread_DifferentInputsDifferentOutput(t *testing.T) {
+	t.Parallel()
 	thread1 := DeterministicThread("wf-123", "key-a")
 	thread2 := DeterministicThread("wf-123", "key-b")
 
@@ -259,6 +281,7 @@ func TestDeterministicThread_DifferentInputsDifferentOutput(t *testing.T) {
 }
 
 func TestDeterministicThread_DifferentWorkflowIDsDifferentOutput(t *testing.T) {
+	t.Parallel()
 	thread1 := DeterministicThread("wf-111", "same-key")
 	thread2 := DeterministicThread("wf-222", "same-key")
 
@@ -266,6 +289,7 @@ func TestDeterministicThread_DifferentWorkflowIDsDifferentOutput(t *testing.T) {
 }
 
 func TestDeterministicThread_OutputIsValidUUID(t *testing.T) {
+	t.Parallel()
 	thread := DeterministicThread("wf-123", "test-key")
 
 	// Should be a valid UUID format (36 characters with hyphens)
@@ -274,6 +298,7 @@ func TestDeterministicThread_OutputIsValidUUID(t *testing.T) {
 }
 
 func TestDeterministicThread_ConsistentAcrossMultipleCalls(t *testing.T) {
+	t.Parallel()
 	parentID := "wf-test-workflow-12345"
 	key := "step_call_llm:iter:5"
 
@@ -289,6 +314,7 @@ func TestDeterministicThread_ConsistentAcrossMultipleCalls(t *testing.T) {
 }
 
 func TestDeterministicThread_EmptyInputs(t *testing.T) {
+	t.Parallel()
 	// Should handle empty strings gracefully
 	thread1 := DeterministicThread("", "key")
 	thread2 := DeterministicThread("wf", "")
@@ -309,6 +335,7 @@ func TestDeterministicThread_EmptyInputs(t *testing.T) {
 // =============================================================================
 
 func TestThreadMode_DefaultFallsBackToInherit(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "parent", "parent-thread")
 
 	// Using an empty/invalid model.ThreadMode should default to inherit
@@ -322,6 +349,7 @@ func TestThreadMode_DefaultFallsBackToInherit(t *testing.T) {
 // =============================================================================
 
 func TestForChild_InheritsLoopContext(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-123", "chat-456", "parent", "thread-0").
 		WithLoop("agent_loop", 5)
 
@@ -338,6 +366,7 @@ func TestForChild_InheritsLoopContext(t *testing.T) {
 // =============================================================================
 
 func TestForChildWorkflow_SetsChildWorkflowID(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-parent", "chat-456", "parent", "thread-0")
 
 	child := parent.ForChildWorkflow("wf-child-specific", "spawn_step", model.ThreadModeInherit, "child-workflow", true)
@@ -346,6 +375,7 @@ func TestForChildWorkflow_SetsChildWorkflowID(t *testing.T) {
 }
 
 func TestForChildWorkflow_TracksParentWorkflowID(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-parent", "chat-456", "parent", "thread-0")
 
 	child := parent.ForChildWorkflow("wf-child", "spawn_step", model.ThreadModeInherit, "child", true)
@@ -356,6 +386,7 @@ func TestForChildWorkflow_TracksParentWorkflowID(t *testing.T) {
 }
 
 func TestForChildWorkflow_WithForkMode(t *testing.T) {
+	t.Parallel()
 	parent := NewExecutionContext("wf-parent", "chat-456", "parent", "parent-thread")
 
 	child := parent.ForChildWorkflow("wf-child", "fork_step", model.ThreadModeFork, "child", true)
@@ -371,6 +402,7 @@ func TestForChildWorkflow_WithForkMode(t *testing.T) {
 // =============================================================================
 
 func TestThreadModes_TypicalParallelReviewerPattern(t *testing.T) {
+	t.Parallel()
 	// Simulates: main workflow -> fork to multiple reviewers -> each has own thread
 	main := NewExecutionContext("wf-main", "chat", "implement-validate", "main-thread")
 
@@ -394,6 +426,7 @@ func TestThreadModes_TypicalParallelReviewerPattern(t *testing.T) {
 }
 
 func TestThreadModes_TypicalDevilsAdvocatePattern(t *testing.T) {
+	t.Parallel()
 	// Simulates: main debate with advocates in fresh threads
 	debate := NewExecutionContext("wf-debate", "chat", "devils-advocate", "debate-thread")
 
@@ -413,6 +446,7 @@ func TestThreadModes_TypicalDevilsAdvocatePattern(t *testing.T) {
 }
 
 func TestThreadModes_NestedWorkflowScenario(t *testing.T) {
+	t.Parallel()
 	// Simulates: parent -> child (inherit) -> grandchild (fork)
 	parent := NewExecutionContext("wf-parent", "chat", "parent-wf", "root-thread")
 
@@ -437,6 +471,7 @@ func TestThreadModes_NestedWorkflowScenario(t *testing.T) {
 // =============================================================================
 
 func TestThreadModeConstants(t *testing.T) {
+	t.Parallel()
 	// Verify the string values of thread mode constants
 	assert.Equal(t, "inherit", model.ThreadModeInherit)
 	assert.Equal(t, "new", model.ThreadModeNew)

--- a/internal/workflow/runtime/thread_origin_announce_test.go
+++ b/internal/workflow/runtime/thread_origin_announce_test.go
@@ -32,6 +32,7 @@ func originForAnnouncement(threadMode string) string {
 // omits the field (workflow_status.go only sets "origin" when non-empty), so
 // the authoritative earlier announcement stands.
 func TestInlineExecutorDoesNotOverwriteSpawnOrigin(t *testing.T) {
+	t.Parallel()
 	// The mode a spawned sub-agent's workflow runs under must NOT produce an
 	// origin — anything non-empty here clobbers "spawn".
 	for _, mode := range []string{model.ThreadModeNew, model.ThreadModeInherit} {
@@ -50,6 +51,7 @@ func TestInlineExecutorDoesNotOverwriteSpawnOrigin(t *testing.T) {
 // (377 spawn / 166 fork / 142 main / 28 node in a real database), so the
 // stream never needs to restate it — the read path joins the thread row.
 func TestThreadOriginConstantsAreDistinct(t *testing.T) {
+	t.Parallel()
 	seen := map[string]bool{}
 	for _, o := range []string{
 		model.ThreadOriginMain, model.ThreadOriginSpawn,

--- a/internal/workflow/runtime/tool_call_propagation_test.go
+++ b/internal/workflow/runtime/tool_call_propagation_test.go
@@ -61,6 +61,7 @@ type testCallLLMOutput struct {
 // JSON round-trip (which is what Temporal does with activity outputs).
 
 func TestCallLLMOutput_ToolCallsJSONRoundTrip(t *testing.T) {
+	t.Parallel()
 	// Construct a CallLLMOutput as the call_llm activity would produce it
 	output := testCallLLMOutput{
 		ResponseText: "Let me check that file for you.",
@@ -119,6 +120,7 @@ func TestCallLLMOutput_ToolCallsJSONRoundTrip(t *testing.T) {
 }
 
 func TestCallLLMOutput_EmptyToolCalls_RoundTrip(t *testing.T) {
+	t.Parallel()
 	// When the LLM returns no tool calls (text-only response)
 	output := testCallLLMOutput{
 		ResponseText: "Hello, how can I help?",
@@ -147,6 +149,7 @@ func TestCallLLMOutput_EmptyToolCalls_RoundTrip(t *testing.T) {
 }
 
 func TestCallLLMOutput_NilToolCalls_RoundTrip(t *testing.T) {
+	t.Parallel()
 	// When the LLM returns nil tool calls (no tool_calls field at all)
 	output := testCallLLMOutput{
 		ResponseText: "Hello",
@@ -179,6 +182,7 @@ func TestCallLLMOutput_NilToolCalls_RoundTrip(t *testing.T) {
 // correctly evaluates when tool calls come from a JSON round-tripped CallLLMOutput.
 
 func TestEdgeCondition_ToolCallsFromJSONRoundTrip(t *testing.T) {
+	t.Parallel()
 	// This test simulates the exact data flow:
 	// 1. CallLLM produces output with ToolCalls
 	// 2. Temporal serializes/deserializes via JSON
@@ -278,6 +282,7 @@ func TestEdgeCondition_ToolCallsFromJSONRoundTrip(t *testing.T) {
 }
 
 func TestEdgeCondition_ToolCallsNotText(t *testing.T) {
+	t.Parallel()
 	// Regression test: tool calls should NOT be plain text strings in the output.
 	// When tool calls appear as text (the bug), tool_calls field will be null/empty
 	// and the text will be embedded in response_text instead.
@@ -349,6 +354,7 @@ func TestEdgeCondition_ToolCallsNotText(t *testing.T) {
 // to state machine routing, which is the exact production path.
 
 func TestCallLLMToStateMachineRouting(t *testing.T) {
+	t.Parallel()
 	wfJSON := `{
 		"name": "test-agent",
 		"entry": ["call_llm"],
@@ -436,6 +442,7 @@ func TestCallLLMToStateMachineRouting(t *testing.T) {
 // Tests that {{output.tool_calls}} properly resolves in save_message configuration.
 
 func TestSaveMessageConfig_OutputToolCallsResolution(t *testing.T) {
+	t.Parallel()
 	t.Run("output.tool_calls resolves to structured array", func(t *testing.T) {
 		// Build a save_message config that references output.tool_calls
 		config := &reliantv1.SaveMessageConfig{
@@ -640,6 +647,7 @@ func TestSaveMessageConfig_OutputToolCallsResolution(t *testing.T) {
 // from the DriverResponse, matching the real data flow.
 
 func TestCallLLMOutput_ToolCallFieldTypes(t *testing.T) {
+	t.Parallel()
 	// After JSON round-trip, verify the types of tool call fields match what CEL expects
 	output := testCallLLMOutput{
 		ToolCalls: []testToolCall{

--- a/internal/workflow/runtime/trigger_test.go
+++ b/internal/workflow/runtime/trigger_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestThreadMode_Constants(t *testing.T) {
+	t.Parallel()
 	// Verify the string values match the spec
 	assert.Equal(t, "new", model.ThreadModeNew)
 	assert.Equal(t, "inherit", model.ThreadModeInherit)
@@ -21,6 +22,7 @@ func TestThreadMode_Constants(t *testing.T) {
 // ============================================================================
 
 func TestInlineWorkflowExecutor_ExecContext(t *testing.T) {
+	t.Parallel()
 	t.Run("WithExecContext sets execution context", func(t *testing.T) {
 		// Note: We can only test the struct-level behavior without Temporal context
 		executor := &InlineWorkflowExecutor{

--- a/internal/workflow/runtime/unattended_self_resume_test.go
+++ b/internal/workflow/runtime/unattended_self_resume_test.go
@@ -32,6 +32,7 @@ type SelfResumeSuite struct {
 }
 
 func TestSelfResume(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(SelfResumeSuite))
 }
 

--- a/internal/workflow/runtime/unattended_test.go
+++ b/internal/workflow/runtime/unattended_test.go
@@ -152,6 +152,7 @@ func runAskQuestionWorkflow(
 // An unattended run must never park on a checkpoint. No questions row is created,
 // so there is nothing for a human to answer and nothing to wait on.
 func TestUnattendedAskQuestionCreatesNoQuestionRow(t *testing.T) {
+	t.Parallel()
 	scheduled, result := runAskQuestionWorkflow(t, map[string]interface{}{"unattended": true}, nil)
 
 	require.NotContains(t, scheduled, "QuestionCreate",
@@ -168,6 +169,7 @@ func TestUnattendedAskQuestionCreatesNoQuestionRow(t *testing.T) {
 // The auto-resolution has to be legible as an auto-resolution. A human answer and
 // a machine's "nobody was there" must not read the same in the record.
 func TestUnattendedAskQuestionIsDistinguishableFromAHumanAnswer(t *testing.T) {
+	t.Parallel()
 	_, auto := runAskQuestionWorkflow(t, map[string]interface{}{"unattended": true}, nil)
 
 	require.Equal(t, true, auto.Outputs["auto_resolved"],
@@ -197,6 +199,7 @@ func TestUnattendedAskQuestionIsDistinguishableFromAHumanAnswer(t *testing.T) {
 
 // Regression guard: with the input unset, nothing about the interactive path moves.
 func TestInteractiveAskQuestionStillCreatesAQuestionAndWaits(t *testing.T) {
+	t.Parallel()
 	scheduled, result := runAskQuestionWorkflow(t, map[string]interface{}{}, func(env *testsuite.TestWorkflowEnvironment, questionID *string) {
 		env.RegisterDelayedCallback(func() {
 			require.NotEmpty(t, *questionID)
@@ -215,6 +218,7 @@ func TestInteractiveAskQuestionStillCreatesAQuestionAndWaits(t *testing.T) {
 
 // Explicitly false must behave exactly like unset.
 func TestExplicitlyAttendedAskQuestionStillCreatesAQuestion(t *testing.T) {
+	t.Parallel()
 	scheduled, _ := runAskQuestionWorkflow(t, map[string]interface{}{"unattended": false}, func(env *testsuite.TestWorkflowEnvironment, questionID *string) {
 		env.RegisterDelayedCallback(func() {
 			env.SignalWorkflow("signal.question."+*questionID, map[string]interface{}{
@@ -262,6 +266,7 @@ func askUserToolWorkflowBytes(t *testing.T) []byte {
 // scope-conversation's charter says "You MUST use ask_user at least once" — the
 // call cannot park an unattended run.
 func TestUnattendedAskUserToolReturnsUnansweredWithoutAQuestionRow(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 
@@ -313,6 +318,7 @@ func TestUnattendedAskUserToolReturnsUnansweredWithoutAQuestionRow(t *testing.T)
 
 // Regression guard for the tool path.
 func TestInteractiveAskUserToolStillCreatesAQuestion(t *testing.T) {
+	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 
@@ -362,6 +368,7 @@ func TestInteractiveAskUserToolStillCreatesAQuestion(t *testing.T) {
 // ─── propagation ──────────────────────────────────────────────────────────────
 
 func TestIsUnattended(t *testing.T) {
+	t.Parallel()
 	assert.False(t, IsUnattended(nil))
 	assert.False(t, IsUnattended(map[string]interface{}{}))
 	assert.False(t, IsUnattended(map[string]interface{}{"unattended": false}))
@@ -377,6 +384,7 @@ func TestIsUnattended(t *testing.T) {
 // it is why `unattended` cannot repeat `ask`'s history of being declared,
 // threaded, and inert.
 func TestPropagateUnattendedIsMonotone(t *testing.T) {
+	t.Parallel()
 	t.Run("an unattended parent overrides a child arg that says otherwise", func(t *testing.T) {
 		child := map[string]interface{}{"unattended": false}
 		propagateUnattended(map[string]interface{}{"unattended": true}, child)
@@ -409,6 +417,7 @@ func TestPropagateUnattendedIsMonotone(t *testing.T) {
 // The forge preset hands every spawned fan-out unit `ask_user`. Without this, one
 // unit's question parks the whole unattended run.
 func TestBuildSpawnChildInputsPropagatesUnattended(t *testing.T) {
+	t.Parallel()
 	child := buildSpawnChildInputs(map[string]interface{}{"mode": "auto", "unattended": true})
 	assert.Equal(t, true, child["unattended"],
 		"a spawned sub-agent runs in the same world as its parent")
@@ -419,6 +428,7 @@ func TestBuildSpawnChildInputsPropagatesUnattended(t *testing.T) {
 }
 
 func TestUnattendedAskUserResponseNamesTheQuestionsItCouldNotAnswer(t *testing.T) {
+	t.Parallel()
 	const metadata = `{"type":"ask_user","questions":[` +
 		`{"question":"Which entities?","options":[{"label":"Peptide"},{"label":"Protocol"}]},` +
 		`{"question":"Branding?","options":[]}]}`

--- a/internal/workflow/runtime/wait_for_cancellation_test.go
+++ b/internal/workflow/runtime/wait_for_cancellation_test.go
@@ -33,6 +33,7 @@ import (
 // This asserts the absence directly against the built options, so re-adding the
 // flag anywhere in this path fails here rather than in a user's chat.
 func TestActivityOptions_NeverWaitForCancellation(t *testing.T) {
+	t.Parallel()
 	for _, nodeType := range []string{
 		model.NodeTypeCallLLM,
 		model.NodeTypeExecuteTools,

--- a/internal/workflow/runtime/workflow_context_bridge_test.go
+++ b/internal/workflow/runtime/workflow_context_bridge_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestWorkflowContextToTyped(t *testing.T) {
+	t.Parallel()
 	t.Run("maps all known fields", func(t *testing.T) {
 		ctx := map[string]interface{}{
 			workflowContextKeyID:           "wf-123",

--- a/internal/workflow/runtime/workflow_templates_test.go
+++ b/internal/workflow/runtime/workflow_templates_test.go
@@ -13,6 +13,7 @@ import (
 // TestTemplateResolution tests various template expression patterns
 // These tests define the expected behavior for template resolution
 func TestTemplateResolution(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		template string
@@ -238,6 +239,7 @@ func TestTemplateResolution(t *testing.T) {
 
 // TestResolveWorkflowMap tests resolving templates in a full workflow map structure
 func TestResolveWorkflowMap(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		raw     map[string]interface{}
@@ -421,6 +423,7 @@ func TestResolveWorkflowMap(t *testing.T) {
 
 // TestEndToEndWithTypedStruct tests the full flow: raw map -> resolve -> proto
 func TestEndToEndWithTypedStruct(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		raw    map[string]interface{}
@@ -542,6 +545,7 @@ func TestEndToEndWithTypedStruct(t *testing.T) {
 
 // TestTemplateResolutionAndParsing tests template-aware parsing for validation
 func TestTemplateResolutionAndParsing(t *testing.T) {
+	t.Parallel()
 	// YAML with template in loop while
 	yaml := []byte(`
 name: test-workflow
@@ -604,6 +608,7 @@ nodes:
 
 // TestRuntimeTemplateResolutionFlow tests the full runtime flow as it happens in DynamicWorkflow
 func TestRuntimeTemplateResolutionFlow(t *testing.T) {
+	t.Parallel()
 	yaml := []byte(`
 name: agent
 apiVersion: "0.0.6"
@@ -654,6 +659,7 @@ nodes:
 // completion. Output templates should be preserved and only evaluated later via
 // EvaluateWorkflowOutputs().
 func TestOutputsNotResolvedAtLoadTime(t *testing.T) {
+	t.Parallel()
 	t.Run("outputs remain as templates", func(t *testing.T) {
 		// This mimics the structure of agent.yaml which caused the bug
 		raw := map[string]interface{}{
@@ -746,6 +752,7 @@ outputs:
 // workflow.thread, workflow.id, or step outputs that don't exist at load time.
 // They are evaluated at step execution time via evaluateTemplates().
 func TestNodeInputsNotResolvedAtLoadTime(t *testing.T) {
+	t.Parallel()
 	t.Run("node inputs remain as templates", func(t *testing.T) {
 		// This mimics the structure of agent.yaml where node inputs reference
 		// inputs.* fields that may not be provided

--- a/internal/workflow/runtime/workflow_test.go
+++ b/internal/workflow/runtime/workflow_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestGetBoolInput(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		inputs      map[string]interface{}
@@ -103,6 +104,7 @@ func TestGetBoolInput(t *testing.T) {
 }
 
 func TestGetStringInput(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		inputs      map[string]interface{}
@@ -212,6 +214,7 @@ func TestGetStringInput(t *testing.T) {
 }
 
 func TestModeFromInputs(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		inputs       map[string]interface{}
@@ -269,6 +272,7 @@ func TestModeFromInputs(t *testing.T) {
 }
 
 func TestWorkflowInputData_ToMap(t *testing.T) {
+	t.Parallel()
 	// Test basic fields using builder pattern
 	t.Run("basic fields", func(t *testing.T) {
 		data := NewWorkflowInputs().
@@ -360,6 +364,7 @@ func TestWorkflowInputData_ToMap(t *testing.T) {
 }
 
 func TestNewChatContext(t *testing.T) {
+	t.Parallel()
 	ctx := NewChatContext("chat-456")
 
 	if ctx.ID != "chat-456" {
@@ -371,6 +376,7 @@ func TestNewChatContext(t *testing.T) {
 // TestBuildWorkflowContext_ThreadAccessibility tests that thread is accessible via inputs.thread
 // NOTE: workflow.thread is DEPRECATED and no longer exposed - use inputs.thread instead
 func TestBuildWorkflowContext_ThreadAccessibility(t *testing.T) {
+	t.Parallel()
 	t.Run("thread is accessible via inputs.thread", func(t *testing.T) {
 		inputs := map[string]interface{}{
 			"thread": "test-thread-path",
@@ -420,6 +426,7 @@ func TestBuildWorkflowContext_ThreadAccessibility(t *testing.T) {
 
 // TestGetExecContext tests the GetExecContext helper on WorkflowInput.
 func TestGetExecContext(t *testing.T) {
+	t.Parallel()
 	t.Run("returns ExecContext when set", func(t *testing.T) {
 		execCtx := &ExecutionContext{
 			WorkflowID:   "wf-123",
@@ -539,6 +546,7 @@ func TestGetExecContext(t *testing.T) {
 }
 
 func TestHumanizeRetryError(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		err          error

--- a/internal/workflow/validation/always_null_output_test.go
+++ b/internal/workflow/validation/always_null_output_test.go
@@ -21,6 +21,7 @@ import (
 // legal. Validation flags only the statically-provable always-null case, which
 // is almost certainly an authoring mistake.
 func TestAlwaysNullOutputWarning(t *testing.T) {
+	t.Parallel()
 	findAlwaysNullWarnings := func(result *Result) []*Error {
 		var found []*Error
 		for _, w := range result.Warnings() {

--- a/internal/workflow/validation/cel_adversarial_test.go
+++ b/internal/workflow/validation/cel_adversarial_test.go
@@ -14,6 +14,7 @@ import (
 // TestCELAdversarial_FalsePositives tests valid expressions that might incorrectly fail validation.
 // These are expressions that SHOULD pass but might trigger false alarms.
 func TestCELAdversarial_FalsePositives(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		yaml string
@@ -371,6 +372,7 @@ nodes:
 // TestCELAdversarial_FalseNegatives tests invalid expressions that might incorrectly pass validation.
 // These are expressions that SHOULD fail but might slip through.
 func TestCELAdversarial_FalseNegatives(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		yaml          string
@@ -617,6 +619,7 @@ edges:
 
 // TestCELAdversarial_TypeSystemEdgeCases tests edge cases in the type system.
 func TestCELAdversarial_TypeSystemEdgeCases(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		yaml        string
@@ -770,6 +773,7 @@ nodes:
 
 // TestCELAdversarial_NullHandling tests null handling edge cases.
 func TestCELAdversarial_NullHandling(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		yaml        string
@@ -928,6 +932,7 @@ edges:
 
 // TestCELAdversarial_ComplexNesting tests deeply nested object access.
 func TestCELAdversarial_ComplexNesting(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		yaml        string
@@ -1082,6 +1087,7 @@ nodes:
 
 // TestCELAdversarial_BuiltinWorkflows tests real builtin workflows for validation issues.
 func TestCELAdversarial_BuiltinWorkflows(t *testing.T) {
+	t.Parallel()
 	builtinDir := "../../../workflow/builtin"
 	workflows := []string{
 		"agent.yaml",

--- a/internal/workflow/validation/cel_compilation_test.go
+++ b/internal/workflow/validation/cel_compilation_test.go
@@ -16,6 +16,7 @@ import (
 // TestValidateCELWithCompilation_TypeMismatch tests that type mismatches in comparisons
 // are caught at validation time via CEL compilation.
 func TestValidateCELWithCompilation_TypeMismatch(t *testing.T) {
+	t.Parallel()
 	// Workflow with type mismatch: comparing int to string
 	workflowYAML := `
 name: test-type-mismatch
@@ -62,12 +63,14 @@ edges:
 }
 
 func TestEncodedNodeCELIdentifier(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "simple_node", encodedNodeCELIdentifier("simple_node"))
 	assert.Equal(t, "router_1775339690239", encodedNodeCELIdentifier("router-1775339690239"))
 	assert.Equal(t, "loop_inner_node", encodedNodeCELIdentifier("loop.inner:node"))
 }
 
 func TestRewriteNodesAccess_EncodesHyphenatedNodeIDs(t *testing.T) {
+	t.Parallel()
 	rewritten := rewriteNodesAccess(
 		"nodes.router-1775339690239.response_text == '' || size(nodes.router-1775339690239.message.text) == 0",
 		[]string{"router-1775339690239"},
@@ -76,6 +79,7 @@ func TestRewriteNodesAccess_EncodesHyphenatedNodeIDs(t *testing.T) {
 }
 
 func TestRewriteNodesAccess_PreservesHasAndBareNodeAccess(t *testing.T) {
+	t.Parallel()
 	rewritten := rewriteNodesAccess(
 		"has(nodes.router-1775339690239) || size(nodes.router-1775339690239) == 0 || nodes.router-1775339690239 != null",
 		[]string{"router-1775339690239"},
@@ -88,6 +92,7 @@ func TestRewriteNodesAccess_PreservesHasAndBareNodeAccess(t *testing.T) {
 }
 
 func TestRewriteNodesAccess_IgnoresStringLiteralsAndLongestMatchWins(t *testing.T) {
+	t.Parallel()
 	rewritten := rewriteNodesAccess(
 		"'nodes.router-1.response_text' + nodes.router-1.response_text + nodes.router-1a.response_text",
 		[]string{"router-1", "router-1a"},
@@ -100,6 +105,7 @@ func TestRewriteNodesAccess_IgnoresStringLiteralsAndLongestMatchWins(t *testing.
 }
 
 func TestValidateCELWithCompilation_CELSafeNodeIDOutputs(t *testing.T) {
+	t.Parallel()
 	// Router has fixed top-level fields; child outputs are accessed via outputs sub-field.
 	t.Run("valid access via outputs sub-field and metadata fields", func(t *testing.T) {
 		workflowYAML := `
@@ -161,6 +167,7 @@ outputs:
 // accessed via nodes.router.outputs.<field>. Direct access to child output
 // names at the top level (e.g. nodes.router.message) is an error.
 func TestRouterNodeStrictOutputValidation(t *testing.T) {
+	t.Parallel()
 	makeYAML := func(fieldExpr string) string {
 		return fmt.Sprintf(`
 name: test-router-strict
@@ -441,6 +448,7 @@ outputs:
 
 // TestValidateCELWithCompilation_ValidFieldAccess tests that valid field access passes.
 func TestValidateCELWithCompilation_ValidFieldAccess(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-valid-field
 entry: [my_run]
@@ -471,6 +479,7 @@ outputs:
 
 // TestValidateCELWithCompilation_TypeInference tests that output types are inferred.
 func TestValidateCELWithCompilation_TypeInference(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-type-inference
 entry: [my_run]
@@ -504,6 +513,7 @@ outputs:
 }
 
 func TestValidateCELWithCompilation_MalformedExpressionsAndUnknownSelectors(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-cel-negative
 entry: [step1]
@@ -572,6 +582,7 @@ func containsAt(s, sub string) bool {
 // TestValidateCELWithCompilation_AllBuiltinWorkflows validates all builtin workflows
 // using CEL compilation to catch invalid field access and type errors.
 func TestValidateCELWithCompilation_AllBuiltinWorkflows(t *testing.T) {
+	t.Parallel()
 	// Find all builtin workflow files
 	builtinDir := "../builtin"
 	files, err := filepath.Glob(filepath.Join(builtinDir, "*.yaml"))
@@ -666,6 +677,7 @@ func TestValidateCELWithCompilation_AllBuiltinWorkflows(t *testing.T) {
 // TestValidateCELWithCompilation_AllUserWorkflows validates all user workflows
 // in .reliant/workflows/ directory.
 func TestValidateCELWithCompilation_AllUserWorkflows(t *testing.T) {
+	t.Parallel()
 	// Find user workflow files
 	userDir := "../../../../.reliant/workflows"
 	files, err := filepath.Glob(filepath.Join(userDir, "**/*.yaml"))
@@ -727,6 +739,7 @@ func TestValidateCELWithCompilation_AllUserWorkflows(t *testing.T) {
 // TestBuildWorkflowTypeContext_RefBasedOutputResolution tests that ref-based
 // workflow nodes resolve their outputs via the WorkflowLoader.
 func TestBuildWorkflowTypeContext_RefBasedOutputResolution(t *testing.T) {
+	t.Parallel()
 	parentYAML := `
 name: test-ref-outputs
 entry: [call_agent]
@@ -798,6 +811,7 @@ outputs:
 // TestBuildWorkflowTypeContext_RefBasedLoopOutputResolution tests that ref-based
 // loop nodes resolve their outputs via the WorkflowLoader.
 func TestBuildWorkflowTypeContext_RefBasedLoopOutputResolution(t *testing.T) {
+	t.Parallel()
 	parentYAML := `
 name: test-ref-loop-outputs
 entry: [my_loop]
@@ -848,6 +862,7 @@ outputs:
 // features were designed to fix. Without those features, these workflow patterns
 // would fail at CEL compilation time (load-time validation), not at runtime.
 func TestValidation_CatchesPreFixBugs(t *testing.T) {
+	t.Parallel()
 
 	// Bug 1: Referencing output.log_file in a run node's save_message
 	// Our fix: added log_file and working_dir to RunOutput proto so CEL knows about them.

--- a/internal/workflow/validation/cel_object_properties_test.go
+++ b/internal/workflow/validation/cel_object_properties_test.go
@@ -11,6 +11,7 @@ import (
 // TestValidateCEL_ObjectPropertyAccess tests that CEL validation properly validates
 // access to object input properties defined in JSON Schema.
 func TestValidateCEL_ObjectPropertyAccess(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		workflow  string
@@ -293,6 +294,7 @@ nodes:
 
 // TestValidateCEL_ObjectArrayProperties tests CEL validation for array properties in objects.
 func TestValidateCEL_ObjectArrayProperties(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-array-property
 entry: [step1]
@@ -338,6 +340,7 @@ nodes:
 
 // TestValidateCEL_ObjectRequiredFields tests that required fields are properly checked.
 func TestValidateCEL_ObjectRequiredFields(t *testing.T) {
+	t.Parallel()
 	// This test verifies that the type context properly includes required field information
 	workflowYAML := `
 name: test-required-fields
@@ -384,6 +387,7 @@ nodes:
 // TestSchemaTypeChecker_TypeMismatch tests that type mismatches in operations
 // are caught by the AST-based schema type checker.
 func TestSchemaTypeChecker_TypeMismatch(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		workflow  string
@@ -516,6 +520,7 @@ nodes:
 
 // TestSchemaTypeChecker_ValidOperations tests that valid operations pass type checking.
 func TestSchemaTypeChecker_ValidOperations(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		workflow string
@@ -645,6 +650,7 @@ outputs:
 
 // TestSchemaTypeChecker_NestedObjects tests type checking for nested object properties.
 func TestSchemaTypeChecker_NestedObjects(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		workflow  string
@@ -760,6 +766,7 @@ nodes:
 
 // TestSchemaTypeChecker_AdditionalProperties tests behavior when additionalProperties is set.
 func TestSchemaTypeChecker_AdditionalProperties(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		workflow  string

--- a/internal/workflow/validation/cel_provider_test.go
+++ b/internal/workflow/validation/cel_provider_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestWorkflowTypeProvider_StrictUnknownNestedNodeOutputField(t *testing.T) {
+	t.Parallel()
 	env, err := cel.NewEnv()
 	require.NoError(t, err)
 
@@ -33,6 +34,7 @@ func TestWorkflowTypeProvider_StrictUnknownNestedNodeOutputField(t *testing.T) {
 }
 
 func TestWorkflowTypeProvider_DynamicNestedNodeOutputFieldException(t *testing.T) {
+	t.Parallel()
 	env, err := cel.NewEnv()
 	require.NoError(t, err)
 
@@ -55,6 +57,7 @@ func TestWorkflowTypeProvider_DynamicNestedNodeOutputFieldException(t *testing.T
 }
 
 func TestWorkflowTypeProvider_AdditionalPropertiesNestedNodeOutputFieldException(t *testing.T) {
+	t.Parallel()
 	env, err := cel.NewEnv()
 	require.NoError(t, err)
 
@@ -79,6 +82,7 @@ func TestWorkflowTypeProvider_AdditionalPropertiesNestedNodeOutputFieldException
 }
 
 func TestGetAvailableToolNames_DeterministicOrder(t *testing.T) {
+	t.Parallel()
 	names := getAvailableToolNames(map[string]*ResponseToolSchema{
 		"zeta":  {},
 		"alpha": {},

--- a/internal/workflow/validation/cel_safe_node_ids_test.go
+++ b/internal/workflow/validation/cel_safe_node_ids_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestStaticAnalysis_RejectsHyphenatedNodeIDs(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test_invalid_node_ids
 entry: [router_1]

--- a/internal/workflow/validation/condition_bool_integration_test.go
+++ b/internal/workflow/validation/condition_bool_integration_test.go
@@ -11,6 +11,7 @@ import (
 // TestConditionBoolType_Integration demonstrates the boolean type validation
 // working end-to-end with realistic workflow examples.
 func TestConditionBoolType_Integration(t *testing.T) {
+	t.Parallel()
 	t.Run("Valid workflow with boolean conditions", func(t *testing.T) {
 		workflowYAML := `
 name: valid-workflow
@@ -243,6 +244,7 @@ edges:
 
 // TestConditionBoolType_ErrorQuality tests that error messages are helpful and actionable.
 func TestConditionBoolType_ErrorQuality(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name               string
 		condition          string

--- a/internal/workflow/validation/condition_bool_type_test.go
+++ b/internal/workflow/validation/condition_bool_type_test.go
@@ -10,6 +10,7 @@ import (
 
 // TestEdgeCondition_BoolType tests that edge conditions must return boolean type.
 func TestEdgeCondition_BoolType(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		condition      string
@@ -131,6 +132,7 @@ edges:
 
 // TestNodeCondition_BoolType tests that node conditions must return boolean type.
 func TestNodeCondition_BoolType(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		condition      string
@@ -240,6 +242,7 @@ nodes:
 
 // TestEdgeCondition_BoolType_DetailedSuggestions tests that error suggestions are helpful.
 func TestEdgeCondition_BoolType_DetailedSuggestions(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name               string
 		condition          string
@@ -314,6 +317,7 @@ edges:
 // TestLoopWhileCondition_BoolType tests that loop while conditions must return boolean.
 // Note: Loop while conditions are validated separately, but should also enforce bool type.
 func TestLoopWhileCondition_BoolType(t *testing.T) {
+	t.Parallel()
 	t.Run("Valid: boolean comparison", func(t *testing.T) {
 		workflowYAML := `
 name: test-loop-while-bool
@@ -353,6 +357,7 @@ nodes:
 
 // TestConditionBoolType_ComplexExpressions tests boolean validation with complex expressions.
 func TestConditionBoolType_ComplexExpressions(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		condition  string

--- a/internal/workflow/validation/conditional_access_ast_test.go
+++ b/internal/workflow/validation/conditional_access_ast_test.go
@@ -11,6 +11,7 @@ import (
 
 // TestAST_DirectAccess_Unsafe tests that direct access to conditional nodes is detected as unsafe.
 func TestAST_DirectAccess_Unsafe(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		expr     string
@@ -74,6 +75,7 @@ func TestAST_DirectAccess_Unsafe(t *testing.T) {
 // TestAST_OptionalChaining_Safe tests that optional chaining is correctly identified as safe.
 // Note: CEL's optional chaining syntax uses macros and requires EnableMacroCallTracking
 func TestAST_OptionalChaining_Safe(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		expr string
@@ -118,6 +120,7 @@ func TestAST_OptionalChaining_Safe(t *testing.T) {
 
 // TestAST_HasCheck_Safe tests that has() checks are correctly identified as safe.
 func TestAST_HasCheck_Safe(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		expr string
@@ -155,6 +158,7 @@ func TestAST_HasCheck_Safe(t *testing.T) {
 
 // TestAST_NullComparison_Safe tests that null comparisons are correctly identified as safe.
 func TestAST_NullComparison_Safe(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		expr string
@@ -204,6 +208,7 @@ func TestAST_NullComparison_Safe(t *testing.T) {
 
 // TestAST_StringLiteral_NoFalsePositive tests that string literals don't trigger false positives.
 func TestAST_StringLiteral_NoFalsePositive(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		expr string
@@ -239,6 +244,7 @@ func TestAST_StringLiteral_NoFalsePositive(t *testing.T) {
 
 // TestAST_MultipleNodes_MixedSafety tests expressions with both safe and unsafe accesses.
 func TestAST_MultipleNodes_MixedSafety(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		expr           string
@@ -293,6 +299,7 @@ func TestAST_MultipleNodes_MixedSafety(t *testing.T) {
 
 // TestAST_NestedAccess tests deeply nested field access patterns.
 func TestAST_NestedAccess(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		expr     string
@@ -339,6 +346,7 @@ func TestAST_NestedAccess(t *testing.T) {
 
 // TestAST_ComplexExpressions tests complex real-world expressions.
 func TestAST_ComplexExpressions(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		expr           string
@@ -400,6 +408,7 @@ func TestAST_ComplexExpressions(t *testing.T) {
 
 // TestAST_UnconditionalNodes tests that unconditional nodes don't trigger warnings.
 func TestAST_UnconditionalNodes(t *testing.T) {
+	t.Parallel()
 	expr := "nodes.regular_node.output + nodes.another_regular.value"
 
 	env, err := cel.NewEnv(
@@ -419,6 +428,7 @@ func TestAST_UnconditionalNodes(t *testing.T) {
 
 // TestAST_EmptyExpression tests handling of empty/nil expressions.
 func TestAST_EmptyExpression(t *testing.T) {
+	t.Parallel()
 	conditionalNodes := map[string]bool{
 		"cond": true,
 	}

--- a/internal/workflow/validation/conditional_access_test.go
+++ b/internal/workflow/validation/conditional_access_test.go
@@ -13,6 +13,7 @@ import (
 // TestWarnConditionalNodeAccess_DirectAccess tests that a warning IS generated
 // when directly accessing outputs from a conditional node without null safety.
 func TestWarnConditionalNodeAccess_DirectAccess(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-conditional-access
 entry: [step1]
@@ -65,6 +66,7 @@ nodes:
 // TestWarnConditionalNodeAccess_UnconditionalNode tests that NO warning is generated
 // when accessing outputs from an unconditional node.
 func TestWarnConditionalNodeAccess_UnconditionalNode(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-unconditional-access
 entry: [step1]
@@ -96,6 +98,7 @@ nodes:
 // TestWarnConditionalNodeAccess_OptionalChaining tests that NO warning is generated
 // when using optional chaining (nodes.?id.field) to access conditional node outputs.
 func TestWarnConditionalNodeAccess_OptionalChaining(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-optional-chaining
 entry: [step1]
@@ -139,6 +142,7 @@ nodes:
 // TestWarnConditionalNodeAccess_HasCheck tests that NO warning is generated
 // when using has() to check for conditional node outputs.
 func TestWarnConditionalNodeAccess_HasCheck(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-has-check
 entry: [step1]
@@ -181,6 +185,7 @@ edges:
 // TestWarnConditionalNodeAccess_NullCheck tests that NO warning is generated
 // when using null comparison to check conditional node outputs.
 func TestWarnConditionalNodeAccess_NullCheck(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-null-check
 entry: [step1]
@@ -223,6 +228,7 @@ edges:
 // TestWarnConditionalNodeAccess_ReverseNullCheck tests that NO warning is generated
 // when using reverse null comparison (null != nodes.id).
 func TestWarnConditionalNodeAccess_ReverseNullCheck(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-reverse-null-check
 entry: [step1]
@@ -265,6 +271,7 @@ edges:
 // TestWarnConditionalNodeAccess_JoinNode tests that JoinNode conditions don't trigger warnings.
 // JoinNode uses condition differently (for join mode: all/any), not for conditional execution.
 func TestWarnConditionalNodeAccess_JoinNode(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-join-node
 entry: [step1]
@@ -314,6 +321,7 @@ edges:
 
 // TestWarnConditionalNodeAccess_EdgeCondition tests warnings in edge conditions.
 func TestWarnConditionalNodeAccess_EdgeCondition(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-edge-condition
 entry: [step1]
@@ -364,6 +372,7 @@ edges:
 
 // TestWarnConditionalNodeAccess_OutputExpression tests warnings in output expressions.
 func TestWarnConditionalNodeAccess_OutputExpression(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-output-expression
 entry: [step1]
@@ -408,6 +417,7 @@ outputs:
 // TestWarnConditionalNodeAccess_MultipleConditionalNodes tests warnings when
 // multiple conditional nodes are accessed unsafely.
 func TestWarnConditionalNodeAccess_MultipleConditionalNodes(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-multiple-conditional
 entry: [step1]

--- a/internal/workflow/validation/cross_workflow_test.go
+++ b/internal/workflow/validation/cross_workflow_test.go
@@ -272,6 +272,7 @@ func TestStaticAnalysisWithOptions_InlineInputInheritanceContract(t *testing.T) 
 }
 
 func TestStaticAnalysisWithOptions_WorkflowNameIdentityContract(t *testing.T) {
+	t.Parallel()
 	parent := &reliantv1.Workflow{
 		Name:  "builtin://agent",
 		Entry: []string{"workflow_call"},
@@ -315,6 +316,7 @@ func TestStaticAnalysisWithOptions_WorkflowNameIdentityContract(t *testing.T) {
 }
 
 func TestStaticAnalysisWithOptions_SpawnWorkflowNameIdentityTemplateContract(t *testing.T) {
+	t.Parallel()
 	workflow := &reliantv1.Workflow{
 		Name:  "builtin://agent",
 		Entry: []string{"llm"},
@@ -360,6 +362,7 @@ func TestStaticAnalysisWithOptions_SpawnWorkflowNameIdentityTemplateContract(t *
 }
 
 func TestStaticAnalysisWithOptions_SpawnWorkflowNameUsesCanonicalWorkflowRefOverride(t *testing.T) {
+	t.Parallel()
 	workflow := &reliantv1.Workflow{
 		Name:  "agent",
 		Entry: []string{"llm"},
@@ -523,6 +526,7 @@ func TestPassthroughOnInlineWorkflowIsIgnored(t *testing.T) {
 }
 
 func TestPassthroughOnNonWorkflowNodeIsRejectedByYAML(t *testing.T) {
+	t.Parallel()
 	// passthrough is only a valid field on workflow and loop nodes.
 	// If someone puts passthrough on a run node in YAML, the parser should
 	// reject it as an unknown field.

--- a/internal/workflow/validation/inputs_test.go
+++ b/internal/workflow/validation/inputs_test.go
@@ -829,6 +829,7 @@ func TestValidateInputs_GroupTypeMismatchAndAmbiguousShapes(t *testing.T) {
 // reject every value with an empty "(allowed: )" list, which bricks in-flight
 // workflows resumed against a schema loaded mid-edit.
 func TestValidateInputs_EmptyEnumAcceptsAnyString(t *testing.T) {
+	t.Parallel()
 	workflow := &reliantv1.Workflow{
 		Name: "empty-enum",
 		Inputs: map[string]*reliantv1.Input{

--- a/internal/workflow/validation/iter_item_type_test.go
+++ b/internal/workflow/validation/iter_item_type_test.go
@@ -22,6 +22,7 @@ func makeResponseSchemaStruct(schema map[string]interface{}) *structpb.Value {
 // TestIterItemTypeInference_ResponseSchema tests that iter.item fields are validated
 // when the loop items come from a workflow node with a response_schema arg.
 func TestIterItemTypeInference_ResponseSchema(t *testing.T) {
+	t.Parallel()
 	// Build a response schema with waves array containing has_frontend boolean
 	responseSchema := map[string]interface{}{
 		"type": "object",
@@ -96,6 +97,7 @@ func TestIterItemTypeInference_ResponseSchema(t *testing.T) {
 // TestIterItemTypeInference_InvalidField tests that accessing a nonexistent field
 // on iter.item produces a validation error when the item type is known.
 func TestIterItemTypeInference_InvalidField(t *testing.T) {
+	t.Parallel()
 	responseSchema := map[string]interface{}{
 		"type": "object",
 		"properties": map[string]interface{}{
@@ -172,6 +174,7 @@ func TestIterItemTypeInference_InvalidField(t *testing.T) {
 // TestIterItemTypeInference_FallbackToDyn tests that when iter.item type can't be
 // inferred (no response_schema), validation falls back to dyn and allows any field.
 func TestIterItemTypeInference_FallbackToDyn(t *testing.T) {
+	t.Parallel()
 	wf := &reliantv1.Workflow{
 		Name:  "test-iter-type-dyn",
 		Entry: []string{"data_source"},
@@ -219,6 +222,7 @@ func TestIterItemTypeInference_FallbackToDyn(t *testing.T) {
 
 // TestInferLoopItemFields_ParseNodeFieldPath tests the expression parser.
 func TestInferLoopItemFields_ParseNodeFieldPath(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		expr     string
 		wantNil  bool
@@ -263,6 +267,7 @@ func TestInferLoopItemFields_ParseNodeFieldPath(t *testing.T) {
 
 // TestInferLoopItemFields_Direct tests the inference function directly.
 func TestInferLoopItemFields_Direct(t *testing.T) {
+	t.Parallel()
 	responseSchema := map[string]interface{}{
 		"type": "object",
 		"properties": map[string]interface{}{
@@ -322,6 +327,7 @@ func TestInferLoopItemFields_Direct(t *testing.T) {
 // TestTypedIterCELCompilation directly tests that the CEL environment rejects
 // unknown fields on iter.item when the type is known.
 func TestTypedIterCELCompilation(t *testing.T) {
+	t.Parallel()
 	typeCtx := &WorkflowTypeContext{
 		InputFields:  make(map[string]*FieldInfo),
 		InputGroups:  make(map[string]map[string]*FieldInfo),

--- a/internal/workflow/validation/node_base_validation_test.go
+++ b/internal/workflow/validation/node_base_validation_test.go
@@ -11,6 +11,7 @@ import (
 // TestNodeBaseValidation_ThreadInject tests that CEL expressions in thread.inject are properly validated.
 // This test should fail before the fix, as the recursive validation skips NodeBase.
 func TestNodeBaseValidation_ThreadInject(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-thread-inject-validation
 entry: [step1]
@@ -46,6 +47,7 @@ nodes:
 
 // TestNodeBaseValidation_SaveMessage_Valid tests that valid CEL in save_message passes.
 func TestNodeBaseValidation_SaveMessage_Valid(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-save-message-validation-valid
 entry: [step1]
@@ -74,6 +76,7 @@ nodes:
 // TestNodeBaseValidation_SaveMessage_Invalid tests that invalid CEL in save_message is caught.
 // This test should fail before the fix.
 func TestNodeBaseValidation_SaveMessage_Invalid(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-save-message-validation-invalid
 entry: [step1]
@@ -109,6 +112,7 @@ nodes:
 // TestNodeBaseValidation_SaveMessage_ToolCallsTypeMismatch tests that save_message.tool_calls
 // correctly validates the return type. It should fail if a non-list type is returned.
 func TestNodeBaseValidation_SaveMessage_ToolCallsTypeMismatch(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-save-message-tool-calls-type-mismatch
 entry: [step1]
@@ -144,6 +148,7 @@ nodes:
 // TestNodeBaseValidation_SaveMessage_ToolCallsStaticTextError tests that providing static text
 // for save_message.tool_calls results in an error, as it requires a CEL expression.
 func TestNodeBaseValidation_SaveMessage_ToolCallsStaticTextError(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-save-message-tool-calls-static-text
 entry: [step1]

--- a/internal/workflow/validation/node_order_test.go
+++ b/internal/workflow/validation/node_order_test.go
@@ -36,6 +36,7 @@ func orderingIssues(result *Result) []*Error {
 // scrape_website — so the unguarded {{nodes.scrape_website.response_text}}
 // in the inject content hard-fails at runtime. Static validation must flag it.
 func TestNodeOrdering_RouterSkipUnguardedInjectWarns(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: pitch-deck-shape
 entry: [classify]
@@ -95,6 +96,7 @@ edges:
 // founder_interview shape: guarding the reference with has() silences the
 // ordering warning (mirrors the actual pitch-deck.yaml fix).
 func TestNodeOrdering_GuardedInjectDoesNotWarn(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: pitch-deck-shape-fixed
 entry: [classify]
@@ -138,6 +140,7 @@ edges:
 // workflow at all is a validation ERROR — including inside thread.inject
 // content, not just primary args.
 func TestNodeOrdering_UnknownNodeReferenceInInjectIsError(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: unknown-node-ref
 entry: [first]
@@ -170,6 +173,7 @@ edges:
 // TestNodeOrdering_DownstreamReferenceIsError: referencing a node that always
 // executes AFTER the current node can never be satisfied — hard error.
 func TestNodeOrdering_DownstreamReferenceIsError(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: downstream-ref
 entry: [first]
@@ -206,6 +210,7 @@ edges:
 // TestNodeOrdering_LinearChainDoesNotWarn: straight-line references to
 // guaranteed-upstream nodes are fine.
 func TestNodeOrdering_LinearChainDoesNotWarn(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: linear-chain
 entry: [first]
@@ -233,6 +238,7 @@ edges:
 // TestNodeOrdering_AllJoinGuaranteesBothBranches: after an "all" join, BOTH
 // parallel parents are guaranteed complete — no warning.
 func TestNodeOrdering_AllJoinGuaranteesBothBranches(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: all-join
 entry: [start]
@@ -277,6 +283,7 @@ edges:
 // TestNodeOrdering_ParallelSiblingWarns: a node referencing its parallel
 // sibling (no join in between) is not guaranteed ordering — warning.
 func TestNodeOrdering_ParallelSiblingWarns(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: parallel-sibling
 entry: [start]
@@ -312,6 +319,7 @@ edges:
 // conditional-access warning covers them (their output KEY exists even when
 // skipped, only field access is risky).
 func TestNodeOrdering_ConditionalNodeCoveredByConditionalWarning(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: conditional-node
 entry: [first]
@@ -351,6 +359,7 @@ edges:
 // TestComputeGuaranteedBefore_PitchDeckShape verifies the guaranteed-before
 // sets on the pitch-deck-like graph directly.
 func TestComputeGuaranteedBefore_PitchDeckShape(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: guaranteed-before
 entry: [classify]

--- a/internal/workflow/validation/node_outcome_test.go
+++ b/internal/workflow/validation/node_outcome_test.go
@@ -15,6 +15,7 @@ import (
 // nothing puts the run straight back to reporting a false green.
 
 func TestNodeOutcomeParsesAndValidates(t *testing.T) {
+	t.Parallel()
 	wf, err := wfyaml.ParseWorkflow([]byte(`
 name: outcome-valid
 entry: [work]
@@ -57,6 +58,7 @@ edges:
 }
 
 func TestNodeOutcomeRejectsUnknownValue(t *testing.T) {
+	t.Parallel()
 	wf, err := wfyaml.ParseWorkflow([]byte(`
 name: outcome-typo
 entry: [work]
@@ -83,6 +85,7 @@ nodes:
 // inline executor, which never stamps the run's verdict. A declaration there
 // would read correctly and do nothing — silently reinstating the false green.
 func TestNodeOutcomeRejectedInsideInlineWorkflow(t *testing.T) {
+	t.Parallel()
 	wf, err := wfyaml.ParseWorkflow([]byte(`
 name: outcome-inline
 entry: [attempt]

--- a/internal/workflow/validation/output_validation_test.go
+++ b/internal/workflow/validation/output_validation_test.go
@@ -12,6 +12,7 @@ import (
 // - ERROR: accessing unknown field on a KNOWN type (e.g., nodes.llm.unknown_field)
 // - WARNING: accessing field on a DYN type (e.g., nodes.external_ref.field where external_ref is dyn)
 func TestOutputTypeValidationDistinction(t *testing.T) {
+	t.Parallel()
 	t.Run("error on unknown field of known type", func(t *testing.T) {
 		yaml := `
 name: test
@@ -88,6 +89,7 @@ outputs:
 
 // TestOutputTypeValidation verifies that output expressions are type-checked.
 func TestOutputTypeValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		yaml           string
@@ -219,6 +221,7 @@ outputs:
 
 // TestOutputTypeInference verifies that output types are correctly inferred.
 func TestOutputTypeInference(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		yaml          string

--- a/internal/workflow/validation/parallel_loop_test.go
+++ b/internal/workflow/validation/parallel_loop_test.go
@@ -34,6 +34,7 @@ func hasStructuralError(result *Result, substring string) bool {
 }
 
 func TestParallelLoopRequiresItems(t *testing.T) {
+	t.Parallel()
 	wf := makeParallelLoopWorkflow(&reliantv1.LoopArgs{
 		Parallel: &reliantv1.CelBool{Value: &reliantv1.CelBool_Literal{Literal: true}},
 		Ref:      &reliantv1.CelString{Value: &reliantv1.CelString_Literal{Literal: "builtin://agent"}},
@@ -45,6 +46,7 @@ func TestParallelLoopRequiresItems(t *testing.T) {
 }
 
 func TestParallelLoopDisallowsWhile(t *testing.T) {
+	t.Parallel()
 	wf := makeParallelLoopWorkflow(&reliantv1.LoopArgs{
 		Parallel: &reliantv1.CelBool{Value: &reliantv1.CelBool_Literal{Literal: true}},
 		Items:    &reliantv1.CelString{Value: &reliantv1.CelString_Literal{Literal: "{{inputs.components}}"}},
@@ -58,6 +60,7 @@ func TestParallelLoopDisallowsWhile(t *testing.T) {
 }
 
 func TestParallelLoopValidOnFailure(t *testing.T) {
+	t.Parallel()
 	for _, valid := range []string{"continue", "fail_fast", "fail_all"} {
 		wf := makeParallelLoopWorkflow(&reliantv1.LoopArgs{
 			Parallel:  &reliantv1.CelBool{Value: &reliantv1.CelBool_Literal{Literal: true}},
@@ -73,6 +76,7 @@ func TestParallelLoopValidOnFailure(t *testing.T) {
 }
 
 func TestParallelLoopInvalidOnFailure(t *testing.T) {
+	t.Parallel()
 	wf := makeParallelLoopWorkflow(&reliantv1.LoopArgs{
 		Parallel:  &reliantv1.CelBool{Value: &reliantv1.CelBool_Literal{Literal: true}},
 		Items:     &reliantv1.CelString{Value: &reliantv1.CelString_Literal{Literal: "{{inputs.components}}"}},
@@ -86,6 +90,7 @@ func TestParallelLoopInvalidOnFailure(t *testing.T) {
 }
 
 func TestSequentialLoopStillRequiresWhile(t *testing.T) {
+	t.Parallel()
 	wf := makeParallelLoopWorkflow(&reliantv1.LoopArgs{
 		// No parallel flag = sequential
 		Ref: &reliantv1.CelString{Value: &reliantv1.CelString_Literal{Literal: "builtin://agent"}},
@@ -97,6 +102,7 @@ func TestSequentialLoopStillRequiresWhile(t *testing.T) {
 }
 
 func TestValidParallelLoopPasses(t *testing.T) {
+	t.Parallel()
 	wf := makeParallelLoopWorkflow(&reliantv1.LoopArgs{
 		Parallel: &reliantv1.CelBool{Value: &reliantv1.CelBool_Literal{Literal: true}},
 		Items:    &reliantv1.CelString{Value: &reliantv1.CelString_Literal{Literal: "{{inputs.components}}"}},

--- a/internal/workflow/validation/reserved_system_inputs_test.go
+++ b/internal/workflow/validation/reserved_system_inputs_test.go
@@ -63,6 +63,7 @@ func validateInject(t *testing.T, yaml string) []*Error {
 // the exact expression the removed weakening used to accept — inputs.preview_url_template,
 // with no such declared input — must now be a hard validation error.
 func TestReservedInputs_PreviewURLTemplateNowErrors(t *testing.T) {
+	t.Parallel()
 	yaml := buildInjectWorkflow(t, "preview-url-undeclared", "", "{{ inputs.preview_url_template }}")
 	errs := validateInject(t, yaml)
 	require.NotEmpty(t, errs,
@@ -73,6 +74,7 @@ func TestReservedInputs_PreviewURLTemplateNowErrors(t *testing.T) {
 // TestReservedInputs_ArbitraryUndeclaredErrors proves the validator is not merely
 // blocking one name — any undeclared input reference fails.
 func TestReservedInputs_ArbitraryUndeclaredErrors(t *testing.T) {
+	t.Parallel()
 	yaml := buildInjectWorkflow(t, "arbitrary-undeclared", "", "{{ inputs.totally_made_up_thing }}")
 	errs := validateInject(t, yaml)
 	require.NotEmpty(t, errs, "an arbitrary undeclared input reference must be a hard error")
@@ -84,6 +86,7 @@ func TestReservedInputs_ArbitraryUndeclaredErrors(t *testing.T) {
 // session_daemon_id, project_path, and spawned_by may be absent at runtime, so a
 // template reference would be a foot-gun — it must fail static validation.
 func TestReservedInputs_ConditionalEngineValuesNotReferenceable(t *testing.T) {
+	t.Parallel()
 	for _, name := range []string{"session_daemon_id", "project_path", "spawned_by"} {
 		t.Run(name, func(t *testing.T) {
 			yaml := buildInjectWorkflow(t, "conditional-"+name, "", "{{ inputs."+name+" }}")
@@ -98,6 +101,7 @@ func TestReservedInputs_ConditionalEngineValuesNotReferenceable(t *testing.T) {
 // TestReservedInputs_SystemKeywordsValidateCleanly proves the always-injected trio
 // is declared as typed reserved keywords, so referencing them is allowed.
 func TestReservedInputs_SystemKeywordsValidateCleanly(t *testing.T) {
+	t.Parallel()
 	for _, name := range []string{"chat_id", "workflow_id", "unique_activity_id"} {
 		t.Run(name, func(t *testing.T) {
 			yaml := buildInjectWorkflow(t, "reserved-"+name, "", "{{ inputs."+name+" }}")
@@ -114,6 +118,7 @@ func TestReservedInputs_SystemKeywordsValidateCleanly(t *testing.T) {
 // closed, typed set — not a wildcard that swallows near-misses. A typo of a
 // reserved name must still fail (and ideally suggest the correct name).
 func TestReservedInputs_TypoOfSystemKeywordErrors(t *testing.T) {
+	t.Parallel()
 	yaml := buildInjectWorkflow(t, "reserved-typo", "", "{{ inputs.chat_idd }}")
 	errs := validateInject(t, yaml)
 	require.NotEmpty(t, errs, "a typo of a reserved keyword (chat_idd) must still be a hard error")
@@ -124,6 +129,7 @@ func TestReservedInputs_TypoOfSystemKeywordErrors(t *testing.T) {
 // declared input is referenceable, so the hardening didn't over-rotate into
 // rejecting legitimate inputs.
 func TestReservedInputs_DeclaredInputStillValidates(t *testing.T) {
+	t.Parallel()
 	declared := "  topic:\n    type: string\n"
 	yaml := buildInjectWorkflow(t, "declared-ok", declared, "{{ inputs.topic }}")
 	errs := validateInject(t, yaml)

--- a/internal/workflow/validation/response_data_test.go
+++ b/internal/workflow/validation/response_data_test.go
@@ -11,6 +11,7 @@ import (
 
 // TestValidateResponseDataAccess_ValidAccess tests that valid response_data field access passes.
 func TestValidateResponseDataAccess_ValidAccess(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-valid-response-data
 entry: [call_llm]
@@ -65,6 +66,7 @@ outputs:
 
 // TestValidateResponseDataAccess_InvalidToolName tests that invalid tool names are caught.
 func TestValidateResponseDataAccess_InvalidToolName(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-invalid-tool-name
 entry: [call_llm]
@@ -114,6 +116,7 @@ outputs:
 
 // TestValidateResponseDataAccess_InvalidFieldName tests that invalid field names are caught.
 func TestValidateResponseDataAccess_InvalidFieldName(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-invalid-field-name
 entry: [call_llm]
@@ -168,6 +171,7 @@ outputs:
 // TestValidateResponseDataAccess_NoResponseTool tests that accessing response_data
 // without a response tool defined doesn't cause errors (lenient for MCP/external tools).
 func TestValidateResponseDataAccess_NoResponseTool(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-no-response-tool
 entry: [call_llm]
@@ -203,6 +207,7 @@ outputs:
 
 // TestValidateResponseDataAccess_EdgeCondition tests validation in edge conditions.
 func TestValidateResponseDataAccess_EdgeCondition(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-edge-condition
 entry: [call_llm]
@@ -267,6 +272,7 @@ edges:
 // TestValidateResponseDataAccess_MultipleResponseTools tests validation with multiple
 // response tools (multiple call_llm nodes feeding into different execute_tools).
 func TestValidateResponseDataAccess_MultipleResponseTools(t *testing.T) {
+	t.Parallel()
 	workflowYAML := `
 name: test-multiple-response-tools
 entry: [review_llm]

--- a/internal/workflow/validation/response_tool_context_test.go
+++ b/internal/workflow/validation/response_tool_context_test.go
@@ -15,6 +15,7 @@ import (
 // =============================================================================
 
 func TestBuildResponseToolContext_SimpleNode(t *testing.T) {
+	t.Parallel()
 	wf, err := wfyaml.ParseWorkflow([]byte(`
 name: test
 entry: [call_llm, execute]
@@ -57,6 +58,7 @@ outputs:
 }
 
 func TestBuildResponseToolContext_MultipleTools(t *testing.T) {
+	t.Parallel()
 	wf, err := wfyaml.ParseWorkflow([]byte(`
 name: test
 entry: [call_llm_1]
@@ -120,6 +122,7 @@ outputs:
 }
 
 func TestBuildResponseToolContext_DynamicSource(t *testing.T) {
+	t.Parallel()
 	wf, err := wfyaml.ParseWorkflow([]byte(`
 name: test
 entry: [call_llm, execute]
@@ -158,6 +161,7 @@ outputs:
 }
 
 func TestBuildResponseToolContext_NoResponseTool(t *testing.T) {
+	t.Parallel()
 	wf, err := wfyaml.ParseWorkflow([]byte(`
 name: test
 entry: [call_llm, execute]
@@ -188,6 +192,7 @@ outputs:
 }
 
 func TestBuildResponseToolContext_TemplateToolName(t *testing.T) {
+	t.Parallel()
 	wf, err := wfyaml.ParseWorkflow([]byte(`
 name: test
 entry: [call_llm, execute]
@@ -230,6 +235,7 @@ outputs:
 // =============================================================================
 
 func TestResolveToolCallsSource_SimplePattern(t *testing.T) {
+	t.Parallel()
 	// Test that simple node.X.tool_calls patterns are correctly resolved
 	// by checking that validation correctly identifies the source node
 	wf, err := wfyaml.ParseWorkflow([]byte(`
@@ -265,6 +271,7 @@ outputs:
 }
 
 func TestResolveToolCallsSource_ComplexExpression(t *testing.T) {
+	t.Parallel()
 	// Complex expressions should be treated as dynamic source
 	wf, err := wfyaml.ParseWorkflow([]byte(`
 name: test
@@ -308,6 +315,7 @@ outputs:
 // =============================================================================
 
 func TestJSONSchemaToFieldInfo(t *testing.T) {
+	t.Parallel()
 	// Test that JSON Schema properties are correctly converted and used in validation
 	wf, err := wfyaml.ParseWorkflow([]byte(`
 name: test
@@ -349,6 +357,7 @@ nodes:
 }
 
 func TestJSONSchemaToFieldInfo_EmptySchema(t *testing.T) {
+	t.Parallel()
 	// Object with no properties should allow dynamic access
 	wf, err := wfyaml.ParseWorkflow([]byte(`
 name: test

--- a/internal/workflow/validation/skills_test.go
+++ b/internal/workflow/validation/skills_test.go
@@ -45,6 +45,7 @@ func skillsArg(values ...string) map[string]*structpb.Value {
 // charter asked for it under the synthetic namespace, and the preloader
 // silently skipped it on every run.
 func TestValidateSkillReferencesRejectsUnresolvable(t *testing.T) {
+	t.Parallel()
 	wf := &reliantv1.Workflow{
 		Name: "charter",
 		Nodes: []*reliantv1.Node{
@@ -64,6 +65,7 @@ func TestValidateSkillReferencesRejectsUnresolvable(t *testing.T) {
 }
 
 func TestValidateSkillReferencesAcceptsResolvable(t *testing.T) {
+	t.Parallel()
 	wf := &reliantv1.Workflow{
 		Nodes: []*reliantv1.Node{
 			workflowNode("build", &reliantv1.Node_Workflow{
@@ -86,6 +88,7 @@ func TestValidateSkillReferencesAcceptsResolvable(t *testing.T) {
 // TestValidateSkillReferencesChecksCallLLMLiterals covers the terminal
 // consumer: skills named directly on a call_llm node.
 func TestValidateSkillReferencesChecksCallLLMLiterals(t *testing.T) {
+	t.Parallel()
 	wf := &reliantv1.Workflow{
 		Nodes: []*reliantv1.Node{{
 			Id:   "ask",
@@ -109,6 +112,7 @@ func TestValidateSkillReferencesChecksCallLLMLiterals(t *testing.T) {
 // DEFAULT names a skill — just as silent a failure, and the shape
 // scope-conversation.yaml ships.
 func TestValidateSkillReferencesChecksInputDefaults(t *testing.T) {
+	t.Parallel()
 	wf := &reliantv1.Workflow{
 		Inputs: map[string]*reliantv1.Input{
 			"skills": {Type: "array", Config: &reliantv1.Input_ArrayInput{
@@ -131,6 +135,7 @@ func TestValidateSkillReferencesChecksInputDefaults(t *testing.T) {
 // guessed at — otherwise every forwarding workflow ("{{inputs.skills}}") would
 // fail validation and the check would be turned off.
 func TestValidateSkillReferencesSkipsTemplates(t *testing.T) {
+	t.Parallel()
 	wf := &reliantv1.Workflow{
 		Nodes: []*reliantv1.Node{
 			workflowNode("forward", &reliantv1.Node_Workflow{
@@ -160,6 +165,7 @@ func TestValidateSkillReferencesSkipsTemplates(t *testing.T) {
 // layer. The guard against that becoming a silent no-op everywhere is
 // TestBuiltinWorkflowSkillsResolve, which always supplies a real one.
 func TestValidateSkillReferencesNoResolverIsNoOp(t *testing.T) {
+	t.Parallel()
 	wf := &reliantv1.Workflow{
 		Nodes: []*reliantv1.Node{
 			workflowNode("build", &reliantv1.Node_Workflow{
@@ -178,6 +184,7 @@ func TestValidateSkillReferencesNoResolverIsNoOp(t *testing.T) {
 // the whole list on the first unknowable entry would let a typo ride along
 // beside any templated entry.
 func TestValidateSkillReferencesChecksLiteralsInAMixedList(t *testing.T) {
+	t.Parallel()
 	wf := &reliantv1.Workflow{
 		Nodes: []*reliantv1.Node{
 			workflowNode("build", &reliantv1.Node_Workflow{

--- a/internal/workflow/validation/spawn_validation_test.go
+++ b/internal/workflow/validation/spawn_validation_test.go
@@ -30,6 +30,7 @@ func makeCallLLMNode(id string, spawnEntries []string) *reliantv1.Node {
 }
 
 func TestValidateSpawnRefsLoadable_ExistingWorkflow(t *testing.T) {
+	t.Parallel()
 	loader := func(name string) (*reliantv1.Workflow, error) {
 		if name == "builtin://agent" {
 			return &reliantv1.Workflow{Name: "agent", Entry: []string{"loop"}, Nodes: []*reliantv1.Node{
@@ -48,6 +49,7 @@ func TestValidateSpawnRefsLoadable_ExistingWorkflow(t *testing.T) {
 }
 
 func TestValidateSpawnRefsLoadable_NonExistentWorkflow(t *testing.T) {
+	t.Parallel()
 	loader := func(name string) (*reliantv1.Workflow, error) {
 		return nil, fmt.Errorf("workflow not found: %s", name)
 	}
@@ -63,6 +65,7 @@ func TestValidateSpawnRefsLoadable_NonExistentWorkflow(t *testing.T) {
 }
 
 func TestValidateSpawnRefsLoadable_TemplateSpawnWorkflowNameUsesIdentity(t *testing.T) {
+	t.Parallel()
 	loader := func(name string) (*reliantv1.Workflow, error) {
 		if name == "builtin://agent" {
 			return &reliantv1.Workflow{Name: "agent"}, nil
@@ -79,6 +82,7 @@ func TestValidateSpawnRefsLoadable_TemplateSpawnWorkflowNameUsesIdentity(t *test
 }
 
 func TestValidateSpawnRefsLoadable_TemplateSpawnWorkflowNameExpressionMustBeDirectIdentity(t *testing.T) {
+	t.Parallel()
 	loader := func(name string) (*reliantv1.Workflow, error) {
 		if name == "builtin://agent" {
 			return &reliantv1.Workflow{Name: "agent"}, nil
@@ -106,6 +110,7 @@ func TestValidateSpawnRefsLoadable_TemplateSpawnWorkflowNameExpressionMustBeDire
 }
 
 func TestValidateSpawnRefsLoadable_TemplateSpawnWorkflowNameWithWhitespaceStillValidates(t *testing.T) {
+	t.Parallel()
 	loader := func(name string) (*reliantv1.Workflow, error) {
 		if name == "builtin://agent" {
 			return &reliantv1.Workflow{Name: "agent"}, nil
@@ -122,6 +127,7 @@ func TestValidateSpawnRefsLoadable_TemplateSpawnWorkflowNameWithWhitespaceStillV
 }
 
 func TestValidateSpawnRefsLoadable_SyntheticNameIsRejected(t *testing.T) {
+	t.Parallel()
 	loader := func(name string) (*reliantv1.Workflow, error) {
 		if name == "builtin://agent" {
 			return &reliantv1.Workflow{Name: "agent"}, nil

--- a/internal/workflow/validation/structural_test.go
+++ b/internal/workflow/validation/structural_test.go
@@ -32,6 +32,7 @@ func casesEdge(from string, cases []*reliantv1.EdgeCase, defaults ...string) *re
 // =============================================================================
 
 func TestUnreachableNodeDetection(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		workflow    *reliantv1.Workflow
@@ -189,6 +190,7 @@ func TestUnreachableNodeDetection(t *testing.T) {
 // =============================================================================
 
 func TestCycleDetection(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		workflow    *reliantv1.Workflow
@@ -387,6 +389,7 @@ func TestCycleDetection(t *testing.T) {
 // =============================================================================
 
 func TestRouterNodeValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		workflow    *reliantv1.Workflow
@@ -660,6 +663,7 @@ func TestRouterNodeValidation(t *testing.T) {
 }
 
 func TestInlineWorkflowCycleDetection(t *testing.T) {
+	t.Parallel()
 	// Test that cycle detection also works for inline workflows
 	workflow := &reliantv1.Workflow{
 		Name:  "parent",
@@ -702,6 +706,7 @@ func TestInlineWorkflowCycleDetection(t *testing.T) {
 }
 
 func TestInlineWorkflowUnreachableNodeDetection(t *testing.T) {
+	t.Parallel()
 	// Test that unreachable node detection also works for inline workflows
 	workflow := &reliantv1.Workflow{
 		Name:  "parent",
@@ -745,6 +750,7 @@ func TestInlineWorkflowUnreachableNodeDetection(t *testing.T) {
 // ============================================================================
 
 func TestValidateStructure_ResumeNode(t *testing.T) {
+	t.Parallel()
 	makeWf := func(resumeNode string) *reliantv1.Workflow {
 		return &reliantv1.Workflow{
 			Name:       "test",

--- a/internal/workflow/validation/structured_agent_test.go
+++ b/internal/workflow/validation/structured_agent_test.go
@@ -12,6 +12,7 @@ import (
 
 // TestStructuredAgentV3Validation tests that the v3 structured-agent validates correctly
 func TestStructuredAgentV3Validation(t *testing.T) {
+	t.Parallel()
 	// Load the structured-agent workflow
 	data, err := os.ReadFile("../builtin/structured-agent.yaml")
 	require.NoError(t, err, "should read structured-agent.yaml")

--- a/internal/workflow/validation/type_check_test.go
+++ b/internal/workflow/validation/type_check_test.go
@@ -15,6 +15,7 @@ import (
 
 // TestCheckTypeCompatibility_ExactMatch tests that exact type matches are compatible.
 func TestCheckTypeCompatibility_ExactMatch(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		expected *FieldInfo
@@ -63,6 +64,7 @@ func TestCheckTypeCompatibility_ExactMatch(t *testing.T) {
 
 // TestCheckTypeCompatibility_SliceTypes tests array/slice type compatibility.
 func TestCheckTypeCompatibility_SliceTypes(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		expected *FieldInfo
@@ -138,6 +140,7 @@ func TestCheckTypeCompatibility_SliceTypes(t *testing.T) {
 
 // TestCheckTypeCompatibility_DynamicAllowed tests that dynamic types are always allowed.
 func TestCheckTypeCompatibility_DynamicAllowed(t *testing.T) {
+	t.Parallel()
 	expected := &FieldInfo{
 		Kind:     reflect.Slice,
 		IsSlice:  true,
@@ -156,6 +159,7 @@ func TestCheckTypeCompatibility_DynamicAllowed(t *testing.T) {
 
 // TestCheckTypeCompatibility_Mismatch tests type mismatches are detected.
 func TestCheckTypeCompatibility_Mismatch(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		expected   *FieldInfo
@@ -206,6 +210,7 @@ func TestCheckTypeCompatibility_Mismatch(t *testing.T) {
 
 // TestGetExpectedFieldType_SaveMessage tests expected types for save_message fields.
 func TestGetExpectedFieldType_SaveMessage(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		fieldName string
@@ -256,6 +261,7 @@ func TestGetExpectedFieldType_SaveMessage(t *testing.T) {
 
 // TestInferCELOutputType_Simple tests output type inference for simple expressions.
 func TestInferCELOutputType_Simple(t *testing.T) {
+	t.Parallel()
 	env, err := cel.NewEnv(
 		cel.Variable("str", cel.StringType),
 		cel.Variable("num", cel.IntType),
@@ -317,6 +323,7 @@ func TestInferCELOutputType_Simple(t *testing.T) {
 
 // TestInferCELOutputType_ObjectLiteral tests object literal construction.
 func TestInferCELOutputType_ObjectLiteral(t *testing.T) {
+	t.Parallel()
 	env, err := cel.NewEnv(
 		ext.NativeTypes(
 			ext.ParseStructTag("json"),
@@ -342,6 +349,7 @@ func TestInferCELOutputType_ObjectLiteral(t *testing.T) {
 
 // TestInferCELOutputType_MapExpression tests map/filter operations.
 func TestInferCELOutputType_MapExpression(t *testing.T) {
+	t.Parallel()
 	env, err := cel.NewEnv(
 		ext.NativeTypes(
 			ext.ParseStructTag("json"),
@@ -385,6 +393,7 @@ func TestInferCELOutputType_MapExpression(t *testing.T) {
 
 // TestIntegration_ToolResultsValidation tests end-to-end validation of tool_results field.
 func TestIntegration_ToolResultsValidation(t *testing.T) {
+	t.Parallel()
 	env, err := cel.NewEnv(
 		ext.NativeTypes(
 			ext.ParseStructTag("json"),
@@ -442,6 +451,7 @@ func TestIntegration_ToolResultsValidation(t *testing.T) {
 
 // TestIntegration_ManualConstruction tests manually constructed objects.
 func TestIntegration_ManualConstruction(t *testing.T) {
+	t.Parallel()
 	env, err := cel.NewEnv(
 		ext.NativeTypes(
 			ext.ParseStructTag("json"),
@@ -474,6 +484,7 @@ func TestIntegration_ManualConstruction(t *testing.T) {
 
 // TestIntegration_ConditionalLogic tests conditional expressions.
 func TestIntegration_ConditionalLogic(t *testing.T) {
+	t.Parallel()
 	env, err := cel.NewEnv(
 		ext.NativeTypes(
 			ext.ParseStructTag("json"),
@@ -500,6 +511,7 @@ func TestIntegration_ConditionalLogic(t *testing.T) {
 
 // TestFormatTypeError tests error message formatting.
 func TestFormatTypeError(t *testing.T) {
+	t.Parallel()
 	expected := &FieldInfo{
 		Kind:     reflect.Slice,
 		IsSlice:  true,
@@ -521,6 +533,7 @@ func TestFormatTypeError(t *testing.T) {
 
 // TestInferElementType tests element type inference from list type strings.
 func TestInferElementType(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		typeStr  string
@@ -563,6 +576,7 @@ func TestInferElementType(t *testing.T) {
 
 // TestFormatFieldType tests field type formatting for user messages.
 func TestFormatFieldType(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		info *FieldInfo

--- a/internal/workflow/validation/unknown_node_type_test.go
+++ b/internal/workflow/validation/unknown_node_type_test.go
@@ -12,6 +12,7 @@ import (
 // TestStaticValidation_RejectsUnknownNodeType verifies that static analysis
 // rejects workflows with unrecognized node types.
 func TestStaticValidation_RejectsUnknownNodeType(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		yaml        string
@@ -72,6 +73,7 @@ nodes:
 // node type passes the type check in validateNodeArgs (they may fail for
 // other reasons like missing args, but NOT for unknown type).
 func TestStaticValidation_AcceptsKnownNodeTypes(t *testing.T) {
+	t.Parallel()
 	// Minimal valid workflow for each known type
 	workflows := map[string]string{
 		"call_llm": `
@@ -131,6 +133,7 @@ nodes:
 // field at all is rejected. This is the exact bug from the blog-content-pipeline
 // workflow where `deai_loop` used `loop:` as a nested key instead of `type: loop`.
 func TestStaticValidation_RejectsMissingType(t *testing.T) {
+	t.Parallel()
 	// Simulate a node that has no type field — this is what the YAML parser
 	// produces when a node uses structural keys (like loop:) without type:
 	wf, err := wfyaml.ParseWorkflow([]byte(`
@@ -156,6 +159,7 @@ nodes:
 // TestStaticValidation_UnknownTypeIncludesValidTypes verifies the error
 // message includes the list of valid types for discoverability.
 func TestStaticValidation_UnknownTypeIncludesValidTypes(t *testing.T) {
+	t.Parallel()
 	yaml := `
 name: test
 entry: [n]

--- a/internal/worktree/service_test.go
+++ b/internal/worktree/service_test.go
@@ -70,6 +70,7 @@ func execGitCommand(dir, command string, args ...string) error {
 }
 
 func TestNewService(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 
 	service, err := NewService(tempDir, tempDir)
@@ -333,6 +334,7 @@ func TestWorktreeWithSessionID(t *testing.T) {
 }
 
 func TestWorktreeStates(t *testing.T) {
+	t.Parallel()
 	states := []Status{StatusActive, StatusCompleted, StatusAbandoned, StatusMerging}
 
 	for _, state := range states {
@@ -385,6 +387,7 @@ func BenchmarkListWorktrees(b *testing.B) {
 // Tests for recursive file copy functionality
 
 func TestFindMatchingFiles(t *testing.T) {
+	t.Parallel()
 	// Create temporary directory structure
 	tmpDir := t.TempDir()
 
@@ -482,6 +485,7 @@ func TestFindMatchingFiles(t *testing.T) {
 }
 
 func TestCopyFilePaths(t *testing.T) {
+	t.Parallel()
 	// Create source directory
 	srcDir := t.TempDir()
 
@@ -526,6 +530,7 @@ func TestCopyFilePaths(t *testing.T) {
 }
 
 func TestCopyFilesIntegration(t *testing.T) {
+	t.Parallel()
 	// Create source directory with nested .env files
 	srcDir := t.TempDir()
 
@@ -594,6 +599,7 @@ func TestCreateWorktreeWithCopyFiles(t *testing.T) {
 }
 
 func TestCopyDirectory(t *testing.T) {
+	t.Parallel()
 	// Create source directory
 	srcDir := t.TempDir()
 
@@ -648,6 +654,7 @@ func TestCopyDirectory(t *testing.T) {
 }
 
 func TestFindMatchingFilesWithDirectory(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 
 	// Create directory structure


### PR DESCRIPTION
## What

PR CI spent most of its time installing tools it never used and regenerating code that is already committed. This removes that work rather than caching it, and raises `t.Parallel()` adoption from 0.7% to ~26%.

Measured from run 33583995765: `Backend (Go)` was ~8m, of which only **190s was testing** and ~260s was setup.

## The findings that drove this

**goose was installed in all five jobs, ~58s each, and never invoked.** It is a *library* dependency (`github.com/pressly/goose/v3`, imported by `internal/db/connect.go`, which embeds the migrations and calls `goose.Up()` in-process). Nothing shells out to the goose binary except `check-migrations.yml`, which installs it itself. Deleted, not cached.

**Generated code is committed**, and `.gitignore` says so explicitly: *"a checkout builds as-cloned. Regenerating must be a no-op."* So `make generate-go` (~140s) was never a build input for the test jobs. Verified: `go build ./...` and the full suite pass on a clean `git archive` of HEAD with no generator run, and `npm run typecheck` / `build:alpha` do too.

**But main was violating that contract** — `make generate-go` produced a real diff, including `ListSettings` gaining `ORDER BY key, updated_at` in the committed sqlc output while the `.sql` source had already changed. The old setup could not catch this: every job ran the generators and threw the output away. Fixed in its own commit, and now enforced.

## Changes

1. **`ci:` tool installs** — goose removed everywhere. ripgrep kept in `backend` (it is real: `requireRipgrep()` *skips* those tests when absent, so a missing `rg` means a silent green) but installed from apt, not compiled; dropped from `e2e-backend`, verified by running the e2e suite with `rg` off `PATH`. forge cached on the go.mod-resolved version. Go and buf dropped entirely from `web`, `e2e-frontend`, `electron`, which are now pure Node jobs.
2. **`ci:` Go build cache** — `setup-go`'s `cache: true` caches modules but not `~/.cache/go-build`, so every run recompiled the dependency graph from scratch. Keyed on Go version + `go.sum`, with restore-keys.
3. **`ci:` new `generate-drift` job** — runs the generators and fails on a diff. This is what makes removing them from the critical path safe, and it runs *in parallel* instead of in front of the tests.
4. **`test:` 1024 `t.Parallel()` calls** across the seven slowest packages.

## Measured, each package timed in isolation

| package | before | after |
|---|---|---|
| `internal/llm/tools` | 46.9s | **5.8s** |
| `internal/workflow/runtime` | 20.8s | 17.6s |
| `internal/workflow/builtin` | 5.0s | 2.9s |
| `internal/servergateway` | 3.0s | 2.1s |
| `internal/worktree` | 1.8s | 1.5s |

`llm/tools` dominates because its cost was ~30 `TestCodeContext_*` tests that each spawn gopls/tsserver against an isolated `t.TempDir` fixture — latency-bound, so they overlap almost perfectly.

## Safety

A test was left serial if it can reach `t.Setenv`/`t.Chdir` **directly or transitively through a helper**, or if it assigns to a package-level global. Both were found the hard way: a body-only scan missed `newDaemonClientForTest` (calls `t.Setenv` two frames down — panicked 13 tests) and `shortWaitDelay` (writes `daemon.ExecWaitDelay` — raced). 66 tests stay serial for those reasons.

`internal/toolexec/daemonruntime` is deliberately **not** parallelized: it races on shared process-level state (the daemon data-dir claim, the cgroupmem watcher), which is a property of the package rather than any one test.

Verified with `-race -count=2` on every package touched, plus the full `./internal/...` suite, `go build ./...` and `go vet`.

## Pre-existing bug found, not fixed here

`internal/llm/tools/shell` has a genuine data race, reproducible on unmodified `main`:

```
go test ./internal/llm/tools/shell/ -race -count=2 -run TestStartProcess_HealthyWorkingDirUnaffected
```

`BackgroundManager.GetProcess` writes `process.Ports` under only `RLock` while a monitor goroutine writes `Status`/`cmd`. Out of scope for a CI-perf PR; flagged for a follow-up.

---

## Measured result (updated after CI ran)

Warm-cache run [33810135214](https://github.com/reliant-labs/reliant/actions/runs/33810135214), against baseline run 33583995765:

| job | before | after |
|---|---|---|
| **Backend (Go)** — critical path | **8m00s** | **4m01s** |
| E2E Backend (Go) | 5m | 47s |
| Web (lint, test, build) | 7m | 3m00s |
| E2E Frontend (Playwright) | 4m | 2m26s |
| Electron (build smoke) | 5m | 1m11s |
| Generated code is up to date | — | 54s (new) |

**PR CI critical path: ~12m to ~4m.**

Backend step detail, before to after: `Install goose` 58s to **gone**, `Generate Go code` 140s to **gone** (now a parallel job), `Install forge` 52s to **0s** (cache hit), `Go tests` 190s to **91s**.

### Two honest caveats

**The first run after a cache key changes is slower, not faster.** That run took 7m54s: caches were empty, so forge paid 91s and `Go tests` took 313s. The 140s `Generate Go code` step it replaced had been *warming the build cache* as a side effect, so removing it moved that compilation into the test step until the build cache is populated. Steady state is the 4m01s above; expect one slow run after any `go.sum` or Go-version bump.

**The `t.Parallel()` work contributes much less on CI than locally.** Local wins were measured on 16 cores. Re-measured under `GOMAXPROCS=4` (what `ubuntu-latest` actually provides), the full `./internal/...` suite goes 90.8s to 87.6s — about 3%. `llm/tools` alone still improves (46.9s to 11.7s at 4 CPUs), but the suite is bounded by package-level parallelism that `go test` already did. Most of the `Go tests` 190s to 91s improvement is the **build cache**, not the parallelism.

The parallelism is still worth keeping — it is a large win on developer machines and on any future larger runner, and it surfaced two real bugs — but it is not what halved CI, and this PR should not be read as evidence that it was.
