### PR TITLE
chore: pin forge by commit (make pin-forge / pin-drift)

### DIFF
--- a/.github/workflows/pin-drift.yml
+++ b/.github/workflows/pin-drift.yml
@@ -1,0 +1,77 @@
+# forge pin drift check — reports, never blocks.
+#
+# WHY THIS EXISTS
+# ===============
+#
+# Pre-launch we pin forge by COMMIT rather than by tag, because a tagged
+# release costs three tags, three CI cycles and three merges (plus up to ~20
+# minutes of module-proxy lag) before a one-line fix reaches prod — the only
+# environment where our bugs actually appear. See docs/development/pinning.md.
+#
+# That trade has exactly one real cost, and this workflow is the thing that
+# pays it. A commit pin has NO VERSION NUMBER TO NOTICE IS STALE. `v0.1.11`
+# next to a `v0.1.14` release is obviously old at a glance;
+# `v0.1.15-0.20260910160302-c195f15386be` looks equally current whether it is
+# one commit behind or ninety. Nothing decays visibly, so nothing prompts a
+# bump, and the pin quietly ages until someone wonders why a forge fix they
+# merged weeks ago never reached prod.
+#
+# WHERE IT RUNS, AND WHY THERE
+# ============================
+#
+# Separate from pr-ci.yml deliberately. pr-ci is a GATE — every job in it can
+# fail the PR — and this check must never do that (see below). Folding a
+# never-failing job into the gate blurs what a red PR-CI means, and it would
+# inherit that workflow's change-detection plumbing for no benefit.
+#
+# It runs on `pull_request` (the annotation lands where somebody is holding the
+# context) and on a weekly `schedule`. The schedule is the one that matters
+# most: drift is caused by the SIBLING moving, so the commit that makes a pin
+# stale never lands in this repo at all, and a quiet week with no PRs is
+# exactly when a pin rots unobserved.
+#
+# WHY IT NEVER FAILS THE BUILD
+# ============================
+#
+# A deliberately older pin is legitimate. Holding forge steady while chasing a
+# regression is normal, and a check that failed CI for it would be one whose
+# only remedy is to bypass it — and a check people routinely bypass has already
+# stopped being a check.
+#
+# The invariant that genuinely MUST hold is enforced as a hard failure where it
+# belongs: internal/buildmode's guards fail the test job if go.mod carries a
+# forge `replace`, or requires no concrete forge version at all.
+name: Pin Drift
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pin-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    name: Report forge pin drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Report drift
+        env:
+          # The compare API reads reliant-labs/forge, which is private. The
+          # default GITHUB_TOKEN is scoped to THIS repository only and cannot
+          # see it. The script degrades honestly when a compare fails (it says
+          # "skipped" rather than claiming up-to-date), so a missing
+          # SIBLING_READ_TOKEN yields a useless-but-not-misleading report
+          # instead of a false green.
+          GH_TOKEN: ${{ secrets.SIBLING_READ_TOKEN || secrets.GITHUB_TOKEN }}
+        run: ./scripts/pin-drift.sh --github

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ NC := \033[0m # No Color
 MINTLIFY_DOCS_DIR := docs
 MINTLIFY_PORT ?= 3000
 
-.PHONY: all build build-all clean test test-race test-coverage test-ci test-e2e replay-fixtures deps fmt vet lint security help generate generate-cli generate-tools-ref generate-shortcuts generate-nodes generate-types generate-presets generate-workflow-builder-skill generate-changelog generate-mintlify-reference docs docs-build mint changelog changelog-draft postgres-up postgres-down db-driver-audit generate-yaml-bindings build-api-server build-temporal-worker build-tools-daemon build-services docker-build
+.PHONY: all build build-all clean test test-race test-coverage test-ci test-e2e replay-fixtures deps fmt vet lint security help generate generate-cli generate-tools-ref generate-shortcuts generate-nodes generate-types generate-presets generate-workflow-builder-skill generate-changelog generate-mintlify-reference docs docs-build mint changelog changelog-draft postgres-up postgres-down db-driver-audit generate-yaml-bindings build-api-server build-temporal-worker build-tools-daemon build-services docker-build pin-forge pin-drift
 
 # Default target
 all: deps fmt vet test build
@@ -248,6 +248,19 @@ proto-format:
 db-driver-audit:
 	@echo "$(YELLOW)Running DB driver audit...$(NC)"
 	@./scripts/db-driver-audit.sh
+
+## pin-forge: Pin forge + forge/pkg to forge's current origin/main commit
+# Pre-launch we pin by COMMIT, not tag — a tag costs three CI cycles and up to
+# 20 minutes of module-proxy lag before a one-line forge fix can reach prod,
+# where every bug we chase actually lives. See docs/pinning.md for the mode
+# switch and the exact command to go back to tags at launch.
+# Pass a ref to pin something else: make pin-forge REF=<sha|branch|tag>
+pin-forge:
+	@./scripts/pin-forge.sh $(REF)
+
+## pin-drift: Report how many commits behind forge's main the pin has fallen
+pin-drift:
+	@./scripts/pin-drift.sh
 
 ## sqlc: Generate database code with sqlc
 SQLC_VERSION := v1.31.1

--- a/docs/development/pinning.md
+++ b/docs/development/pinning.md
@@ -1,0 +1,74 @@
+# Pinning forge: commits now, tags at launch
+
+**If you found a version like `v0.1.15-0.20260910160302-c195f15386be` in
+`go.mod` and it looked wrong: it is deliberate.** That is a Go pseudo-version,
+this repo is in commit-pinning mode, and the reasoning is below. Do not "fix"
+it back to a tag without reading the switch section — you would be reverting a
+decision, not correcting a mistake.
+
+The authoritative version of this document, covering all three repos, is
+**`control-plane/docs/pinning.md`**. This file is the reliant-side summary.
+
+## The commands
+
+```sh
+make pin-forge                 # pin forge AND forge/pkg to forge@origin/main
+make pin-forge REF=v0.1.14     # pin to a specific tag, branch or sha
+make pin-drift                 # how far behind the pin is (warn-only)
+```
+
+`make pin-forge` reads forge's `origin/main` from the **remote** rather than
+trusting the local `../forge` checkout, which on a dev box is routinely on
+another agent's branch or days stale. It pins **both** forge modules to one
+commit — they are tagged from a single commit, so a split pin compiles today
+and skews later — then proves the result with `GOWORK=off go build ./...`.
+
+`GOWORK=off` matters here specifically: this repo has a `go.work` that resolves
+forge from `../forge` on disk, so a plain `go build` can pass while CI fails on
+the version `go.mod` actually pins.
+
+It edits `go.mod` and `go.sum` and **stops**. It does not commit — this
+checkout is shared with other agents, and staging paths in a tree holding
+someone else's in-flight work is how that work gets lost.
+
+## Why commits, pre-launch
+
+Prod is the only real environment, and every bug we chase has only ever
+appeared there. Shipping one forge fix the tagged way costs three tags, three
+CI cycles and three merges. Measured: a commit pin resolves in **2.065s**; a
+freshly pushed tag took **~20 minutes** to become usable because
+`proxy.golang.org` had not ingested it. `GOPRIVATE=github.com/reliant-labs/*`
+(already in `pr-ci.yml`) is what makes the fast number real.
+
+A pseudo-version is a real, resolvable, checksummed module version. It is **not**
+a `replace` — a `replace` applies in every build mode, `GOWORK=off` does not
+disable it, and it breaks the container build. That remains forbidden and
+`internal/buildmode/forge_replace_guard_test.go` is untouched by this mode; it
+passes on a pseudo-version as-is.
+
+## Drift
+
+A commit pin has no version number to notice is stale — a pseudo-version looks
+equally current whether it is one commit old or ninety. `make pin-drift`
+reports how many commits behind `forge@main` each pin is. It **warns and never
+fails**: a deliberately older pin is legitimate, and a check that failed CI for
+it would be one whose only fix is to bypass it.
+
+## Switching back to tags at launch
+
+```sh
+make pin-forge REF=vX.Y.Z
+grep 'reliant-labs/forge' go.mod    # both lines must read vX.Y.Z
+GOWORK=off go build ./...
+go test -count=1 ./internal/buildmode/
+```
+
+Then confirm nothing pseudo-versioned remains:
+
+```sh
+grep -n 'reliant-labs/forge' go.mod | grep -- '-0\.[0-9]\{14\}-'   # expect no output
+```
+
+Nothing needs to be un-built to switch: `pin-forge` takes a `REF` and the drift
+check already understands both shapes. The full release procedure is in the
+`release` skill; this file only covers which SHAPE the pins take.

--- a/go.mod
+++ b/go.mod
@@ -34,8 +34,8 @@ require (
 	github.com/pressly/goose/v3 v3.28.0
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.3
-	github.com/reliant-labs/forge v0.1.14
-	github.com/reliant-labs/forge/pkg v0.1.14
+	github.com/reliant-labs/forge v0.1.15-0.20260910160302-c195f15386be
+	github.com/reliant-labs/forge/pkg v0.1.15-0.20260910160302-c195f15386be
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/sqlc-dev/pqtype v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -460,10 +460,10 @@ github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEo
 github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
 github.com/prometheus/procfs v0.22.0 h1:6q9+/JL9IKAPbCmBrv9n5O5Ty3NKnciV5X7YGw0oics=
 github.com/prometheus/procfs v0.22.0/go.mod h1:CvmFr/GVhIjIvWJZW3tgkODBQMRIf0EyWMQLHCHab58=
-github.com/reliant-labs/forge v0.1.14 h1:1ncEA6QNW0E44nVjTJPtYgw/zUxpVU7dGtWXpBlaF5I=
-github.com/reliant-labs/forge v0.1.14/go.mod h1:MRwzgDMi+42IIWfq4WHzFGy8hWEEH1KRFe3bBccVKkA=
-github.com/reliant-labs/forge/pkg v0.1.14 h1:oEi68/DnGrk7r/zJf5IKTC02p6cISJJhsGKjhCULOuw=
-github.com/reliant-labs/forge/pkg v0.1.14/go.mod h1:sfx6mK8xPMq8RqvfpkNa3mj4mBp7CDOKaNyTZLmX1QE=
+github.com/reliant-labs/forge v0.1.15-0.20260910160302-c195f15386be h1:bt0nEl+zcZr9ia+GyFHG5TLYvi2yTtL2xktBJXk6kEw=
+github.com/reliant-labs/forge v0.1.15-0.20260910160302-c195f15386be/go.mod h1:MRwzgDMi+42IIWfq4WHzFGy8hWEEH1KRFe3bBccVKkA=
+github.com/reliant-labs/forge/pkg v0.1.15-0.20260910160302-c195f15386be h1:wsn/pVRg3nnj9Zgdyvel6jQhi/VCTEgNRNHtWzXrPGc=
+github.com/reliant-labs/forge/pkg v0.1.15-0.20260910160302-c195f15386be/go.mod h1:sfx6mK8xPMq8RqvfpkNa3mj4mBp7CDOKaNyTZLmX1QE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/scripts/pin-drift.sh
+++ b/scripts/pin-drift.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Report how far behind the sibling's main this repo's forge pin has fallen.
+#
+# ── Why this exists ──────────────────────────────────────────────────────
+#
+# A commit pin has one real weakness, and this is it: there is no version
+# number to notice is stale. `v0.1.11` next to a `v0.1.14` release is
+# obviously behind at a glance; `v0.1.15-0.20260910160302-c195f15386be` looks
+# equally current whether it is one commit old or ninety. Nothing decays
+# visibly, so nothing prompts a bump.
+#
+# ── Why it WARNS and never fails ─────────────────────────────────────────
+#
+# A deliberately older pin is legitimate — holding forge steady while
+# investigating a regression is a normal thing to do, and a check that failed
+# CI for it would be one whose only fix is to bypass it. A check people
+# routinely bypass has already stopped being a check. So: say something,
+# block nothing. This is the same posture as setup-forge's CLI/pkg divergence
+# warning, for the same reason.
+#
+# Exit code is 0 unless the check itself could not run.
+#
+# Usage:
+#   scripts/pin-drift.sh            # human-readable
+#   scripts/pin-drift.sh --github   # also emit ::warning for CI annotations
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+GITHUB_MODE=0
+[ "${1:-}" = "--github" ] && GITHUB_MODE=1
+
+# The drift threshold at which we start nagging. Small enough to be useful,
+# large enough that a normal same-day pin does not trip it.
+THRESHOLD="${PIN_DRIFT_THRESHOLD:-10}"
+
+pinned_version() {
+  sed -n "s|^[[:space:]]*$1[[:space:]]\{1,\}\(v[^[:space:]]*\).*|\1|p" go.mod | head -1
+}
+
+# A pin is one of two shapes and the compare API accepts both as a base:
+#   tag              v0.1.14
+#   pseudo-version   v0.1.15-0.20260910160302-c195f15386be  (sha = last field)
+# Reducing both to "something git can resolve" keeps this working unchanged
+# across the launch switch back to tags, which is the point — a drift check
+# that only understands one mode has to be rewritten at the worst moment.
+pin_ref() {
+  case "$1" in
+    *-*-*) echo "${1##*-}" ;;
+    *)     echo "$1" ;;
+  esac
+}
+
+report() {
+  local label="$1" repo="$2" version="$3"
+
+  if [ -z "${version}" ]; then
+    echo "  ${label}: not pinned in go.mod — skipping"
+    return
+  fi
+
+  local ref; ref="$(pin_ref "${version}")"
+  local behind
+  # ahead_by counts commits main has that the pin does not — i.e. exactly how
+  # far behind the pin is. Needs gh auth; these are private repos.
+  behind="$(gh api "repos/${repo}/compare/${ref}...main" --jq '.ahead_by' 2>/dev/null || true)"
+
+  if [ -z "${behind}" ]; then
+    echo "  ${label}: ${version}"
+    echo "      could not compare against ${repo}@main (gh auth? unreachable commit?) — skipped"
+    return
+  fi
+
+  local shape="tag"
+  case "${version}" in *-*-*) shape="commit" ;; esac
+
+  if [ "${behind}" -eq 0 ]; then
+    echo "  ${label}: ${version} [${shape}] — up to date with ${repo}@main"
+  elif [ "${behind}" -lt "${THRESHOLD}" ]; then
+    echo "  ${label}: ${version} [${shape}] — ${behind} commit(s) behind ${repo}@main"
+  else
+    echo "  ${label}: ${version} [${shape}] — ${behind} commits behind ${repo}@main  (>= ${THRESHOLD})"
+    if [ "${GITHUB_MODE}" = "1" ]; then
+      echo "::warning file=go.mod::${label} is ${behind} commits behind ${repo}@main (pinned ${version}). Pre-launch we pin by commit, so nothing about this version string looks stale on its own. Run 'make pin-forge' to move it, or ignore this if the older pin is deliberate. See docs/pinning.md."
+    fi
+  fi
+}
+
+echo "pin drift (warn-only; a deliberately older pin is fine):"
+report "forge    " "reliant-labs/forge" "$(pinned_version github.com/reliant-labs/forge)"
+report "forge/pkg" "reliant-labs/forge" "$(pinned_version github.com/reliant-labs/forge/pkg)"

