### PR TITLE
fix(web): keep the worktree store in sync after create and chat unarchive

### DIFF
--- a/web/src/api/worktree-grpc.ts
+++ b/web/src/api/worktree-grpc.ts
@@ -128,18 +128,6 @@ export interface PRInfo {
   state?: string;
 }
 
-export interface BatchCreateWorktreeResult {
-  repo_id: string;
-  worktree?: Worktree;
-  error?: string;
-}
-
-export interface BatchCreateResult {
-  results: BatchCreateWorktreeResult[];
-  all_succeeded: boolean;
-  rolled_back: boolean;
-}
-
 // Per-repo summary row used by the right-sidebar grouped view.
 // Mirrors reliant.v1.WorktreeRepoStatus.
 export interface WorktreeRepoStatus {
@@ -224,13 +212,19 @@ export const worktreeGrpc = {
   // CRUD Operations
   // =============================================================================
 
-  // Create a new worktree
+  // Create a new worktree.
+  //
+  // A worktree always spans every nested repo in the project — one RPC covers
+  // both the single- and multi-repo case. baseBranches pins a base branch per
+  // repo (key = repo_id); repos absent from the map fall back to baseBranch,
+  // then to per-repo default-branch detection on the daemon.
   async create(
     projectId: string,
     name: string,
     branch: string,
     options?: {
       baseBranch?: string;
+      baseBranches?: Record<string, string>;
       chatId?: string;
       copyFiles?: string[];
       force?: boolean;
@@ -243,6 +237,7 @@ export const worktreeGrpc = {
       name,
       branch,
       baseBranch: options?.baseBranch,
+      baseBranches: options?.baseBranches || {},
       chatId: options?.chatId,
       copyFiles: options?.copyFiles || [],
       force: options?.force || false,
@@ -251,48 +246,6 @@ export const worktreeGrpc = {
     const response = await client.createWorktree(request);
     if (!response.worktree) throw new Error("No worktree in response");
     return protoToFrontend(response.worktree);
-  },
-
-  // Create worktrees in multiple repos atomically (all-or-nothing).
-  // baseBranches lets the caller pin a specific base branch per repo (key =
-  // repo_id). Repos missing from the map fall back to baseBranch, then to
-  // per-repo default-branch detection on the daemon.
-  async batchCreate(
-    projectId: string,
-    repoIds: string[],
-    name: string,
-    branch: string,
-    options?: {
-      baseBranch?: string;
-      baseBranches?: Record<string, string>;
-      chatId?: string;
-      copyFiles?: string[];
-      force?: boolean;
-    }
-  ): Promise<BatchCreateResult> {
-    const client = grpcClient.worktree();
-    const request = create(CreateWorktreeRequestSchema, {
-      projectId,
-      name,
-      branch,
-      baseBranch: options?.baseBranch,
-      baseBranches: options?.baseBranches || {},
-      chatId: options?.chatId,
-      copyFiles: options?.copyFiles || [],
-      force: options?.force || false,
-    });
-    const response = await client.createWorktree(request);
-    if (!response.worktree) throw new Error("No worktree in response");
-
-    const worktree = protoToFrontend(response.worktree);
-    return {
-      results: repoIds.map((repoId) => ({
-        repo_id: repoId,
-        worktree,
-      })),
-      all_succeeded: true,
-      rolled_back: false,
-    };
   },
 
   // List worktrees for a project

--- a/web/src/components/Chat/NewChatView.tsx
+++ b/web/src/components/Chat/NewChatView.tsx
@@ -234,9 +234,12 @@ export function NewChatView({
     return () => window.removeEventListener("open-create-worktree-modal", handler);
   }, []);
 
-  const handleWorktreeCreated = (worktreeId: string) => {
-    setSelectedWorkspaceId(worktreeId);
+  const handleWorktreeCreated = async (worktreeId: string) => {
     setShowWorkspaceDropdown(false);
+    // Switch the global context too. Setting local state alone loses the
+    // selection: the sync effect below sees an id that isn't the current
+    // worktree and snaps the toggle back.
+    await handleWorkspaceSelect(worktreeId);
   };
 
   const handleWorktreesImported = (_importedWorktreeIds?: string[]) => {
@@ -246,8 +249,11 @@ export function NewChatView({
   };
 
   const handleWorkspaceSelect = async (worktreeId: string | null) => {
+    // Read from the store rather than the render closure: a workspace created
+    // moments ago is already in the store but not yet in this render's list.
+    const latestWorktrees = useWorktreeStore.getState().worktrees;
     if (worktreeId && currentProject) {
-      const worktree = worktrees.find((w) => w.id === worktreeId);
+      const worktree = latestWorktrees.find((w) => w.id === worktreeId);
       if (worktree) {
         await switchWorktreeContext(currentProject.id, worktree);
         setSelectedWorkspaceId(worktreeId);

--- a/web/src/components/Chat/WorktreeSelector.tsx
+++ b/web/src/components/Chat/WorktreeSelector.tsx
@@ -45,9 +45,13 @@ export function WorktreeSelector({
     const effectiveWorktreeId = worktreeId || mainWorktree?.id || null;
     onWorktreeSelect?.(effectiveWorktreeId);
 
-    // Also update the global current worktree in the store
+    // Also update the global current worktree in the store. Look it up in the
+    // store rather than this render's list, which won't yet contain a
+    // just-created workspace.
     if (currentProject && effectiveWorktreeId) {
-      const worktree = activeWorktrees.find(w => w.id === effectiveWorktreeId);
+      const worktree = useWorktreeStore
+        .getState()
+        .worktrees.find((w) => w.id === effectiveWorktreeId && !w.deleted_at);
       if (worktree) {
         await switchWorktreeContext(currentProject.id, worktree);
       }

--- a/web/src/components/Worktrees/CreateWorktreeModal.tsx
+++ b/web/src/components/Worktrees/CreateWorktreeModal.tsx
@@ -10,8 +10,6 @@ import { Button } from "../ui/Button";
 import { cn } from "../../lib/utils";
 import { WorktreeStatus } from "../../gen/reliant/v1/worktree_pb";
 import { repoGrpc, type Repo } from "../../api/repo-grpc";
-import { worktreeGrpc } from "../../api/worktree-grpc";
-import { toast } from "../../lib/toast-manager";
 import { logger } from "../../lib/logger";
 
 interface CreateWorktreeModalProps {
@@ -237,60 +235,23 @@ export function CreateWorktreeModal({
       // Merge default copy_files with any additional files (e.g., modified/untracked files from source worktree)
       const allCopyFiles = [...new Set([...formData.copy_files, ...additionalCopyFiles])];
 
-      // Multi-repo branch: project has >1 nested repo. The worktree always
-      // spans all of them; only per-repo base-branch overrides are user-tunable.
+      // A worktree always spans every nested repo, so single- and multi-repo
+      // both go through the store. Multi-repo differs only in offering
+      // per-repo base-branch overrides; entries the user left blank are
+      // omitted so the daemon falls back to per-repo default-branch detection.
+      const baseBranchesMap: Record<string, string> = {};
       if (isMultiRepo) {
-        const repoIds = repos.map((r) => r.id);
-        // Only send entries the user actually filled in. Empty values fall
-        // back to daemon-side per-repo default-branch detection.
-        const baseBranchesMap: Record<string, string> = {};
-        for (const id of repoIds) {
-          const v = formData.base_branches[id]?.trim();
-          if (v) baseBranchesMap[id] = v;
+        for (const repo of repos) {
+          const override = formData.base_branches[repo.id]?.trim();
+          if (override) baseBranchesMap[repo.id] = override;
         }
-        const result = await worktreeGrpc.batchCreate(
-          projectId,
-          repoIds,
-          finalName,
-          finalBranch,
-          {
-            baseBranches: baseBranchesMap,
-            copyFiles: allCopyFiles,
-            force: formData.force,
-          }
-        );
-
-        if (result.all_succeeded) {
-          const firstWorktreeId = result.results.find((r) => r.worktree)?.worktree?.id;
-          if (firstWorktreeId) {
-            await onWorktreeCreated(firstWorktreeId);
-          }
-          toast.success(
-            `Workspace "${finalName}" created in ${result.results.length} repos`,
-            { duration: 4000 }
-          );
-          onClose();
-          resetFormState();
-        } else {
-          const failed = result.results.filter((r) => r.error);
-          const lines = failed.map((r) => {
-            const repoName = repos.find((rr) => rr.id === r.repo_id)?.name || r.repo_id;
-            return `${repoName}: ${r.error}`;
-          });
-          const heading = result.rolled_back
-            ? "Batch creation failed; rolled back successful creates"
-            : "Batch creation failed";
-          toast.error(`${heading}\n${lines.join("\n")}`);
-          setError(`${heading}: ${lines.join("; ")}`);
-        }
-        return;
       }
 
-      // Single-repo (or no-repos-discovered) path: legacy single-create RPC.
       const worktree = await createWorktree({
         name: finalName,
         branch: finalBranch,
-        base_branch: formData.base_branch,
+        base_branch: isMultiRepo ? undefined : formData.base_branch,
+        base_branches: isMultiRepo ? baseBranchesMap : undefined,
         project_id: projectId,
         copy_files: allCopyFiles,
         status: WorktreeStatus.ACTIVE,

--- a/web/src/components/Worktrees/__tests__/CreateWorktreeModal.multirepo.test.tsx
+++ b/web/src/components/Worktrees/__tests__/CreateWorktreeModal.multirepo.test.tsx
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const createWorktreeMock = vi.hoisted(() => vi.fn());
+const listReposMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../store/worktreeStore", () => ({
+  useWorktreeStore: Object.assign(
+    (selector: (s: unknown) => unknown) =>
+      selector({ createWorktree: createWorktreeMock }),
+    { getState: () => ({ createWorktree: createWorktreeMock }) }
+  ),
+}));
+
+vi.mock("../../../store/projectStore", () => ({
+  useProjectStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      currentProject: { id: "project-1", is_git_repo: true, default_branch: "main" },
+      refreshCurrentProject: vi.fn(),
+    }),
+}));
+
+vi.mock("../../../api/repo-grpc", () => ({
+  repoGrpc: { list: listReposMock },
+}));
+
+vi.mock("../../../hooks/useBranches", () => ({
+  useBranches: () => ({
+    branches: [],
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+import { CreateWorktreeModal } from "../CreateWorktreeModal";
+
+describe("CreateWorktreeModal in a multi-repo project", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listReposMock.mockResolvedValue({
+      repos: [
+        { id: "repo-a", name: "api", relative_path: "api" },
+        { id: "repo-b", name: "web", relative_path: "web" },
+      ],
+    });
+    createWorktreeMock.mockResolvedValue({ id: "wt-new", name: "feature-x" });
+  });
+
+  // Regression: this path used to call worktreeGrpc.batchCreate directly,
+  // which left the Zustand store unaware of the new workspace — so it did not
+  // appear in any picker until a page reload.
+  it("creates through the worktree store so the store learns about it", async () => {
+    const onWorktreeCreated = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <CreateWorktreeModal
+        isOpen
+        onClose={vi.fn()}
+        onWorktreeCreated={onWorktreeCreated}
+        projectId="project-1"
+      />
+    );
+
+    await waitFor(() => expect(listReposMock).toHaveBeenCalled());
+
+    const nameInput = await screen.findByPlaceholderText(/feature|name/i);
+    await user.type(nameInput, "feature-x");
+
+    const submit = screen.getByRole("button", { name: /create workspace/i });
+    await user.click(submit);
+
+    await waitFor(() => {
+      expect(createWorktreeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          project_id: "project-1",
+          name: "feature-x",
+        })
+      );
+    });
+
+    await waitFor(() => expect(onWorktreeCreated).toHaveBeenCalledWith("wt-new"));
+  });
+});

--- a/web/src/hooks/__tests__/useUnarchiveChat.worktreeRefresh.test.tsx
+++ b/web/src/hooks/__tests__/useUnarchiveChat.worktreeRefresh.test.tsx
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+const unarchiveMock = vi.hoisted(() => vi.fn());
+const refreshWorktreesMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../api/client", () => ({
+  api: {
+    chatsV2: {
+      unarchive: unarchiveMock,
+    },
+  },
+}));
+
+vi.mock("../../store/worktreeStore", () => ({
+  useWorktreeStore: {
+    getState: () => ({
+      refreshWorktrees: refreshWorktreesMock,
+    }),
+  },
+}));
+
+vi.mock("../../store/projectStore", () => ({
+  useProjectStore: {
+    getState: () => ({
+      currentProject: { id: "project-1" },
+    }),
+  },
+}));
+
+import { useUnarchiveChat } from "../chat-queries";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useUnarchiveChat", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    unarchiveMock.mockResolvedValue({ chat: { id: "chat-1" } });
+    refreshWorktreesMock.mockResolvedValue(undefined);
+  });
+
+  // The server unarchives the chat's worktree alongside the chat
+  // (chat_crud.go). Worktrees live in Zustand, which React Query
+  // invalidation cannot reach — without an explicit refresh the sidebar
+  // drops the restored chat because its worktree is still archived locally.
+  it("refreshes the worktree store so the restored chat's workspace reappears", async () => {
+    const { result } = renderHook(() => useUnarchiveChat(), { wrapper });
+
+    await result.current.mutateAsync("chat-1");
+
+    await waitFor(() => {
+      expect(refreshWorktreesMock).toHaveBeenCalledWith("project-1");
+    });
+  });
+});

--- a/web/src/hooks/chat-queries.ts
+++ b/web/src/hooks/chat-queries.ts
@@ -242,9 +242,24 @@ export function useUnarchiveChat() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (chatId: string) => api.chatsV2.unarchive(chatId),
-    onSuccess: () => {
+    onSuccess: async () => {
       queryClient.invalidateQueries({ queryKey: chatKeys.lists() });
       queryClient.invalidateQueries({ queryKey: chatKeys.archived() });
+
+      // Unarchiving a chat also unarchives its workspace server-side. That
+      // lives in Zustand, which query invalidation cannot reach, and the
+      // sidebar hides any chat whose worktree is missing from the store — so
+      // without this the restored chat stays invisible until a page reload.
+      // Imported dynamically: both stores import this module for
+      // getChatFromCache, so a static import would close the cycle.
+      const [{ useProjectStore }, { useWorktreeStore }] = await Promise.all([
+        import("../store/projectStore"),
+        import("../store/worktreeStore"),
+      ]);
+      const projectId = useProjectStore.getState().currentProject?.id;
+      if (projectId) {
+        await useWorktreeStore.getState().refreshWorktrees(projectId);
+      }
     },
   });
 }

--- a/web/src/store/__tests__/worktreeStore.create-multirepo.test.ts
+++ b/web/src/store/__tests__/worktreeStore.create-multirepo.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WorktreeStatus } from "../../gen/reliant/v1/worktree_pb";
+import type { Worktree } from "../worktreeStore";
+
+const createMock = vi.hoisted(() => vi.fn());
+const listMock = vi.hoisted(() => vi.fn());
+const toastSuccessMock = vi.hoisted(() => vi.fn());
+const toastErrorMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../api/worktree-grpc", () => ({
+  worktreeGrpc: {
+    create: createMock,
+    list: listMock,
+  },
+}));
+
+vi.mock("../../lib/toast-manager", () => ({
+  toast: {
+    success: toastSuccessMock,
+    error: toastErrorMock,
+  },
+}));
+
+import { useWorktreeStore } from "../worktreeStore";
+
+const projectId = "project-1";
+const now = "2026-01-01T00:00:00.000Z";
+
+function buildWorktree(overrides: Partial<Worktree>): Worktree {
+  return {
+    id: "wt-main",
+    name: "Main workspace",
+    path: "/tmp/project",
+    branch: "main",
+    base_branch: "main",
+    project_id: projectId,
+    status: WorktreeStatus.UNSPECIFIED,
+    is_main: true,
+    created_at: now,
+    updated_at: now,
+    last_active: now,
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+describe("worktreeStore.createWorktree in a multi-repo project", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useWorktreeStore.getState().reset();
+    useWorktreeStore.setState({
+      worktrees: [buildWorktree({})],
+      hasLoaded: true,
+    });
+
+    createMock.mockResolvedValue({
+      id: "wt-new",
+      name: "new-feature",
+      path: "/tmp/worktrees/wt-new",
+      branch: "new-feature",
+      base_branch: "main",
+      project_id: projectId,
+      status: WorktreeStatus.ACTIVE,
+      is_main: false,
+      created_at: now,
+      updated_at: now,
+      last_active: now,
+    });
+  });
+
+  it("appends the new worktree to the store and selects it", async () => {
+    const created = await useWorktreeStore.getState().createWorktree({
+      project_id: projectId,
+      name: "new-feature",
+      branch: "new-feature",
+      base_branches: { "repo-a": "main", "repo-b": "develop" },
+    });
+
+    expect(created.id).toBe("wt-new");
+    expect(useWorktreeStore.getState().worktrees.map((w) => w.id)).toContain("wt-new");
+    expect(useWorktreeStore.getState().currentWorktree?.id).toBe("wt-new");
+  });
+
+  it("forwards per-repo base branch overrides to the RPC layer", async () => {
+    await useWorktreeStore.getState().createWorktree({
+      project_id: projectId,
+      name: "new-feature",
+      branch: "new-feature",
+      base_branches: { "repo-a": "main", "repo-b": "develop" },
+    });
+
+    expect(createMock).toHaveBeenCalledWith(
+      projectId,
+      "new-feature",
+      "new-feature",
+      expect.objectContaining({
+        baseBranches: { "repo-a": "main", "repo-b": "develop" },
+      })
+    );
+  });
+});
+
+describe("worktreeStore.refreshWorktrees", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useWorktreeStore.getState().reset();
+    useWorktreeStore.setState({
+      worktrees: [buildWorktree({})],
+      hasLoaded: true,
+      lastLoadIncludedArchived: false,
+    });
+  });
+
+  it("refetches even when an identical load is already in flight", async () => {
+    // First call resolves with pre-mutation data, second with post-mutation
+    // data. A singleflight-joined refresh would observe only the first.
+    listMock
+      .mockResolvedValueOnce({
+        worktrees: [
+          {
+            id: "wt-main",
+            name: "Main workspace",
+            path: "/tmp/project",
+            branch: "main",
+            base_branch: "main",
+            project_id: projectId,
+            status: WorktreeStatus.UNSPECIFIED,
+            is_main: true,
+            created_at: now,
+            updated_at: now,
+            last_active: now,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        worktrees: [
+          {
+            id: "wt-main",
+            name: "Main workspace",
+            path: "/tmp/project",
+            branch: "main",
+            base_branch: "main",
+            project_id: projectId,
+            status: WorktreeStatus.UNSPECIFIED,
+            is_main: true,
+            created_at: now,
+            updated_at: now,
+            last_active: now,
+          },
+          {
+            id: "wt-restored",
+            name: "Restored workspace",
+            path: "/tmp/worktrees/wt-restored",
+            branch: "restored",
+            base_branch: "main",
+            project_id: projectId,
+            status: WorktreeStatus.ACTIVE,
+            is_main: false,
+            created_at: now,
+            updated_at: now,
+            last_active: now,
+          },
+        ],
+      });
+
+    const inFlight = useWorktreeStore.getState().loadWorktrees(projectId);
+    const refresh = useWorktreeStore.getState().refreshWorktrees(projectId);
+
+    await Promise.all([inFlight, refresh]);
+
+    expect(listMock).toHaveBeenCalledTimes(2);
+    expect(useWorktreeStore.getState().worktrees.map((w) => w.id)).toContain(
+      "wt-restored"
+    );
+  });
+});

