### PR TITLE
ci: fetch our own modules direct, not through proxy.golang.org

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -236,6 +236,27 @@ jobs:
 
       - name: Install forge
         if: steps.forge-cache.outputs.cache-hit != 'true'
+        # GOPRIVATE routes OUR OWN modules straight at GitHub instead of
+        # proxy.golang.org. This is a real, measured delay, not a nicety: a
+        # freshly pushed tag takes proxy.golang.org ~20 MINUTES to ingest, and
+        # until it does, `go install ...@vX.Y.Z` fails with
+        #   invalid version: unknown revision vX.Y.Z
+        # on a tag that already exists and that `GOPROXY=direct` fetches
+        # instantly. Because the release chain is forge -> reliant ->
+        # control-plane, that stall is paid at EVERY hop of every release.
+        #
+        # It also removes a class of confusion the proxy's immutability
+        # creates: a deleted-and-re-cut tag is served forever from its first
+        # publish (that is how forge v0.1.12 became permanently unusable).
+        # Going direct means the tag in git is the tag you build.
+        #
+        # Scoped to reliant-labs/* on purpose — third-party modules keep using
+        # the proxy and the checksum database, which is where those are
+        # actually worth having.
+        env:
+          GOPRIVATE: github.com/reliant-labs/*
+          GONOSUMDB: github.com/reliant-labs/*
+          GONOSUMCHECK: "1"
         run: go install "github.com/reliant-labs/forge/cmd/forge@${{ steps.forge-version.outputs.version }}"
 
       - name: Lint (forge)


### PR DESCRIPTION
## The delay, measured

forge `v0.1.14` was tagged at **14:37 UTC**. At **14:55** `proxy.golang.org` still returned:

```
invalid version: unknown revision v0.1.14
```

~20 minutes, on a tag that already existed in git and that `GOPROXY=direct` fetched instantly. CI's `Install forge` step failed for that whole window — and since the release chain is forge → reliant → control-plane, that stall is paid at **every hop of every release**. `v0.1.13` hit it the same way earlier today.

This was the single largest source of delay in today's release.

## Second benefit: the proxy's immutability stops biting

A deleted-and-re-cut tag is served **forever** from its first publish. That is how forge `v0.1.12` became permanently unusable — tagged Sept 5, published, deleted, re-cut at a different commit, and the proxy still serves the Sept 5 tree (which lacks `schemadef.ColumnMarkerOwner` and does not compile). Direct means the tag in git is the tag you build.

## Scope

`GOPRIVATE=github.com/reliant-labs/*` only, on the `Install forge` step. Third-party modules keep the proxy and the checksum database.