### PR TITLE
fix(release): give the Windows portable build its own artifact name

### DIFF
--- a/electron/electron-builder.common.js
+++ b/electron/electron-builder.common.js
@@ -156,6 +156,18 @@ const config = {
 
   artifactName: "${productName}-${version}-${os}-${arch}.${ext}",
 
+  // The portable build needs its OWN name. Both win targets are .exe for x64,
+  // so the global artifactName above resolves them to the same
+  // Reliant-<version>-win-x64.exe: portable overwrites the NSIS installer on
+  // disk and then re-uploads that key to R2. The second PUT of a key already
+  // being served has failed the publish step with `read ECONNRESET` three
+  // times in a row on v1.7.13 — after the installers were uploaded but BEFORE
+  // latest.yml was written, so Windows shipped binaries that no client was
+  // ever offered (the feed stayed on 1.7.11).
+  portable: {
+    artifactName: "${productName}-${version}-${os}-${arch}-portable.${ext}"
+  },
+
   dmg: {
     sign: false,
     writeUpdateInfo: true


### PR DESCRIPTION
## The bug

Both `win` targets produce an x64 `.exe`, and the global `artifactName` resolves them to the **same** `Reliant-<version>-win-x64.exe`. The portable build overwrites the NSIS installer on disk, then re-uploads that same key to R2.

That second PUT failed with `read ECONNRESET` on **all three attempts** of the v1.7.13 release.

## Why it matters more than it looks

The upload dies *after* the installers upload but *before* `latest.yml` is written. So v1.7.13 published three working Windows binaries that **no client was ever offered** — the update feed is still on 1.7.11:

```
Reliant-1.7.13-win-x64.exe     200
Reliant-1.7.13-win-arm64.exe   200
Reliant-1.7.13-win.exe         200
latest.yml                     version: 1.7.11   ← stuck
```

v1.7.11 survived the identical duplicate upload, which is what made this look transient. It is not — it reproduced three times at the same step.

## The fix

Give `portable` its own `artifactName`. Every other electron-builder config spreads from `common`, so they all inherit it.

Found while cutting the v1.7.13 release.