### PR TITLE
chore: require forge + forge/pkg v0.1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,8 +34,8 @@ require (
 	github.com/pressly/goose/v3 v3.28.0
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.3
-	github.com/reliant-labs/forge v0.1.13
-	github.com/reliant-labs/forge/pkg v0.1.13
+	github.com/reliant-labs/forge v0.1.14
+	github.com/reliant-labs/forge/pkg v0.1.14
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/sqlc-dev/pqtype v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -460,10 +460,10 @@ github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEo
 github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
 github.com/prometheus/procfs v0.22.0 h1:6q9+/JL9IKAPbCmBrv9n5O5Ty3NKnciV5X7YGw0oics=
 github.com/prometheus/procfs v0.22.0/go.mod h1:CvmFr/GVhIjIvWJZW3tgkODBQMRIf0EyWMQLHCHab58=
-github.com/reliant-labs/forge v0.1.13 h1:IPIf61Vj/eUGip8hqRJ8ih739D1XZlyo09DU8yc8/P8=
-github.com/reliant-labs/forge v0.1.13/go.mod h1:nIhy0XW0FBIM2M7ASspG6eRtxkBrxR5H1U6lTGkxPGg=
-github.com/reliant-labs/forge/pkg v0.1.13 h1:8LYeSRthAH82Xe0gpjbBgNRXB+nNNzJheK8wPuyEb7Q=
-github.com/reliant-labs/forge/pkg v0.1.13/go.mod h1:sfx6mK8xPMq8RqvfpkNa3mj4mBp7CDOKaNyTZLmX1QE=
+github.com/reliant-labs/forge v0.1.14 h1:1ncEA6QNW0E44nVjTJPtYgw/zUxpVU7dGtWXpBlaF5I=
+github.com/reliant-labs/forge v0.1.14/go.mod h1:MRwzgDMi+42IIWfq4WHzFGy8hWEEH1KRFe3bBccVKkA=
+github.com/reliant-labs/forge/pkg v0.1.14 h1:oEi68/DnGrk7r/zJf5IKTC02p6cISJJhsGKjhCULOuw=
+github.com/reliant-labs/forge/pkg v0.1.14/go.mod h1:sfx6mK8xPMq8RqvfpkNa3mj4mBp7CDOKaNyTZLmX1QE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
Bumps both forge modules together (same tag, same commit — a split pin compiles today and produces skew later).

## What v0.1.14 brings

- **tsconfig peer pins from tracked files.** The hoisting decision used to probe `node_modules`, so a dev machine wrote `../../` and CI wrote `./` — failing `Verify Generated Code` on a file nobody edited. Root cause was control-plane's gitignored dev web-runtime bridge.
- **`forge build <env>` renders the env's frontend runtime config first.** Previously every cloud frontend image shipped **dev's** `config.js`, because only `forge env up` re-rendered it.
- go.sum pruned of superseded `forge/pkg v0.1.11` entries.

## ⚠️ v0.1.12 is burned

`pkg/v0.1.12` was tagged Sept 5, published, then deleted and re-cut at a different commit. The Go module proxy is immutable and still serves the Sept 5 tree, which lacks `schemadef.ColumnMarkerOwner` and does not compile. Never pin it.

## Verification

`GOWORK=off go build ./...` clean (the consumer view — published modules, not the sibling checkout), `go test ./...` clean, both `go.sum` entry pairs present.