### PR TITLE
chore: require forge + forge/pkg v0.1.15, changelog for v1.7.13

### DIFF
--- a/docs/data/releases/v1.7.13.yaml
+++ b/docs/data/releases/v1.7.13.yaml
@@ -1,0 +1,13 @@
+version: "v1.7.13"
+date: "2026-09-10"
+title: "The chat list stops rearranging itself, and new workspaces show up straight away"
+summary: "A maintenance release. The chat list now keeps a steady order instead of reshuffling whenever any conversation is touched, workspaces you create appear immediately rather than after a manual refresh, and a chat whose provider goes quiet now explains itself instead of showing a bare internal code."
+items:
+  - title: "The chat list no longer rearranges itself while you work"
+    description: "The list arrived from the server ordered by whichever conversation was touched most recently, so activity in a chat you were not looking at could reorder the ones you were. Ordering is now decided entirely by the chats themselves, with ties broken consistently, so the list stays put unless something you care about actually changes."
+  - title: "A workspace you create appears immediately"
+    description: "Creating a workspace in a project with more than one repository saved it without telling the part of the app that tracks workspaces, so it was missing from every picker until you refreshed — and the selection would snap back to the main branch on its own. Unarchiving a chat had the same gap. Both now update the app's view of your workspaces as soon as the change is made."
+  - title: "A stalled provider now explains itself"
+    description: "When a provider accepted a request and then went silent until the turn was cut, the message you saw ended in a bracketed internal code. That tail is now removed before the message is shown, leaving the readable explanation — which provider stalled, and that the turn is being retried."
+  - title: "Release tags are now guaranteed to match what shipped"
+    description: "Version tags were being created from whichever commit happened to be checked out, which could differ from the commit that actually landed. Tagging now targets the commit on the main branch and verifies it before publishing, so a released version always corresponds to the code that shipped."

--- a/go.mod
+++ b/go.mod
@@ -34,8 +34,8 @@ require (
 	github.com/pressly/goose/v3 v3.28.0
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.3
-	github.com/reliant-labs/forge v0.1.15-0.20260910160302-c195f15386be
-	github.com/reliant-labs/forge/pkg v0.1.15-0.20260910160302-c195f15386be
+	github.com/reliant-labs/forge v0.1.15
+	github.com/reliant-labs/forge/pkg v0.1.15
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/sqlc-dev/pqtype v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -460,10 +460,10 @@ github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEo
 github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
 github.com/prometheus/procfs v0.22.0 h1:6q9+/JL9IKAPbCmBrv9n5O5Ty3NKnciV5X7YGw0oics=
 github.com/prometheus/procfs v0.22.0/go.mod h1:CvmFr/GVhIjIvWJZW3tgkODBQMRIf0EyWMQLHCHab58=
-github.com/reliant-labs/forge v0.1.15-0.20260910160302-c195f15386be h1:bt0nEl+zcZr9ia+GyFHG5TLYvi2yTtL2xktBJXk6kEw=
-github.com/reliant-labs/forge v0.1.15-0.20260910160302-c195f15386be/go.mod h1:MRwzgDMi+42IIWfq4WHzFGy8hWEEH1KRFe3bBccVKkA=
-github.com/reliant-labs/forge/pkg v0.1.15-0.20260910160302-c195f15386be h1:wsn/pVRg3nnj9Zgdyvel6jQhi/VCTEgNRNHtWzXrPGc=
-github.com/reliant-labs/forge/pkg v0.1.15-0.20260910160302-c195f15386be/go.mod h1:sfx6mK8xPMq8RqvfpkNa3mj4mBp7CDOKaNyTZLmX1QE=
+github.com/reliant-labs/forge v0.1.15 h1:+rbpxz6x577Frmui/gO2+W7yo2mhUQJE6IQF+heYnXs=
+github.com/reliant-labs/forge v0.1.15/go.mod h1:jQJeYlwG/SF3tMAL2uEo/GiGWUZ4e6hywH9N25vOark=
+github.com/reliant-labs/forge/pkg v0.1.15 h1:8XZs7RYeJAtpMQrgFzF8Pzu6PeM9BHC5dXoJ1m5iCEE=
+github.com/reliant-labs/forge/pkg v0.1.15/go.mod h1:sfx6mK8xPMq8RqvfpkNa3mj4mBp7CDOKaNyTZLmX1QE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
Moves both forge pins off the unreleased pseudo-version `v0.1.15-0.20260910160302-c195f15386be` onto the real `v0.1.15` tag, and adds the v1.7.13 changelog that `scripts/release.sh` validates.

Gate: `GOWORK=off go build ./...` clean — the consumer's view, so the hashes really are in go.sum.

First step of the full release chain: forge v0.1.15 (tagged) → reliant v1.7.13 → control-plane.