### PR TITLE
fix(release): tag the commit that lands on main, and guard that it did

### DIFF
--- a/.github/workflows/release-tag-guard.yml
+++ b/.github/workflows/release-tag-guard.yml
@@ -1,0 +1,118 @@
+# Fails a release whose tag is not an ancestor of main.
+#
+# WHY THIS EXISTS
+# ===============
+#
+# Every tag from v1.7.8 through v1.7.12 is off main. `git describe --tags
+# --abbrev=0 origin/main` still answers v1.7.7, five releases stale.
+#
+# The cause was scripts/release.sh tagging a `release-*` branch that main then
+# SQUASH-merged: the merged commit is a new object, so the tag stayed behind on
+# the branch. Nothing warned, because from the release's point of view
+# everything worked — the tag existed, the artifacts built, the app shipped.
+#
+# The damage is only visible to things that read history from tags, and those
+# fail quietly too. The one that forced the issue: `go get` derives a
+# pseudo-version from the highest tag REACHABLE from the pinned commit, so
+# pinning reliant's main yields `v1.7.8-0.<date>-<sha>` — which sorts BELOW the
+# released v1.7.12. That makes pinning main a version-number DOWNGRADE that is
+# a content UPGRADE, and Go's minimum-version selection can silently undo it.
+#
+# WHY IT RUNS ON TAG PUSH AND NOT ONLY IN THE RELEASE SCRIPT
+# ==========================================================
+#
+# scripts/release-tag.sh performs the same ancestry check before it tags, and
+# that is the better place to CATCH the mistake — it prevents the bad tag
+# instead of reporting it. But a script only guards the tags it creates. A tag
+# made from the GitHub releases UI, from a stale clone, or by hand at 2am never
+# runs it.
+#
+# This workflow sees every tag however it was made, so the two are not
+# redundant: the script makes the right thing easy, and this makes the wrong
+# thing loud. Given the failure mode here was five releases of total silence,
+# both are warranted.
+#
+# WHAT A FAILURE HERE MEANS
+# =========================
+#
+# The tag is already pushed by the time this runs — a `push` trigger cannot
+# prevent one. This job does not delete or move it, deliberately: a published
+# tag is referenced by the Electron artifacts on R2 and by the Homebrew cask,
+# and moving one is the same class of error as re-cutting a burned Go module
+# version. The correct response to a red run here is to cut the NEXT version
+# through the two-phase flow, leaving the bad tag as history.
+
+name: Release tag guard
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  # Also on PRs that touch the release tooling, so a change to the scripts or
+  # to this workflow is exercised before it is relied on during an actual
+  # release. A guard whose own edits are untested is not a guard.
+  pull_request:
+    paths:
+      - "scripts/release.sh"
+      - "scripts/release-tag.sh"
+      - "scripts/check-release-tags.sh"
+      - ".github/workflows/release-tag-guard.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  tag-on-main:
+    name: Tag is an ancestor of main
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # fetch-depth: 0 is LOAD-BEARING. `git merge-base --is-ancestor`
+          # needs real history on both sides; a shallow clone makes every
+          # ancestry query answer "no" and this job would fail every release
+          # for the wrong reason.
+          fetch-depth: 0
+
+      - name: Fetch main and tags
+        # A tag push checks out a detached HEAD with no branch refs, so main
+        # has to be fetched explicitly before it can be compared against.
+        run: |
+          git fetch origin main:refs/remotes/origin/main --tags --force
+          echo "origin/main is at: $(git rev-parse --short origin/main)"
+
+      - name: Check this tag lands on main
+        if: github.ref_type == 'tag'
+        run: ./scripts/check-release-tags.sh --tag "${{ github.ref_name }}"
+
+      - name: Audit all release tags
+        # On PRs and manual runs there is no tag under test, so audit the whole
+        # set. This is what reports drift that predates the change in hand.
+        if: github.ref_type != 'tag'
+        run: ./scripts/check-release-tags.sh
+
+      - name: Explain a failure
+        if: failure()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" << 'EOF'
+          ## ✖ Release tag is not on `main`
+
+          This tag is not an ancestor of `main`, so it is invisible to
+          `git describe`, to changelog-from-tags, and to Go's pseudo-version
+          derivation — pinning `main` will resolve to a version that sorts
+          *below* this release.
+
+          **Do not move or delete the tag.** It may already be referenced by
+          published Electron artifacts and by the Homebrew cask.
+
+          Cut the next version through the two-phase flow instead:
+
+          ```
+          ./scripts/release.sh <patch|minor|major|prerelease>   # opens the PR
+          # ... merge it ...
+          ./scripts/release-tag.sh                              # tags main
+          ```
+          EOF

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ NC := \033[0m # No Color
 MINTLIFY_DOCS_DIR := docs
 MINTLIFY_PORT ?= 3000
 
-.PHONY: all build build-all clean test test-race test-coverage test-ci test-e2e replay-fixtures deps fmt vet lint security help generate generate-cli generate-tools-ref generate-shortcuts generate-nodes generate-types generate-presets generate-workflow-builder-skill generate-changelog generate-mintlify-reference docs docs-build mint changelog changelog-draft postgres-up postgres-down db-driver-audit generate-yaml-bindings build-api-server build-temporal-worker build-tools-daemon build-services docker-build
+.PHONY: all build build-all clean test test-race test-coverage test-ci test-e2e replay-fixtures deps fmt vet lint security help generate generate-cli generate-tools-ref generate-shortcuts generate-nodes generate-types generate-presets generate-workflow-builder-skill generate-changelog generate-mintlify-reference docs docs-build mint changelog changelog-draft postgres-up postgres-down db-driver-audit generate-yaml-bindings build-api-server build-temporal-worker build-tools-daemon build-services docker-build release-rc release-patch release-minor release-major release-tag release-tag-dry-run check-release-tags
 
 # Default target
 all: deps fmt vet test build
@@ -468,7 +468,16 @@ version:
 	@echo "Date:    $(DATE)"
 	@echo "Branch:  $(BRANCH)"
 
-## release-rc: Release new release candidate (0.0.1-rc38 → 0.0.1-rc39)
+# A release is TWO steps. `release-*` opens the version-bump PR; `release-tag`
+# tags the commit once that PR has MERGED.
+#
+# They are separate because main squash-merges — the commit on the release
+# branch is not the commit that lands, so tagging before the merge strands the
+# tag off the trunk. That is what happened to v1.7.8..v1.7.12, and to fifteen
+# older tags; `git describe --tags --abbrev=0 origin/main` still answers
+# v1.7.7. See the header of scripts/release.sh.
+
+## release-rc: Open the version-bump PR for a release candidate (0.0.1-rc38 → 0.0.1-rc39)
 release-rc:
 	@echo "$(YELLOW)Creating new release candidate...$(NC)"
 	@./scripts/release.sh prerelease
@@ -483,10 +492,22 @@ release-minor:
 	@echo "$(YELLOW)Creating minor release...$(NC)"
 	@./scripts/release.sh minor
 
-## release-major: Release major version (0.1.0 → 1.0.0)
+## release-major: Open the version-bump PR for a major release (0.1.0 → 1.0.0)
 release-major:
 	@echo "$(YELLOW)Creating major release...$(NC)"
 	@./scripts/release.sh major
+
+## release-tag: STEP 2 — tag the merged release commit on main (run after the PR merges)
+release-tag:
+	@./scripts/release-tag.sh
+
+## release-tag-dry-run: Preview which commit step 2 would tag, creating nothing
+release-tag-dry-run:
+	@./scripts/release-tag.sh --dry-run
+
+## check-release-tags: Verify every release tag is an ancestor of main
+check-release-tags:
+	@./scripts/check-release-tags.sh
 
 ## info: Show build information
 info:

--- a/contributing/RELEASE_SETUP.md
+++ b/contributing/RELEASE_SETUP.md
@@ -29,10 +29,68 @@ make release-minor        # 0.2.4 → 0.3.0
 make release-major        # 0.3.0 → 1.0.0
 ```
 
-These commands use `./scripts/release.sh` to:
-1. Update `electron/package.json` version
-2. Create a git tag (e.g., `v0.0.1`)
-3. Push the tag — the control-plane's `watch-reliant-image` workflow detects the new tag and triggers the release
+### A release is two steps
+
+Those commands are **step 1 of 2**. They open a version-bump PR and create *no
+tag*. Once that PR has merged:
+
+```bash
+make release-tag              # tags the merged commit on main, starts the builds
+make release-tag-dry-run      # preview which commit would be tagged; creates nothing
+```
+
+Step 1 (`./scripts/release.sh`):
+1. Validates `docs/data/releases/vX.Y.Z.yaml` and regenerates `docs/changelog.mdx`
+2. Updates `electron/package.json` (+ lockfile) on a `release-*` branch
+3. Opens a PR against `main`
+
+Step 2 (`./scripts/release-tag.sh`):
+1. Finds the commit **on `origin/main`** that introduced this version — the bump
+   itself, not main's tip, so work merged after the bump is not swept in
+2. Verifies that commit is an ancestor of `origin/main`, and refuses otherwise
+3. Creates and pushes the tag, which triggers `Release Electron App` and
+   `Build & Push Image`
+
+#### Why it is split
+
+`main` squash-merges — there is not one merge commit in its history. A tag
+created on the `release-*` branch therefore points at a commit that main never
+takes: the squash produces a new object and the tag stays behind on the branch
+forever.
+
+This is not hypothetical. Every tag from **v1.7.8 through v1.7.12** is off
+main, as are fifteen older ones going back to v1.2.3-rc1, and
+`git describe --tags --abbrev=0 origin/main` still answers **v1.7.7**.
+
+Nothing warned, because from the release's point of view everything worked —
+the tag existed, the artifacts built, the app shipped. The damage is only
+visible to things that read history from tags, and those fail quietly too. The
+one that forced the fix: `go get` derives a pseudo-version from the highest tag
+*reachable* from the pinned commit, so pinning reliant's `main` yields
+`v1.7.8-0.<date>-<sha>`, which sorts **below** the released `v1.7.12`. Pinning
+main is then a content upgrade that is a version-number *downgrade*, and Go's
+minimum-version selection can silently undo it.
+
+Tagging after the merge is the only arrangement that is correct by
+construction: tagging a merge commit needs merge commits (main has none), and
+committing the bump straight to main gives up review of the release notes.
+
+#### The guard
+
+```bash
+make check-release-tags       # every release tag must be an ancestor of main
+```
+
+This also runs in CI on every tag push (`.github/workflows/release-tag-guard.yml`),
+so a tag made from the GitHub UI or by hand — which never runs the scripts — is
+caught too.
+
+Tags at or below `BASELINE_TAG` (currently `v1.7.12`) are exempt: they are
+already published, and the Electron artifacts on R2 and the Homebrew cask
+reference them by name. **Do not move or delete a published tag** — it is the
+same class of error as re-cutting a burned Go module version. If a new tag
+lands off main, cut the next version through the two-phase flow rather than
+raising the baseline.
 
 ## Changelog
 

--- a/internal/version/release_tags_test.go
+++ b/internal/version/release_tags_test.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2025 Reliant Labs
+package version_test
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// This file guards the property that makes THIS package's version number mean
+// anything: that a release tag is reachable from main.
+//
+// Every tag from v1.7.8 through v1.7.12 was not. scripts/release.sh cut a
+// `release-*` branch, bumped the version there, tagged that commit and opened
+// a PR; main squash-merges, so the merged commit was a different object and
+// the tag stayed behind on the branch. `git describe --tags --abbrev=0
+// origin/main` answered v1.7.7 for five consecutive releases and nothing
+// noticed, because from the release's point of view everything succeeded.
+//
+// The consequence that forced the fix: `go get` derives a pseudo-version from
+// the highest tag REACHABLE from the pinned commit, so pinning reliant's main
+// produced v1.7.8-0.<date>-<sha> — sorting BELOW the released v1.7.12. Pinning
+// main was a content upgrade that was a version-number downgrade, which Go's
+// minimum-version selection can silently undo.
+//
+// The tests below are cheap and hermetic: they read the release scripts as
+// text and assert on their structure. They deliberately do NOT shell out to
+// git for ancestry — that lives in scripts/check-release-tags.sh, which CI
+// runs on the tag push where the tag actually exists. A unit test cannot see a
+// tag that has not been cut yet, and a test that depends on remote refs is a
+// test that fails on an airplane.
+
+// repoRootFromTest locates the repository root relative to this file, which
+// works regardless of the working directory the test binary is run from.
+func repoRootFromTest(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed; cannot locate the repo root")
+	}
+	// internal/version/release_tags_test.go -> repo root
+	return filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+}
+
+func readScript(t *testing.T, name string) string {
+	t.Helper()
+	path := filepath.Join(repoRootFromTest(t), "scripts", name)
+	out, err := exec.Command("cat", path).Output()
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return string(out)
+}
+
+// TestReleaseScriptDoesNotTag is the direct regression test for the defect.
+//
+// scripts/release.sh runs BEFORE the release PR merges, so any commit it can
+// reach is a commit that main will squash into something else. It must
+// therefore never create a tag — that is the whole bug, in one line of shell.
+//
+// The assertion is on the absence of `git tag`, not on the presence of some
+// comment, because the comment is not what breaks the release.
+func TestReleaseScriptDoesNotTag(t *testing.T) {
+	t.Parallel()
+
+	script := readScript(t, "release.sh")
+
+	for i, line := range strings.Split(script, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") || trimmed == "" {
+			continue
+		}
+		// `git tag` with any argument creates or moves a tag. A bare
+		// `git tag` (listing) and `git tag --list` are reads, but neither
+		// belongs in this script, so the simplest correct rule is: no
+		// `git tag` at all.
+		if strings.Contains(trimmed, "git tag") {
+			t.Errorf("scripts/release.sh:%d creates a tag: %q\n\n"+
+				"release.sh runs before the release PR merges. main squash-merges, so the\n"+
+				"commit this script can reach is NOT the commit that lands — tagging here is\n"+
+				"exactly what stranded v1.7.8..v1.7.12 off the trunk.\n"+
+				"Tagging belongs in scripts/release-tag.sh, which runs after the merge.",
+				i+1, trimmed)
+		}
+	}
+
+	// And it must push no tags either — `git push origin vX.Y.Z` would
+	// publish a tag created some other way.
+	if strings.Contains(script, `git push origin "v$NEW_VERSION"`) {
+		t.Error("scripts/release.sh pushes a version tag; tag publishing belongs in release-tag.sh")
+	}
+}
+
+// TestReleaseTagScriptChecksAncestry pins the guard inside phase 2.
+//
+// release-tag.sh is the one place that decides which commit gets the tag. If
+// its ancestry check is ever removed or weakened, the original defect returns
+// silently and the next person to notice is whoever runs `git describe` months
+// later.
+func TestReleaseTagScriptChecksAncestry(t *testing.T) {
+	t.Parallel()
+
+	script := readScript(t, "release-tag.sh")
+
+	if !strings.Contains(script, "git merge-base --is-ancestor") {
+		t.Error("scripts/release-tag.sh no longer verifies the tagged commit is an ancestor of main.\n" +
+			"That check is the entire point of the script — without it, phase 2 can tag a commit\n" +
+			"that is not on the trunk, which is the defect that stranded v1.7.8..v1.7.12.")
+	}
+
+	// It must reason about origin/main, not a local main. A local main can be
+	// stale or hold another agent's work; the tag has to describe what is
+	// actually published.
+	if !strings.Contains(script, "origin/main") {
+		t.Error("scripts/release-tag.sh must check ancestry against origin/main, not a local branch")
+	}
+
+	// It must refuse to overwrite an existing tag. Published tags are
+	// referenced by Electron artifacts and the Homebrew cask; moving one is
+	// the same class of error as re-cutting a burned Go module version.
+	if !strings.Contains(script, "git ls-remote --exit-code --tags origin") {
+		t.Error("scripts/release-tag.sh must check the REMOTE for an existing tag before creating one")
+	}
+	if strings.Contains(script, "git tag -f") || strings.Contains(script, "push --force") {
+		t.Error("scripts/release-tag.sh must never force-create or force-push a tag")
+	}
+}
+
+// TestBaselineTagIsPinned stops the historical baseline from quietly becoming
+// a suppression mechanism.
+//
+// check-release-tags.sh forgives tags at or below BASELINE_TAG because they
+// are off main AND published — the Electron artifacts on R2 and the Homebrew
+// cask reference them by name, so moving one would break real installs for no
+// gain. (The audit that motivated this found twenty such tags, back to
+// v1.2.3-rc1; the flow has been stranding them intermittently for months.)
+//
+// That baseline is a record of when the two-phase flow landed, not a dial. The
+// cheapest way to make a future off-main tag "pass" is to nudge BASELINE_TAG
+// past it — a one-word change that looks like routine maintenance in a diff.
+// This test converts that into a deliberate edit to an assertion with a reason
+// attached, which is the difference between a decision and an accident.
+func TestBaselineTagIsPinned(t *testing.T) {
+	t.Parallel()
+
+	script := readScript(t, "check-release-tags.sh")
+
+	const wantBaseline = `BASELINE_TAG="v1.7.12"`
+	if !strings.Contains(script, wantBaseline) {
+		t.Errorf("check-release-tags.sh's BASELINE_TAG changed.\n\n"+
+			"expected exactly: %s\n\n"+
+			"The baseline marks the last release cut by the old single-phase flow. Tags after\n"+
+			"it MUST be ancestors of main. Raising it forgives a real off-main release instead\n"+
+			"of fixing it — if a new tag landed off main, cut the next version through the\n"+
+			"two-phase flow (release.sh, merge, release-tag.sh) rather than moving this.",
+			wantBaseline)
+	}
+
+	// The floor must be applied by version comparison, not by string equality
+	// against a list — that is what keeps it readable as the set grows.
+	if !strings.Contains(script, "version_le") {
+		t.Error("check-release-tags.sh must compare tags against BASELINE_TAG by version order")
+	}
+}