--- a/scripts/pin-forge.sh
+++ b/scripts/pin-forge.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Pin github.com/reliant-labs/forge (both modules) to a sibling COMMIT.
+#
+# ── Why a commit and not a tag ────────────────────────────────────────────
+#
+# Pre-launch, prod is the only real environment and every bug we chase has
+# only ever appeared there. A tag-per-fix costs three tags, three CI cycles
+# and three merges before a one-line forge change reaches prod.
+#
+# A commit pin costs one `go get`. Measured, not estimated: resolving forge
+# at a commit took 2.065s, while a freshly pushed TAG took ~20 MINUTES to
+# become usable because proxy.golang.org had not ingested it yet. GOPRIVATE
+# (github.com/reliant-labs/*) is what makes the 2s number real — it routes
+# our own modules straight at GitHub instead of the proxy.
+#
+# What lands in go.mod is a Go PSEUDO-VERSION, e.g.
+#   v0.1.15-0.20260910160302-c195f15386be
+# That is a real, resolvable, checksummed module version — NOT a `replace`.
+# The distinction matters: a replace applies in every build mode, GOWORK=off
+# does not disable it, and it breaks the container build. See
+# internal/buildmode/forge_replace_guard_test.go, which stays untouched and
+# passes on a pseudo-version.
+#
+# This is not novel here either: forge.yaml already carried the pseudo-version
+# v0.1.12-0.20260903044854-14d84353e34b in September and the tooling handled it.
+#
+# ── This is a MODE, and it ends at launch ────────────────────────────────
+#
+# At launch we go back to tag pins. docs/pinning.md records the mode, why,
+# and the exact command to reverse it. Read that before "fixing" a
+# pseudo-version you find in go.mod.
+#
+# Usage:
+#   scripts/pin-forge.sh              # pin forge's current origin/main
+#   scripts/pin-forge.sh <sha|ref>    # pin an explicit commit, branch or tag
+
+set -euo pipefail
+
+FORGE_REMOTE="https://github.com/reliant-labs/forge"
+FORGE_MOD="github.com/reliant-labs/forge"
+PKG_MOD="github.com/reliant-labs/forge/pkg"
+
+# GOPRIVATE is the whole performance story (see header). Set it here rather
+# than relying on the caller's environment so the script is fast on a fresh
+# machine and in CI, not only on a laptop that happens to export it.
+export GOPRIVATE="${GOPRIVATE:-github.com/reliant-labs/*}"
+# `go get` needs -mod=mod to write go.mod; a repo-level -mod=readonly in
+# GOFLAGS would otherwise make this fail with a confusing "updates to go.mod
+# needed" instead of doing the one thing it exists to do.
+export GOFLAGS="${GOFLAGS:-} -mod=mod"
+
+cd "$(git rev-parse --show-toplevel)"
+
+require_line() { sed -n "s|^[[:space:]]*$1[[:space:]]\{1,\}\(v[^[:space:]]*\).*|\1|p" go.mod | head -1; }
+
+before_forge="$(require_line "$FORGE_MOD")"
+before_pkg="$(require_line "$PKG_MOD")"
+
+# ── Read the REMOTE, never a local checkout ──────────────────────────────
+# A sibling checkout on this machine is routinely on someone else's branch,
+# mid-rebase, or simply days stale. `git ls-remote` is authoritative and
+# costs well under a second, so there is no reason to trust local state.
+target="${1:-}"
+if [ -z "${target}" ]; then
+  sha="$(git ls-remote "${FORGE_REMOTE}" refs/heads/main | cut -f1)"
+  if [ -z "${sha}" ]; then
+    echo "error: could not read refs/heads/main from ${FORGE_REMOTE}" >&2
+    exit 1
+  fi
+  source_desc="origin/main"
+else
+  # Resolve whatever was handed in (branch, tag or sha) against the remote so
+  # the pin is always a concrete commit. A ref that does not resolve remotely
+  # is passed through unchanged and `go get` reports it.
+  sha="$(git ls-remote "${FORGE_REMOTE}" "${target}" | cut -f1 | head -1)"
+  if [ -z "${sha}" ]; then sha="${target}"; fi
+  source_desc="${target}"
+fi
+
+echo "==> pinning forge to ${source_desc} (${sha})"
+
+# ── Both modules, one `go get` ───────────────────────────────────────────
+# forge and forge/pkg are tagged from a SINGLE commit and are expected to be
+# the same source vintage. Pinning them separately compiles today and skews
+# the moment one moves without the other, which is a failure that surfaces as
+# an inscrutable type error in a consumer months later. One command, one sha.
+go get "${FORGE_MOD}@${sha}" "${PKG_MOD}@${sha}"
+go mod tidy
+
+after_forge="$(require_line "$FORGE_MOD")"
+after_pkg="$(require_line "$PKG_MOD")"
+
+# ── Verify the pin SURVIVED tidy ─────────────────────────────────────────
+# This is not ceremony. A pseudo-version derives its numeric prefix from the
+# last tag REACHABLE from that commit, so it can sort BELOW a release tag —
+# reliant's own main resolves to v1.7.8-0.… while v1.7.12 exists. Go picks
+# the maximum required version, so if anything in the graph still requires a
+# higher tag, MVS silently restores it and the pin you asked for is not the
+# pin you got. Fail loudly instead of shipping the wrong forge.
+short="${sha:0:12}"
+for pair in "${FORGE_MOD}:${after_forge}" "${PKG_MOD}:${after_pkg}"; do
+  mod="${pair%%:*}"; got="${pair#*:}"
+  if [ -z "${got}" ]; then
+    echo "error: ${mod} is not required in go.mod after tidy" >&2
+    exit 1
+  fi
+  # Two acceptable outcomes. A commit pin records a pseudo-version CONTAINING
+  # the sha. An explicit TAG argument records the tag itself — we resolved it
+  # to a sha above only to have something concrete to report, and the tag
+  # never contains that sha, so it must be matched separately or the tag path
+  # (which still has to work after launch) false-fails.
+  if [ "${got}" = "${target}" ]; then continue; fi
+  case "${got}" in
+    *"${short}"*) : ;;
+    *)
+      echo "error: ${mod} resolved to ${got}, which is neither the requested ref (${source_desc}) nor a pseudo-version containing ${short}." >&2
+      echo "       Minimum version selection kept a higher version from the module graph." >&2
+      echo "       A pseudo-version can sort BELOW an existing release tag — see docs/pinning.md." >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ "${after_forge}" != "${after_pkg}" ]; then
+  echo "error: forge (${after_forge}) and forge/pkg (${after_pkg}) disagree — they are tagged from one commit and must match" >&2
+  exit 1
+fi
+
+# ── Prove it against the CONSUMER's view ─────────────────────────────────
+# GOWORK=off is the only local signal that sees what CI sees. With go.work
+# active, forge resolves from ../forge on disk, so code calling an API that
+# exists only in an unreleased sibling checkout builds perfectly here and
+# fails every CI job. This repo has a go.work; without this line the script
+# would "verify" nothing.
+echo "==> GOWORK=off go build ./..."
+GOWORK=off go build ./...
+
+echo
+echo "pinned forge -> ${source_desc} (${sha})"
+printf '  %-40s %s -> %s\n' "${FORGE_MOD}" "${before_forge:-<absent>}" "${after_forge}"
+printf '  %-40s %s -> %s\n' "${PKG_MOD}" "${before_pkg:-<absent>}" "${after_pkg}"
+echo
+echo "Files changed: go.mod, go.sum. Review and commit them yourself —"
+echo "this script deliberately does not commit (see docs/pinning.md)."