--- a/web/src/store/worktreeStore.ts
+++ b/web/src/store/worktreeStore.ts
@@ -38,6 +38,15 @@ export interface Worktree {
   cleanup_metadata?: CleanupMetadata | null; // Tracks what was deleted during archive
 }
 
+// Create-only inputs. base_branches carries per-repo base-branch overrides
+// (key = repo_id) for multi-repo projects; the server resolves them into each
+// repo's checkout and does not echo them back on the Worktree.
+export type CreateWorktreeInput = Partial<Worktree> & {
+  force?: boolean;
+  source_worktree_id?: string;
+  base_branches?: Record<string, string>;
+};
+
 export interface DiscoveredWorktree {
   path: string;
   name: string;
@@ -102,8 +111,12 @@ interface WorktreeStore {
   lastLoadIncludedArchived: boolean;
 
   loadWorktrees: (projectId?: string, options?: { includeArchived?: boolean }) => Promise<void>;
+  // Like loadWorktrees, but never joins an in-flight request. Use after a
+  // mutation whose effects must be observed: a singleflight-deduplicated load
+  // can return data fetched BEFORE the mutation landed.
+  refreshWorktrees: (projectId?: string, options?: { includeArchived?: boolean }) => Promise<void>;
   selectWorktree: (worktree: Worktree | null, options?: { skipWorkspaceStateSave?: boolean }) => void;
-  createWorktree: (data: Partial<Worktree> & { force?: boolean; source_worktree_id?: string }) => Promise<Worktree>;
+  createWorktree: (data: CreateWorktreeInput) => Promise<Worktree>;
   importWorktree: (data: { path: string; name?: string; project_id: string }) => Promise<Worktree>;
   discoverWorktrees: (projectId: string) => Promise<void>;
   // ONLY archives (sets deleted_at). Never permanently deletes.
@@ -122,6 +135,88 @@ interface WorktreeStore {
 
 function getCurrentLoadOptions(): { includeArchived: boolean } {
   return { includeArchived: useWorktreeStore.getState().lastLoadIncludedArchived };
+}
+
+// Monotonic ticket per fetch, so a slow response cannot overwrite a newer one.
+// Responses can land out of order — a refresh issued after a mutation often
+// resolves before the pre-mutation load it raced — and applying them by
+// arrival order silently restores stale data.
+let loadTicket = 0;
+let lastAppliedTicket = 0;
+
+/**
+ * Fetch worktrees and apply them to the store.
+ *
+ * `dedupe` controls whether the request may join an identical in-flight one.
+ * Reads set it (cheap, and the common case is several components mounting at
+ * once); post-mutation refreshes must not, because an in-flight request that
+ * started before the mutation would resolve with pre-mutation data.
+ */
+async function fetchWorktreesInto(
+  projectId: string,
+  includeArchived: boolean,
+  dedupe: boolean
+): Promise<void> {
+  const set = useWorktreeStore.setState;
+  const ticket = ++loadTicket;
+  set({ isLoading: true, error: null });
+
+  // A response is stale if a later request has already been applied. Stale
+  // responses are dropped entirely, including their isLoading reset — the
+  // newer request still in flight owns that.
+  const isStale = () => ticket < lastAppliedTicket;
+
+  try {
+    const fetchWorktrees = async () => {
+      const response = await worktreeGrpc.list(projectId, { includeArchived });
+      return response.worktrees.map(grpcToStore);
+    };
+
+    const loadedWorktrees = dedupe
+      ? await singleflight(
+          `loadWorktrees:${projectId}:${includeArchived ? "with-archived" : "active"}`,
+          fetchWorktrees
+        )
+      : await fetchWorktrees();
+
+    if (isStale()) {
+      logger.info('[WorktreeStore] Dropping stale worktree load', {
+        projectId,
+        ticket,
+        lastAppliedTicket,
+      });
+      return;
+    }
+    lastAppliedTicket = ticket;
+
+    set({
+      worktrees: loadedWorktrees,
+      isLoading: false,
+      hasLoaded: true,
+      lastLoadIncludedArchived: includeArchived,
+    });
+
+    // Auto-select main worktree if no worktree is currently selected
+    const currentWorktree = useWorktreeStore.getState().currentWorktree;
+    if (!currentWorktree) {
+      const mainWorktree = loadedWorktrees.find(w => w.is_main && w.project_id === projectId);
+      if (mainWorktree) {
+        logger.info('[WorktreeStore] Auto-selecting main worktree after load', {
+          worktreeId: mainWorktree.id,
+          name: mainWorktree.name,
+        });
+        useWorktreeStore.getState().selectWorktree(mainWorktree, { skipWorkspaceStateSave: true });
+      }
+    }
+  } catch (error) {
+    if (isStale()) return;
+    lastAppliedTicket = ticket;
+    set({
+      error: getErrorMessage(error, 'Failed to load worktrees'),
+      isLoading: false,
+      hasLoaded: true,
+    });
+  }
 }
 
 type ArchivedWorktreeActiveChatSnapshot = {
@@ -186,41 +281,18 @@ export const useWorktreeStore = create<WorktreeStore>((set) => ({
       set({ worktrees: [], isLoading: false, hasLoaded: true, lastLoadIncludedArchived: false });
       return;
     }
-    set({ isLoading: true, error: null });
-    try {
-      // Use singleflight to deduplicate concurrent calls for the same project
-      // (e.g., selectProject + useWorkspaceRestore both calling loadWorktrees)
-      const includeArchived = options?.includeArchived ?? false;
-      const loadedWorktrees = await singleflight(`loadWorktrees:${projectId}:${includeArchived ? "with-archived" : "active"}`, async () => {
-        const response = await worktreeGrpc.list(projectId, { includeArchived });
-        return response.worktrees.map(grpcToStore);
-      });
-      set({
-        worktrees: loadedWorktrees,
-        isLoading: false,
-        hasLoaded: true,
-        lastLoadIncludedArchived: includeArchived,
-      });
-      
-      // Auto-select main worktree if no worktree is currently selected
-      const currentWorktree = useWorktreeStore.getState().currentWorktree;
-      if (!currentWorktree) {
-        const mainWorktree = loadedWorktrees.find(w => w.is_main && w.project_id === projectId);
-        if (mainWorktree) {
-          logger.info('[WorktreeStore] Auto-selecting main worktree after load', {
-            worktreeId: mainWorktree.id,
-            name: mainWorktree.name,
-          });
-          useWorktreeStore.getState().selectWorktree(mainWorktree, { skipWorkspaceStateSave: true });
-        }
-      }
-    } catch (error) {
-      set({
-        error: getErrorMessage(error, 'Failed to load worktrees'),
-        isLoading: false,
-        hasLoaded: true,
-      });
-    }
+    // Deduplicate concurrent calls for the same project (e.g. selectProject +
+    // useWorkspaceRestore both calling loadWorktrees).
+    await fetchWorktreesInto(projectId, options?.includeArchived ?? false, true);
+  },
+
+  refreshWorktrees: async (projectId?: string, options?: { includeArchived?: boolean }) => {
+    if (!projectId) return;
+    await fetchWorktreesInto(
+      projectId,
+      options?.includeArchived ?? useWorktreeStore.getState().lastLoadIncludedArchived,
+      false
+    );
   },
 
   selectWorktree: (worktree: Worktree | null, options?: { skipWorkspaceStateSave?: boolean }) => {
@@ -257,7 +329,7 @@ export const useWorktreeStore = create<WorktreeStore>((set) => ({
     }
   },
 
-  createWorktree: async (data: Partial<Worktree> & { force?: boolean; source_worktree_id?: string }) => {
+  createWorktree: async (data: CreateWorktreeInput) => {
     set({ isLoading: true, error: null });
     try {
       if (!data.project_id || !data.name || !data.branch) {
@@ -270,6 +342,7 @@ export const useWorktreeStore = create<WorktreeStore>((set) => ({
         data.branch,
         {
           baseBranch: data.base_branch,
+          baseBranches: data.base_branches,
           chatId: data.chat_id,
           copyFiles: data.copy_files,
           force: data.force,
@@ -679,6 +752,8 @@ export const useWorktreeStore = create<WorktreeStore>((set) => ({
   },
 
   reset: () => {
+    // Any in-flight load predates this reset, so let it be dropped on arrival.
+    lastAppliedTicket = loadTicket;
     set({
       worktrees: [],
       currentWorktree: null,


### PR DESCRIPTION
Two paths mutated worktrees without telling the Zustand store that holds them, so the UI only caught up on a manual refresh. Both were reported as "it didn't show until I hit refresh," but the causes are unrelated.

## A new workspace didn't appear, and the toggle snapped back

`CreateWorktreeModal` had two creation paths. The multi-repo path — the one that runs whenever a project has nested repos — called `worktreeGrpc.batchCreate` directly instead of going through `worktreeStore.createWorktree`, so the store never learned the new worktree existed and it was missing from every picker.

That also explains the selection reverting. `NewChatView.handleWorktreeCreated` only set local component state; the sync effect below it then looked that id up in `worktrees`, didn't find it, concluded the selection was invalid, and reset to the main worktree. The selection was being actively undone a moment after the user made it.

`batchCreate` was additionally a fiction: it issued the **same single** `createWorktree` RPC as `create()`, then fabricated per-repo results with `all_succeeded` hardcoded to `true` — so the modal's multi-repo error handling was unreachable dead code that could never surface a real failure. Removed. `base_branches` already rides on the single request, so one call genuinely covers both cases.

## An unarchived chat's workspace stayed hidden

The server does the right thing — `chat_crud.go` unarchives the associated worktree when a chat is unarchived. But `useUnarchiveChat` only invalidated React Query chat keys, and worktrees are not in React Query; they are in Zustand, which invalidation cannot reach. The sidebar drops any chat whose worktree is absent from that store, so the restored chat stayed invisible until a reload.

## A latent race the fix uncovered

The first attempt at refreshing did not work, which is worth knowing about. `loadWorktrees` wraps its fetch in `singleflight`, so a refresh issued right after a mutation can **join** a request that started before it and get pre-mutation data back. Worse, the test showed the stale response landing last and overwriting the fresh one.

This adds `refreshWorktrees`, which skips deduplication for post-mutation refreshes, plus a monotonic ticket so a slow response can never clobber a newer one. `reset()` invalidates in-flight loads the same way.

## Verification

Three new tests. Each was confirmed to **fail before its fix and pass after** by temporarily reverting each change in isolation, rather than assuming they would catch the bug — the modal test fails with exactly the "store never called" assertion when the old bypass is restored.

- 836 tests pass across 128 files (`store`, `hooks`, `components/Worktrees`, `components/Chat`)
- `npx tsc --noEmit` clean
- `npx eslint` clean on all changed files

Unrelated and left alone: `QuickFileOpen.test.tsx` leaks a `setTimeout` past teardown and logs an unhandled `document is not defined`. It is pre-existing, in a file this PR does not touch, but it is real and will keep producing noise.