--- a/scripts/check-release-tags.sh
+++ b/scripts/check-release-tags.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+
+# Audits every release tag against main, and fails on any NEW one that has
+# drifted off the trunk.
+#
+# Usage: ./scripts/check-release-tags.sh [--tag vX.Y.Z] [--quiet]
+#
+#   (no args)      audit every vX.Y.Z tag in the repo
+#   --tag vX.Y.Z   audit exactly one tag (what CI runs on a tag push)
+#   --quiet        only print failures
+#
+# ── WHAT IT IS FOR ──────────────────────────────────────────────────────────
+#
+# release-tag.sh cannot be the only guard, because it only guards the tags IT
+# creates. A tag made from the GitHub web UI, from a stale clone, or by hand at
+# 2am bypasses it entirely — and the failure is silent: nothing about an
+# off-main tag looks wrong until someone runs `git describe` months later and
+# gets an answer five releases stale.
+#
+# So this runs in CI on the tag push, where it sees every tag however it was
+# made, and it converts that silence into one red run somebody sees.
+#
+# ── THE FROZEN BASELINE, AND WHY IT IS A FLOOR AND NOT A LIST ───────────────
+#
+# The brief described this as five bad tags (v1.7.8..v1.7.12). Auditing the
+# full set found TWENTY of 32 tags off main, going back to v1.2.3-rc1 —
+# v1.3.0, v1.4.0, v1.4.1, v1.6.0-v1.6.3, v1.7.0 and more. The single-phase
+# release flow has been stranding tags intermittently for months; the recent
+# five are simply the ones that started costing something, because commit
+# pinning made the newest tag load-bearing.
+#
+# That rules out an enumerated exemption list. A list of twenty is unreadable,
+# nobody can tell which entries are deliberate, and every future incident
+# arrives as a one-word edit that looks like maintenance.
+#
+# So the baseline is a VERSION FLOOR instead. Every tag at or below the floor
+# is frozen history: published, referenced by Electron artifacts on R2 and by
+# the Homebrew cask, and therefore never to be moved — moving a published tag
+# is the same class of error as re-cutting a burned Go module version. Every
+# tag ABOVE the floor is policed absolutely.
+#
+# The floor is the newest tag that existed when the two-phase flow landed. It
+# encodes a date, not a judgement about any individual tag, which is what makes
+# it safe to read at 2am: raising it is visibly an act of forgiveness for a
+# real release, not a list entry that could plausibly be a typo fix.
+#
+# RAISING THIS IS A LAST RESORT AND ALWAYS WRONG BY DEFAULT. If a new tag lands
+# off main, the fix is to cut the next version through the two-phase flow, not
+# to move the floor past the mistake.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# The last release cut by the old single-phase flow. Tags after this one are
+# required to be ancestors of main.
+BASELINE_TAG="v1.7.12"
+
+# version_le A B — true when A sorts at or below B under version ordering.
+# `sort -V` handles the -rc suffixes consistently with the rest of this repo's
+# tooling (it orders v1.7.12-rc1 before v1.7.12, which is what we want).
+version_le() {
+    [ "$1" = "$2" ] && return 0
+    [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$1" ]
+}
+
+SINGLE_TAG=""
+QUIET=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tag)
+            SINGLE_TAG="${2:-}"
+            if [[ -z "$SINGLE_TAG" ]]; then
+                echo -e "${RED}Error: --tag requires a value${NC}" >&2
+                exit 1
+            fi
+            shift 2
+            ;;
+        --quiet)
+            QUIET=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--tag vX.Y.Z] [--quiet]"
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Error: unrecognized argument '$1'${NC}" >&2
+            exit 1
+            ;;
+    esac
+done
+
+say() { [[ "$QUIET" == "true" ]] || echo -e "$@"; }
+
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    echo -e "${RED}Error: Not in a git repository${NC}" >&2
+    exit 1
+fi
+
+# Prefer origin/main; fall back to a local main so the script is usable in a
+# clone that has not fetched (and in CI, which checks out a detached tag).
+if git rev-parse --verify --quiet origin/main >/dev/null; then
+    MAIN_REF="origin/main"
+elif git rev-parse --verify --quiet main >/dev/null; then
+    MAIN_REF="main"
+else
+    echo -e "${RED}Error: neither origin/main nor main exists — cannot check ancestry.${NC}" >&2
+    echo -e "${YELLOW}  In CI, check out with fetch-depth: 0 and fetch origin main.${NC}" >&2
+    exit 1
+fi
+
+if [[ -n "$SINGLE_TAG" ]]; then
+    TAGS="$SINGLE_TAG"
+else
+    TAGS=$(git tag --list 'v*' --sort=v:refname)
+fi
+
+if [[ -z "$TAGS" ]]; then
+    say "${YELLOW}No release tags found — nothing to check.${NC}"
+    exit 0
+fi
+
+say "${BLUE}Checking release tags against ${MAIN_REF}...${NC}"
+say ""
+
+FAILURES=""
+GRANDFATHERED=0
+ON_MAIN=0
+
+for tag in $TAGS; do
+    if ! git rev-parse --verify --quiet "refs/tags/$tag^{commit}" >/dev/null; then
+        echo -e "${RED}Error: tag '$tag' does not exist${NC}" >&2
+        exit 1
+    fi
+    commit=$(git rev-parse "refs/tags/$tag^{commit}")
+
+    if git merge-base --is-ancestor "$commit" "$MAIN_REF" 2>/dev/null; then
+        ON_MAIN=$((ON_MAIN + 1))
+        say "  ${GREEN}✓${NC} $tag  ${commit:0:9}  on ${MAIN_REF}"
+        continue
+    fi
+
+    # Off main. Is it frozen history (at or below the baseline)?
+    if version_le "$tag" "$BASELINE_TAG"; then
+        GRANDFATHERED=$((GRANDFATHERED + 1))
+        say "  ${YELLOW}—${NC} $tag  ${commit:0:9}  off ${MAIN_REF} (pre-${BASELINE_TAG}, published — left alone deliberately)"
+        continue
+    fi
+
+    FAILURES="$FAILURES $tag"
+    say "  ${RED}✗${NC} $tag  ${commit:0:9}  ${RED}OFF ${MAIN_REF}${NC}"
+done
+
+say ""
+
+if [[ -n "$FAILURES" ]]; then
+    echo -e "${RED}✖ Release tags are not on ${MAIN_REF}:${NC}" >&2
+    for tag in $FAILURES; do
+        echo -e "${RED}    $tag${NC}" >&2
+    done
+    cat >&2 <<'EOF'
+
+WHY THIS MATTERS
+
+  A tag that is not an ancestor of main is invisible to everything that reads
+  history from tags:
+
+    * `git describe` on main reports a stale version.
+    * Changelog-from-tags generates against the wrong range.
+    * `go get` on main derives its pseudo-version from the highest tag
+      REACHABLE from the commit, so pinning main produces a version that sorts
+      BELOW the newest release — a content upgrade that is a version-number
+      downgrade, which Go's minimum-version selection can silently undo.
+    * "What is deployed?" stops being answerable by comparing a tag to main.
+
+HOW THIS HAPPENS
+
+  Tagging a `release-*` branch and then squash-merging it. The squash creates a
+  new commit; the tag stays behind on the branch. That is what produced
+  v1.7.8 through v1.7.12.
+
+THE FIX
+
+  Do NOT move the tag if it is already published — Electron artifacts and the
+  Homebrew cask reference it by name. Cut the next version through the normal
+  two-phase flow instead:
+
+    ./scripts/release.sh <patch|minor|major|prerelease>   # opens the PR
+    # ... merge the PR ...
+    ./scripts/release-tag.sh                              # tags the merged commit
+
+EOF
+    exit 1
+fi
+
+say "${GREEN}✅ All release tags accounted for${NC}"
+say "${BLUE}   ${ON_MAIN} on ${MAIN_REF}, ${GRANDFATHERED} pre-${BASELINE_TAG} historical (published, left alone)${NC}"

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+
+# Phase 2 of a release: tag the commit that ACTUALLY LANDED ON MAIN.
+#
+# Usage: ./scripts/release-tag.sh [vX.Y.Z] [--dry-run]
+#
+# Run this AFTER the release PR opened by ./scripts/release.sh has merged.
+# With no version argument it reads the version from origin/main itself, so
+# the common case is a bare `./scripts/release-tag.sh`.
+#
+# ── WHY THIS IS A SEPARATE COMMAND ──────────────────────────────────────────
+#
+# release.sh used to cut a `release-*` branch, bump the version there, tag THAT
+# commit, and open a PR. main squash-merges (there is not one merge commit in
+# its whole history), so the merged commit is a different object than the one
+# that was tagged — and the tag stayed behind on the branch forever.
+#
+# That is not a hypothetical. Every tag from v1.7.8 through v1.7.12 is off
+# main; `git describe --tags --abbrev=0 origin/main` still answers v1.7.7.
+#
+# The consequence that made it urgent: `go get` on main produces a
+# pseudo-version derived from the highest tag REACHABLE from the pinned commit
+# — v1.7.7 — so pinning main yields `v1.7.8-0.<date>-<sha>`, which sorts BELOW
+# the released v1.7.12. Go's minimum-version selection can then silently undo a
+# pin that is a content upgrade but a version-number downgrade.
+#
+# Tagging after the merge is the only option that is correct by construction
+# here: tagging the merge commit needs merge commits (main has none), and
+# committing straight to main gives up review of the changelog.
+#
+# ── WHY IT IS NOT A WORKFLOW ON MERGE ───────────────────────────────────────
+#
+# Because it would not work, and it would fail silently, which is worse than
+# not existing. A tag pushed with the automatic GITHUB_TOKEN does NOT trigger
+# `on: push: tags` workflows — GitHub suppresses that to prevent recursion. So
+# an auto-tagging job would create the tag and neither `Release Electron App`
+# nor `Build & Push Image` would ever run: a release with no artifacts, and no
+# error anywhere. This repo has no PAT (its secrets are Apple/Azure/R2/GCP
+# signing and publishing credentials plus a Homebrew-tap-scoped token), so the
+# push has to carry a human credential. That is this script.
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+DRY_RUN=false
+REQUESTED_TAG=""
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run)
+            DRY_RUN=true
+            ;;
+        v[0-9]*)
+            REQUESTED_TAG="$arg"
+            ;;
+        -h|--help)
+            echo "Usage: $0 [vX.Y.Z] [--dry-run]"
+            echo ""
+            echo "  vX.Y.Z     Tag this specific version (default: read from origin/main)"
+            echo "  --dry-run  Print exactly what would happen, create and push nothing"
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Error: unrecognized argument '$arg'${NC}" >&2
+            echo "Usage: $0 [vX.Y.Z] [--dry-run]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    echo -e "${RED}Error: Not in a git repository${NC}" >&2
+    exit 1
+fi
+
+# Everything below reasons about origin/main, never the local checkout. A
+# local `main` can be stale, ahead, or someone else's in-flight work; the tag
+# has to describe what is actually published.
+echo -e "${YELLOW}📡 Fetching origin...${NC}"
+git fetch origin main --tags --quiet
+
+if ! git rev-parse --verify --quiet origin/main >/dev/null; then
+    echo -e "${RED}Error: origin/main does not exist${NC}" >&2
+    exit 1
+fi
+
+# ── Which version are we tagging? ───────────────────────────────────────────
+#
+# Read from origin/main's electron/package.json, NOT from the working tree.
+# The working tree can hold an unmerged bump, and tagging a version that main
+# does not carry is precisely the failure this script exists to prevent.
+VERSION_ON_MAIN=$(git show origin/main:electron/package.json | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
+
+if [[ -z "$VERSION_ON_MAIN" ]]; then
+    echo -e "${RED}Error: could not read a version from origin/main:electron/package.json${NC}" >&2
+    exit 1
+fi
+
+if [[ -n "$REQUESTED_TAG" ]]; then
+    RELEASE_TAG="$REQUESTED_TAG"
+    NEW_VERSION="${RELEASE_TAG#v}"
+    if [[ "$NEW_VERSION" != "$VERSION_ON_MAIN" ]]; then
+        echo -e "${RED}Error: you asked to tag $RELEASE_TAG, but origin/main carries version $VERSION_ON_MAIN${NC}" >&2
+        echo -e "${YELLOW}  The release PR for $RELEASE_TAG has not merged yet, or you meant v${VERSION_ON_MAIN}.${NC}" >&2
+        echo -e "${YELLOW}  Tagging a version main does not carry is how a tag ends up describing nothing.${NC}" >&2
+        exit 1
+    fi
+else
+    NEW_VERSION="$VERSION_ON_MAIN"
+    RELEASE_TAG="v$NEW_VERSION"
+fi
+
+echo -e "${BLUE}🏷️  Preparing to tag ${RELEASE_TAG}${NC}"
+
+# ── Has this already been released? ─────────────────────────────────────────
+#
+# Checked against the REMOTE as well as locally. A tag that exists upstream is
+# published — Electron artifacts and the Homebrew cask reference it — and
+# moving it is the same class of error as re-cutting a burned Go module
+# version. This script will never do that.
+if git rev-parse --verify --quiet "refs/tags/$RELEASE_TAG" >/dev/null; then
+    EXISTING=$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")
+    echo -e "${RED}Error: tag $RELEASE_TAG already exists locally (at ${EXISTING:0:9})${NC}" >&2
+    echo -e "${YELLOW}  Published tags are never moved. If this release needs another build, cut a new version.${NC}" >&2
+    exit 1
+fi
+
+if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+    echo -e "${RED}Error: tag $RELEASE_TAG already exists on origin${NC}" >&2
+    echo -e "${YELLOW}  Published tags are never moved. If this release needs another build, cut a new version.${NC}" >&2
+    exit 1
+fi
+
+# ── Which commit gets the tag? ──────────────────────────────────────────────
+#
+# The commit on origin/main that INTRODUCED this version, not origin/main's
+# tip. Main keeps moving while a release is in flight, and tagging the tip
+# would silently sweep whatever merged after the bump into the release.
+#
+# Walk the commits that touched electron/package.json oldest-first and take
+# the first one carrying this version — that is the bump itself.
+echo -e "${YELLOW}🔎 Locating the commit on origin/main that set version ${NEW_VERSION}...${NC}"
+
+RELEASE_COMMIT=""
+while read -r candidate; do
+    [[ -z "$candidate" ]] && continue
+    candidate_version=$(git show "$candidate:electron/package.json" 2>/dev/null \
+        | node -p "try{JSON.parse(require('fs').readFileSync(0,'utf8')).version}catch(e){''}" 2>/dev/null || echo "")
+    if [[ "$candidate_version" == "$NEW_VERSION" ]]; then
+        RELEASE_COMMIT="$candidate"
+        break
+    fi
+done < <(git rev-list --reverse origin/main -- electron/package.json)
+
+if [[ -z "$RELEASE_COMMIT" ]]; then
+    echo -e "${RED}Error: no commit on origin/main sets electron/package.json to ${NEW_VERSION}${NC}" >&2
+    echo -e "${YELLOW}  Has the release PR merged? Run: gh pr list --state open --search 'release v${NEW_VERSION}'${NC}" >&2
+    exit 1
+fi
+
+# ── THE GUARD ───────────────────────────────────────────────────────────────
+#
+# The one check that would have caught this five releases ago. It is cheap,
+# and it is the difference between a release that can be described by
+# `git describe` and one that cannot.
+if ! git merge-base --is-ancestor "$RELEASE_COMMIT" origin/main; then
+    echo -e "${RED}✖ REFUSING TO TAG: ${RELEASE_COMMIT:0:9} is not an ancestor of origin/main${NC}" >&2
+    echo -e "${YELLOW}  A tag off the trunk breaks git describe, changelog-from-tags, and Go pseudo-versions.${NC}" >&2
+    exit 1
+fi
+
+# The changelog for a stable release must be on main too — the tag and the
+# release notes describing it should be the same commit, not two states of the
+# repo that happen to both exist.
+if [[ ! "$NEW_VERSION" =~ -rc ]]; then
+    if ! git cat-file -e "$RELEASE_COMMIT:docs/data/releases/${RELEASE_TAG}.yaml" 2>/dev/null; then
+        echo -e "${RED}Error: docs/data/releases/${RELEASE_TAG}.yaml is not present at ${RELEASE_COMMIT:0:9}${NC}" >&2
+        echo -e "${YELLOW}  The release notes did not land with the version bump.${NC}" >&2
+        exit 1
+    fi
+fi
+
+SUBJECT=$(git log -1 --format=%s "$RELEASE_COMMIT")
+
+echo ""
+echo -e "${GREEN}✅ Verified — this tag will land on main${NC}"
+echo -e "${BLUE}  Tag:     ${RELEASE_TAG}${NC}"
+echo -e "${BLUE}  Commit:  ${RELEASE_COMMIT:0:9}  ${SUBJECT}${NC}"
+echo -e "${BLUE}  Ancestor of origin/main: yes${NC}"
+echo ""
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo -e "${YELLOW}🧪 DRY RUN — nothing was created or pushed.${NC}"
+    echo -e "${BLUE}Would run:${NC}"
+    echo -e "${BLUE}  git tag $RELEASE_TAG $RELEASE_COMMIT${NC}"
+    echo -e "${BLUE}  git push origin $RELEASE_TAG${NC}"
+    exit 0
+fi
+
+echo -e "${YELLOW}🏷️  Creating and pushing ${RELEASE_TAG}...${NC}"
+git tag "$RELEASE_TAG" "$RELEASE_COMMIT"
+git push origin "$RELEASE_TAG"
+
+echo ""
+echo -e "${GREEN}🎉 ${RELEASE_TAG} published on main at ${RELEASE_COMMIT:0:9}${NC}"
+echo -e "${BLUE}📦 GitHub Actions is now building: Release Electron App + Build & Push Image${NC}"
+echo -e "${BLUE}Monitor: https://github.com/reliant-labs/reliant/actions${NC}"
+echo ""
+echo -e "${BLUE}📥 Download URLs (available after the build completes):${NC}"
+echo -e "${BLUE}  Latest:    https://downloads.reliantlabs.io/Reliant-latest-mac-arm64.dmg${NC}"
+echo -e "${BLUE}  Versioned: https://downloads.reliantlabs.io/Reliant-${NEW_VERSION}-mac-arm64.dmg${NC}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,14 +1,44 @@
 #!/bin/bash
 
-# Script to create and publish releases to GitHub and Cloudflare R2
+# PHASE 1 of a release: propose the version bump. Creates NO tag.
 # Usage: ./scripts/release.sh [patch|minor|major|prerelease]
 #
 # This script will:
-# 1. Update version in package.json
-# 2. Create git tag
-# 3. Push tag to GitHub
-# 4. Trigger GitHub Actions to build and publish to R2
-# 5. Make app available for download and auto-update
+# 1. Validate and regenerate the changelog
+# 2. Update the version in electron/package.json (+ lockfile)
+# 3. Open a PR against main
+#
+# Then, once that PR has MERGED:
+#
+#   ./scripts/release-tag.sh        # phase 2 — tags the merged commit on main
+#
+# Phase 2 is what creates the tag and triggers `Release Electron App` and
+# `Build & Push Image`.
+#
+# ── WHY THE TAG MOVED OUT OF THIS SCRIPT ────────────────────────────────────
+#
+# This script used to cut a `release-*` branch, bump the version there, tag
+# THAT commit, and open a PR. main squash-merges — there is not a single merge
+# commit in its history — so the commit that landed was a different object than
+# the one that got tagged, and the tag stayed behind on the branch forever.
+#
+# Every tag from v1.7.8 to v1.7.12 is off main because of this. To this day
+# `git describe --tags --abbrev=0 origin/main` answers v1.7.7.
+#
+# Nothing warned. That is the part worth fixing: the tag was created, pushed,
+# and built artifacts, so the release looked entirely successful. The damage
+# only surfaces when something reads history from tags — `git describe`,
+# changelog-from-tags, or `go get`, which derives a pseudo-version from the
+# highest tag REACHABLE from the pinned commit. Pinning main therefore yields
+# v1.7.8-0.<date>-<sha>, which sorts BELOW the released v1.7.12: a content
+# upgrade that is a version-number downgrade, which Go's minimum-version
+# selection can silently undo.
+#
+# The alternatives were considered and rejected. Tagging the merge commit
+# requires merge commits, and main has none. Committing the bump straight to
+# main removes the review step from the one change whose whole content is
+# human-written release notes. Tagging after the merge is the only option that
+# is correct BY CONSTRUCTION rather than by everyone remembering.
 
 set -e
 
@@ -152,17 +182,18 @@ if [[ "$REQUIRES_CHANGELOG" == "true" ]]; then
     make generate-changelog
 fi
 
-# Check if we're on main branch (protected)
+# Always cut a branch. Even when this is run from a non-main branch, the
+# release commit belongs on its own branch so the PR contains the bump and
+# nothing else.
 CURRENT_BRANCH=$(git branch --show-current)
-if [[ $CURRENT_BRANCH == "main" ]]; then
-    echo -e "${YELLOW}📋 Detected main branch - creating feature branch for release...${NC}"
-    VERSION_BRANCH="release-$NEW_VERSION"
-    git checkout -b $VERSION_BRANCH
+VERSION_BRANCH="release-$NEW_VERSION"
+if [[ $CURRENT_BRANCH != "$VERSION_BRANCH" ]]; then
+    echo -e "${YELLOW}📋 Creating release branch...${NC}"
+    git checkout -b "$VERSION_BRANCH"
     echo -e "${BLUE}Created branch: $VERSION_BRANCH${NC}"
 fi
 
-# Create git tag with v prefix
-echo -e "${YELLOW}🏷️  Creating release commit and tag...${NC}"
+echo -e "${YELLOW}📝 Creating release commit (no tag — see phase 2)...${NC}"
 # `npm version` rewrites BOTH package.json and package-lock.json. Staging
 # only the former left the lockfile's version field behind on every release
 # — by v1.7.8 it still read 1.7.4, three releases stale — and left the
@@ -173,35 +204,41 @@ if [[ "$REQUIRES_CHANGELOG" == "true" ]]; then
     git add "$CHANGELOG_FILE" "$GENERATED_CHANGELOG"
 fi
 git commit -m "chore: release v$NEW_VERSION"
-git tag "$RELEASE_TAG"
 
-# Push changes and tags
-echo -e "${YELLOW}🚀 Publishing release to GitHub...${NC}"
+# NO `git tag` HERE. The commit just created is not the commit that will land
+# on main — main squash-merges, so the merged object is a different one.
+# Tagging here is exactly what stranded v1.7.8..v1.7.12 off the trunk.
+
+echo -e "${YELLOW}🚀 Pushing release branch...${NC}"
 git push origin HEAD
-git push origin "v$NEW_VERSION"
 
-echo -e "${BLUE}📦 GitHub Actions will now build and publish to Cloudflare R2${NC}"
-echo -e "${BLUE}Monitor progress: https://github.com/reliant-labs/reliant/actions${NC}"
+echo -e "${YELLOW}📋 Creating pull request...${NC}"
+PR_BODY="Version bump for v$NEW_VERSION.
 
-# If we created a feature branch, create a PR
-if [[ $CURRENT_BRANCH == "main" ]]; then
-    echo -e "${YELLOW}📋 Creating pull request...${NC}"
-    if command -v gh >/dev/null 2>&1; then
-        gh pr create --title "chore: release v$NEW_VERSION" --body "Automated release of v$NEW_VERSION" --base main --head $VERSION_BRANCH
-        echo -e "${GREEN}✅ Pull request created!${NC}"
-    else
-        echo -e "${YELLOW}GitHub CLI not found. Please create a PR manually:${NC}"
-        echo -e "${BLUE}Branch: $VERSION_BRANCH${NC}"
-        echo -e "${BLUE}Base: main${NC}"
-        echo -e "${BLUE}Title: chore: release v$NEW_VERSION${NC}"
-    fi
+**This PR does not create the tag.** After it merges, run:
+
+\`\`\`
+./scripts/release-tag.sh
+\`\`\`
+
+That tags the *merged* commit on \`main\` and triggers \`Release Electron App\`
+and \`Build & Push Image\`. Tagging this branch instead would strand the tag off
+the trunk once the PR is squash-merged — which is how v1.7.8 through v1.7.12
+ended up unreachable from \`main\`."
+
+if command -v gh >/dev/null 2>&1; then
+    gh pr create --title "chore: release v$NEW_VERSION" --body "$PR_BODY" --base main --head "$VERSION_BRANCH"
+    echo -e "${GREEN}✅ Pull request created!${NC}"
+else
+    echo -e "${YELLOW}GitHub CLI not found. Please create a PR manually:${NC}"
+    echo -e "${BLUE}Branch: $VERSION_BRANCH${NC}"
+    echo -e "${BLUE}Base: main${NC}"
+    echo -e "${BLUE}Title: chore: release v$NEW_VERSION${NC}"
 fi
 
-echo -e "${GREEN}🎉 Release v$NEW_VERSION created and published successfully!${NC}"
-echo -e "${BLUE}📥 Download URLs (available after build completes):${NC}"
-echo -e "${BLUE}  Latest: https://downloads.reliantlabs.io/Reliant-latest-mac-arm64.dmg${NC}"
-echo -e "${BLUE}  Versioned: https://downloads.reliantlabs.io/Reliant-${NEW_VERSION}-mac-arm64.dmg${NC}"
-echo -e "${BLUE}Tag: ${RELEASE_TAG}${NC}"
+echo ""
+echo -e "${GREEN}🎉 Release v$NEW_VERSION proposed — phase 1 of 2 complete.${NC}"
+echo -e "${BLUE}Branch: ${VERSION_BRANCH}${NC}"
 echo -e "${BLUE}Commit: $(git rev-parse --short HEAD)${NC}"
 if [[ "$REQUIRES_CHANGELOG" == "true" ]]; then
     echo -e "${BLUE}Changelog source: ${CHANGELOG_FILE}${NC}"
@@ -209,3 +246,11 @@ if [[ "$REQUIRES_CHANGELOG" == "true" ]]; then
 else
     echo -e "${BLUE}Changelog: skipped for RC prerelease${NC}"
 fi
+echo ""
+echo -e "${YELLOW}⚠️  NO TAG WAS CREATED, AND NOTHING IS BUILDING YET.${NC}"
+echo -e "${YELLOW}   Next steps:${NC}"
+echo -e "${BLUE}     1. Review and merge the PR above${NC}"
+echo -e "${BLUE}     2. ./scripts/release-tag.sh${NC}"
+echo ""
+echo -e "${BLUE}   Step 2 tags the merged commit on main and starts the builds.${NC}"
+echo -e "${BLUE}   Preview it any time with: ./scripts/release-tag.sh --dry-run${NC}"


### PR DESCRIPTION
## The defect

**20 of 32 release tags are not ancestors of `main`** — every tag since v1.7.8, plus fifteen older ones back to `v1.2.3-rc1`. `git describe --tags --abbrev=0 origin/main` still answers **v1.7.7**.

```
$ git merge-base --is-ancestor v1.7.12 origin/main; echo $?
1                       # v1.7.12 is NOT on main
```

`scripts/release.sh` cut a `release-*` branch, bumped the version there, tagged **that** commit, and opened a PR. `main` squash-merges — there is not one merge commit in its history — so the merged commit is a different object and the tag stays behind on the branch forever.

The brief described this as five bad tags. Auditing the full set found twenty; the flow has been stranding them intermittently for months. The recent five are just the ones that started costing something.

## Why now

Nothing warned, and that is the part worth fixing. From the release's point of view everything worked: the tag existed, the artifacts built, the app shipped.

`go get` derives a pseudo-version from the highest tag **reachable** from the pinned commit — v1.7.7 — so pinning `main` yields `v1.7.8-0.<date>-<sha>`:

```
$ printf 'v1.7.8-0.20260910160208-6a997b3bb2e9\nv1.7.12\n' | sort -V
v1.7.8-0.20260910160208-6a997b3bb2e9
v1.7.12                 # <- wins
```

Pinning main is a content **upgrade** that is a version-number **downgrade**, which Go's minimum-version selection can silently undo. That blocks the commit-pinning work in reliant#241 / control-plane#240.

## The fix — two phases

```bash
./scripts/release.sh <type>   # opens the version-bump PR, creates NO tag
# ... merge the PR ...
./scripts/release-tag.sh      # tags the merged commit on main
```

Phase 2 finds the commit on `origin/main` that **introduced** the version — the bump itself, not main's tip, so work merged while the release is in flight is not swept in — verifies it is an ancestor of `origin/main`, and refuses otherwise.

### Why this over the alternatives

- **Tag the merge commit** — impossible. `main` has zero merge commits; it is squash-only.
- **Commit straight to main** — gives up review of the one change whose entire content is human-written release notes.
- **Tag after merge** — correct *by construction* rather than by everyone remembering. Chosen.

### Why phase 2 is a command, not a workflow on merge

It would not work, and it would fail **silently**. A tag pushed with the automatic `GITHUB_TOKEN` does not trigger `on: push: tags` (GitHub's recursion prevention), so `Release Electron App` and `Build & Push Image` would never run — a release with no artifacts and no error anywhere. This repo has no PAT (secrets are Apple/Azure/R2/GCP signing plus a tap-scoped token), so the push must carry a human credential.

## The guard

`scripts/check-release-tags.sh` fails if a release tag is not an ancestor of main. It runs in **two** places, which are not redundant:

| Where | Catches |
|---|---|
| `release-tag.sh`, before tagging | Prevents the bad tag |
| `release-tag-guard.yml`, on tag push | A tag made from the GitHub UI or by hand — which never runs the script |

Given the failure mode was months of silence, both are warranted.

Tags at or below `BASELINE_TAG` (`v1.7.12`) are exempt — they are published, and the Electron artifacts on R2 and the Homebrew cask reference them by name. A **version floor** rather than an enumerated list: twenty entries is unreadable, and every future incident would arrive as a one-word edit that looks like maintenance.

## Verification

- **Guard catches the real defect** — with the floor removed, it flags `v1.7.12` off main, exit 1.
- **Guard passes today** — 12 on main, 20 pre-baseline historical, exit 0.
- **Guard catches a *new* off-main tag** — in a throwaway clone, `v1.7.13` (on main) passes and `v1.7.14` (tagged on a branch, squash-merged) fails.
- **Dry run end to end** — against a simulated merged release, phase 2 selected the bump commit `fd3e862`, *not* main's tip `b3e6634`, and confirmed ancestry. Nothing created.
- **Refusals hold** — declines a version main does not carry; declines to move an already-published tag.
- **Tests fail when the defect is reintroduced** — adding `git tag` back to release.sh and nudging the baseline both fail; both pass when reverted.
- `go build ./...` clean; `go test -count=1 ./...` **118 packages ok, 0 failures**.

**No tag was created, moved, or deleted.** No real release was run.

## Downstream

Neither script needed changes:

- `build-workspace-image-cloud.sh` resolves the go.mod ref with `git rev-parse`, which does not care about ancestry — verified `v1.7.12^{commit}` resolves fine despite being off main.
- The pseudo-version to sha reduction is already handled on control-plane's `chore/pin-by-commit` (#240); not duplicated here.

This fix is what makes that pinning work *correct* — once tags land on main, a pin of main resolves above the last release instead of below it.

## Scope

`scripts/release*.sh`, `scripts/check-release-tags.sh`, `.github/workflows/release-tag-guard.yml`, `internal/version/release_tags_test.go`, plus Makefile targets and release docs. No `internal/**` (beyond the new test), `web/**`, or `electron/**` source touched.