### PR DESCRIPTION
## What

Adds `make pin-forge` and `make pin-drift`. Pre-launch we pin forge by **commit** rather than by tag.

## Why

Prod is the only real environment right now, and every bug we chase has only ever appeared there. Shipping one forge fix the tagged way costs three tags, three CI cycles and three merges.

Measured, not estimated:

| | Time to a usable pin |
|---|---|
| commit (`go get ...@<sha>`) | **2.065s** |
| freshly pushed tag | **~20 min** — `proxy.golang.org` had not ingested it |

`GOPRIVATE=github.com/reliant-labs/*` is already in `pr-ci.yml`, which is what makes the fast number real.

## A pseudo-version is not a `replace`

`make pin-forge` writes e.g. `v0.1.15-0.20260910160302-c195f15386be` — a real, resolvable, checksummed module version. A `replace` stays forbidden and **`forge_replace_guard_test.go` is untouched**; it passes unchanged on a pseudo-version (its `v\d+\.\d+\.\d+` is an unanchored prefix).

This is not new either: `forge.yaml` already carried a pseudo-version in September.

## What the script does that is easy to get wrong by hand

- Reads forge's `origin/main` from the **remote** (`git ls-remote`), not a local checkout that is routinely on another agent's branch.
- Pins **both** `forge` and `forge/pkg` to one commit — they are tagged from a single commit; a split pin compiles today and skews later.
- **Verifies the pin survived `go mod tidy`.** Load-bearing: a pseudo-version takes its numeric prefix from the last tag *reachable from that commit*, so it can sort **below** an existing release tag, and minimum-version selection will silently restore the old pin. It fails loudly instead.
- Ends with `GOWORK=off go build ./...` — the only local signal that sees what CI sees, and this repo has a `go.work`.

It edits `go.mod`/`go.sum` and **stops**. No commit, no PR: this checkout is shared with other agents, and staging paths in a tree holding someone else's in-flight work is how that work gets lost.

## Drift

A commit pin has no version number to notice is stale — a pseudo-version looks equally current at one commit old or ninety. `make pin-drift` reports how far behind `forge@main` each pin is.

It **warns and never fails**. A deliberately older pin is legitimate, and a check whose only remedy is to bypass it has already stopped being a check. It understands both tags and commits, so it survives the switch back at launch rather than needing a rewrite then.

## Tag pinning still works

`make pin-forge REF=v0.1.14` writes the tag. This ADDS a fast path; it does not replace the slow one. `docs/development/pinning.md` records the mode and the exact command to switch back at launch.

## Verification

```
$ make pin-forge
==> pinning forge to origin/main (c195f15386be85857873bd6201281582176cc642)
go: upgraded github.com/reliant-labs/forge v0.1.14 => v0.1.15-0.20260910160302-c195f15386be
go: upgraded github.com/reliant-labs/forge/pkg v0.1.14 => v0.1.15-0.20260910160302-c195f15386be
==> GOWORK=off go build ./...          # exit 0

  github.com/reliant-labs/forge      v0.1.14 -> v0.1.15-0.20260910160302-c195f15386be
  github.com/reliant-labs/forge/pkg  v0.1.14 -> v0.1.15-0.20260910160302-c195f15386be
```

Drift against a deliberately-behind pin (`v0.1.13`, threshold lowered to 3):

```
forge    : v0.1.13 [tag] — 5 commits behind reliant-labs/forge@main  (>= 3)
::warning file=go.mod::forge is 5 commits behind reliant-labs/forge@main ...
```

- `go test -count=1 ./...` — **clean, 0 failures**
- `internal/buildmode` guards pass unchanged

Not deployed, not tagged, not merged.
