### PR TITLE
feat(auth): open the localhost OAuth helper on demand, over the daemon connection

### DIFF
--- a/cmd/reliant/commands/auth_serve.go
+++ b/cmd/reliant/commands/auth_serve.go
@@ -2,55 +2,16 @@
 package commands
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
-	"github.com/reliant-labs/reliant/internal/auth/oauthcallback"
-	"github.com/reliant-labs/reliant/internal/logging"
+	"github.com/reliant-labs/reliant/internal/auth/oauthhelper"
 	"github.com/spf13/cobra"
 )
-
-const defaultAuthServePort = 19284
-
-// hostedWebOrigin is the production reliant web app's origin — the same
-// hosted address as web/src/lib/constants.ts's DEFAULT_APP_URL and
-// electron/release.config.json's VITE_APP_URL. There is no shared Go constant
-// for it (builddefaults only carries the API/gateway/auth-provider origins),
-// so it is declared here alongside the local dev origins the web app runs on.
-const hostedWebOrigin = "https://app.reliantlabs.io"
-
-// allowedOrigins is the CORS/CSRF allowlist for this localhost helper, whose
-// only legitimate caller is the reliant web app. RELIANT_WEB_ORIGIN
-// (comma-separated) extends it — needed because the web dev server's port is
-// dynamically allocated per worktree (see .dev-ports.sh FRONTEND_PORT) and
-// won't always be one of the defaults below.
-var allowedOrigins = buildAllowedOrigins()
-
-func buildAllowedOrigins() map[string]bool {
-	origins := []string{
-		hostedWebOrigin,
-		"http://localhost:5173", // vite dev default (web/README.md)
-		"http://localhost:3000", // common dev port (web/src/routes.tsx, scripts/dev.sh)
-	}
-	if extra := os.Getenv("RELIANT_WEB_ORIGIN"); extra != "" {
-		for _, o := range strings.Split(extra, ",") {
-			if o = strings.TrimSpace(o); o != "" {
-				origins = append(origins, o)
-			}
-		}
-	}
-	set := make(map[string]bool, len(origins))
-	for _, o := range origins {
-		set[o] = true
-	}
-	return set
-}
 
 func newAuthServeCmd() *cobra.Command {
 	var port int
@@ -61,12 +22,14 @@ func newAuthServeCmd() *cobra.Command {
 		Long: `Starts a lightweight HTTP server on localhost that handles OAuth
 callback flows for Claude and Codex authentication.
 
-This is required when using the Reliant web UI in a browser (not Electron)
-to connect Claude Code or Codex accounts via OAuth, since the OAuth
-callbacks must be received on localhost.
+USUALLY YOU DO NOT NEED THIS. ` + "`reliant daemon start`" + ` serves the same
+endpoints when it runs on the machine your browser is on, so a local daemon
+already covers it. Run this when the daemon is REMOTE (or not running) and you
+still want to connect an account from this machine — the OAuth provider
+redirects to localhost, which only exists where your browser is.
 
 The server exposes:
-  GET  /health       — Health check (for the frontend to detect availability)
+  GET  /health       — identity + readiness (service, version), for the web app's probe
   POST /oauth/start  — Start an OAuth flow (opens browser, waits for callback)
 
 Example:
@@ -77,92 +40,30 @@ Example:
 		},
 	}
 
-	cmd.Flags().IntVar(&port, "port", defaultAuthServePort, "Port to listen on")
+	cmd.Flags().IntVar(&port, "port", oauthhelper.DefaultPort, "Port to listen on")
 
 	return cmd
 }
 
 func runAuthServe(cmd *cobra.Command, port int) error {
-	mux := http.NewServeMux()
-
-	// Health check
-	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
-		setCORS(w, r)
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	srv, err := oauthhelper.Start(oauthhelper.Options{
+		Port:   port,
+		Source: "auth-serve",
 	})
+	if err != nil {
+		return err
+	}
 
-	// CORS preflight
-	mux.HandleFunc("OPTIONS /", func(w http.ResponseWriter, r *http.Request) {
-		setCORS(w, r)
-		w.WriteHeader(http.StatusNoContent)
-	})
-
-	// Start OAuth flow
-	mux.HandleFunc("POST /oauth/start", func(w http.ResponseWriter, r *http.Request) {
-		setCORS(w, r)
-
-		if origin := r.Header.Get("Origin"); origin != "" && !allowedOrigins[origin] {
-			writeJSON(w, http.StatusForbidden, map[string]string{"error": "origin not allowed"})
-			return
-		}
-
-		var req struct {
-			AuthorizeURLTemplate string `json:"authorize_url_template"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
-			return
-		}
-
-		if req.AuthorizeURLTemplate == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "authorize_url_template is required"})
-			return
-		}
-
-		result, err := oauthcallback.Run(r.Context(), req.AuthorizeURLTemplate)
-		if err != nil {
-			logging.Error("OAuth callback failed", "error", err)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-			return
-		}
-
-		writeJSON(w, http.StatusOK, result)
-	})
-
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
-
-	fmt.Fprintf(cmd.OutOrStdout(), "OAuth helper server listening on http://%s\n", addr)
+	fmt.Fprintf(cmd.OutOrStdout(), "OAuth helper server listening on http://%s\n", srv.Addr())
 	fmt.Fprintf(cmd.OutOrStdout(), "Press Ctrl+C to stop\n")
 
-	server := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	<-sigCh
 
-	// Graceful shutdown on interrupt
-	go func() {
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-		<-sigCh
-		fmt.Fprintln(cmd.OutOrStdout(), "\nShutting down...")
-		_ = server.Close()
-	}()
-
-	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		return fmt.Errorf("server failed: %w", err)
-	}
-
-	return nil
-}
-
-func setCORS(w http.ResponseWriter, r *http.Request) {
-	if origin := r.Header.Get("Origin"); origin != "" && allowedOrigins[origin] {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-}
-
-func writeJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(v)
+	fmt.Fprintln(cmd.OutOrStdout(), "\nShutting down...")
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return srv.Shutdown(shutdownCtx)
 }

--- a/cmd/reliant/commands/daemon.go
+++ b/cmd/reliant/commands/daemon.go
@@ -601,6 +601,14 @@ Credential resolution order:
 			defer shell.GetBackgroundManager().KillAllRunning()
 			defer shell.GetProcessMonitor().Stop()
 
+			// NOTE: the localhost OAuth helper is NOT started here. It is
+			// opened ON DEMAND by the `auth.open_oauth_helper` daemon command
+			// (internal/toolexec/daemonruntime/cmd_oauth_helper.go) when the
+			// web app asks for it, and closed when the linking session ends.
+			// A port that starts browsers and returns authorization codes
+			// should exist for the seconds it is needed, not for the life of
+			// every daemon on every machine.
+
 			// In server mode, skip credential resolution — the gateway dials
 			// into us and already knows our identity from the NATS connect command.
 			if serverMode {
@@ -744,6 +752,7 @@ Credential resolution order:
 	}
 
 	cmd.Flags().StringVar(&port, "port", envOrDefault("TOOLS_DAEMON_PORT", "9190"), "Daemon listen port")
+
 	cmd.Flags().StringVar(&grpcURL, "grpc-url", envOrDefault("DAEMON_GRPC_URL", ""), "gRPC server URL to connect to")
 	cmd.Flags().StringVar(&dataDir, "data-dir", envOrDefault("DAEMON_DATA_DIR", "./data"), "Data directory")
 

--- a/gen/reliant/v1/daemon.pb.go
+++ b/gen/reliant/v1/daemon.pb.go
@@ -23,6 +23,201 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type OpenOAuthHelperRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Browser origin that will call the helper, added to its CORS allowlist.
+	//
+	// Passed from the UI because the daemon cannot know it: a worktree's web dev
+	// server gets a per-worktree port, so the origin is neither one of the
+	// static defaults nor present in the daemon's environment. Without it the
+	// allowlist would reject the very caller that asked for the port.
+	WebOrigin     string `protobuf:"bytes,1,opt,name=web_origin,json=webOrigin,proto3" json:"web_origin,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OpenOAuthHelperRequest) Reset() {
+	*x = OpenOAuthHelperRequest{}
+	mi := &file_reliant_v1_daemon_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OpenOAuthHelperRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OpenOAuthHelperRequest) ProtoMessage() {}
+
+func (x *OpenOAuthHelperRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_reliant_v1_daemon_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OpenOAuthHelperRequest.ProtoReflect.Descriptor instead.
+func (*OpenOAuthHelperRequest) Descriptor() ([]byte, []int) {
+	return file_reliant_v1_daemon_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *OpenOAuthHelperRequest) GetWebOrigin() string {
+	if x != nil {
+		return x.WebOrigin
+	}
+	return ""
+}
+
+type OpenOAuthHelperResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Port the helper is listening on.
+	Port int32 `protobuf:"varint,1,opt,name=port,proto3" json:"port,omitempty"`
+	// Full loopback address, for the probe URL.
+	Addr string `protobuf:"bytes,2,opt,name=addr,proto3" json:"addr,omitempty"`
+	// True when the port was already served (a previous session, or a standalone
+	// `reliant auth serve`). Not an error — the surface exists either way.
+	AlreadyRunning bool `protobuf:"varint,3,opt,name=already_running,json=alreadyRunning,proto3" json:"already_running,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *OpenOAuthHelperResponse) Reset() {
+	*x = OpenOAuthHelperResponse{}
+	mi := &file_reliant_v1_daemon_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OpenOAuthHelperResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OpenOAuthHelperResponse) ProtoMessage() {}
+
+func (x *OpenOAuthHelperResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_reliant_v1_daemon_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OpenOAuthHelperResponse.ProtoReflect.Descriptor instead.
+func (*OpenOAuthHelperResponse) Descriptor() ([]byte, []int) {
+	return file_reliant_v1_daemon_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *OpenOAuthHelperResponse) GetPort() int32 {
+	if x != nil {
+		return x.Port
+	}
+	return 0
+}
+
+func (x *OpenOAuthHelperResponse) GetAddr() string {
+	if x != nil {
+		return x.Addr
+	}
+	return ""
+}
+
+func (x *OpenOAuthHelperResponse) GetAlreadyRunning() bool {
+	if x != nil {
+		return x.AlreadyRunning
+	}
+	return false
+}
+
+type CloseOAuthHelperRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CloseOAuthHelperRequest) Reset() {
+	*x = CloseOAuthHelperRequest{}
+	mi := &file_reliant_v1_daemon_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CloseOAuthHelperRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CloseOAuthHelperRequest) ProtoMessage() {}
+
+func (x *CloseOAuthHelperRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_reliant_v1_daemon_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CloseOAuthHelperRequest.ProtoReflect.Descriptor instead.
+func (*CloseOAuthHelperRequest) Descriptor() ([]byte, []int) {
+	return file_reliant_v1_daemon_proto_rawDescGZIP(), []int{2}
+}
+
+type CloseOAuthHelperResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// False when nothing was open.
+	Closed        bool `protobuf:"varint,1,opt,name=closed,proto3" json:"closed,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CloseOAuthHelperResponse) Reset() {
+	*x = CloseOAuthHelperResponse{}
+	mi := &file_reliant_v1_daemon_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CloseOAuthHelperResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CloseOAuthHelperResponse) ProtoMessage() {}
+
+func (x *CloseOAuthHelperResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_reliant_v1_daemon_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CloseOAuthHelperResponse.ProtoReflect.Descriptor instead.
+func (*CloseOAuthHelperResponse) Descriptor() ([]byte, []int) {
+	return file_reliant_v1_daemon_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *CloseOAuthHelperResponse) GetClosed() bool {
+	if x != nil {
+		return x.Closed
+	}
+	return false
+}
+
 type StartOAuthFlowRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Full OAuth authorize URL with {redirect_uri} placeholder.
@@ -33,7 +228,7 @@ type StartOAuthFlowRequest struct {
 
 func (x *StartOAuthFlowRequest) Reset() {
 	*x = StartOAuthFlowRequest{}
-	mi := &file_reliant_v1_daemon_proto_msgTypes[0]
+	mi := &file_reliant_v1_daemon_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -45,7 +240,7 @@ func (x *StartOAuthFlowRequest) String() string {
 func (*StartOAuthFlowRequest) ProtoMessage() {}
 
 func (x *StartOAuthFlowRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_reliant_v1_daemon_proto_msgTypes[0]
+	mi := &file_reliant_v1_daemon_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58,7 +253,7 @@ func (x *StartOAuthFlowRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartOAuthFlowRequest.ProtoReflect.Descriptor instead.
 func (*StartOAuthFlowRequest) Descriptor() ([]byte, []int) {
-	return file_reliant_v1_daemon_proto_rawDescGZIP(), []int{0}
+	return file_reliant_v1_daemon_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *StartOAuthFlowRequest) GetAuthorizeUrlTemplate() string {
@@ -82,7 +277,7 @@ type StartOAuthFlowResponse struct {
 
 func (x *StartOAuthFlowResponse) Reset() {
 	*x = StartOAuthFlowResponse{}
-	mi := &file_reliant_v1_daemon_proto_msgTypes[1]
+	mi := &file_reliant_v1_daemon_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -94,7 +289,7 @@ func (x *StartOAuthFlowResponse) String() string {
 func (*StartOAuthFlowResponse) ProtoMessage() {}
 
 func (x *StartOAuthFlowResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_reliant_v1_daemon_proto_msgTypes[1]
+	mi := &file_reliant_v1_daemon_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -107,7 +302,7 @@ func (x *StartOAuthFlowResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartOAuthFlowResponse.ProtoReflect.Descriptor instead.
 func (*StartOAuthFlowResponse) Descriptor() ([]byte, []int) {
-	return file_reliant_v1_daemon_proto_rawDescGZIP(), []int{1}
+	return file_reliant_v1_daemon_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *StartOAuthFlowResponse) GetCode() string {
@@ -136,15 +331,27 @@ var File_reliant_v1_daemon_proto protoreflect.FileDescriptor
 const file_reliant_v1_daemon_proto_rawDesc = "" +
 	"\n" +
 	"\x17reliant/v1/daemon.proto\x12\n" +
-	"reliant.v1\"M\n" +
+	"reliant.v1\"7\n" +
+	"\x16OpenOAuthHelperRequest\x12\x1d\n" +
+	"\n" +
+	"web_origin\x18\x01 \x01(\tR\twebOrigin\"j\n" +
+	"\x17OpenOAuthHelperResponse\x12\x12\n" +
+	"\x04port\x18\x01 \x01(\x05R\x04port\x12\x12\n" +
+	"\x04addr\x18\x02 \x01(\tR\x04addr\x12'\n" +
+	"\x0falready_running\x18\x03 \x01(\bR\x0ealreadyRunning\"\x19\n" +
+	"\x17CloseOAuthHelperRequest\"2\n" +
+	"\x18CloseOAuthHelperResponse\x12\x16\n" +
+	"\x06closed\x18\x01 \x01(\bR\x06closed\"M\n" +
 	"\x15StartOAuthFlowRequest\x124\n" +
 	"\x16authorize_url_template\x18\x01 \x01(\tR\x14authorizeUrlTemplate\"e\n" +
 	"\x16StartOAuthFlowResponse\x12\x12\n" +
 	"\x04code\x18\x01 \x01(\tR\x04code\x12\x14\n" +
 	"\x05state\x18\x02 \x01(\tR\x05state\x12!\n" +
-	"\fredirect_uri\x18\x03 \x01(\tR\vredirectUri2j\n" +
+	"\fredirect_uri\x18\x03 \x01(\tR\vredirectUri2\xa9\x02\n" +
 	"\rDaemonService\x12Y\n" +
-	"\x0eStartOAuthFlow\x12!.reliant.v1.StartOAuthFlowRequest\x1a\".reliant.v1.StartOAuthFlowResponse\"\x00B:Z8github.com/reliant-labs/reliant/gen/reliant/v1;reliantv1b\x06proto3"
+	"\x0eStartOAuthFlow\x12!.reliant.v1.StartOAuthFlowRequest\x1a\".reliant.v1.StartOAuthFlowResponse\"\x00\x12\\\n" +
+	"\x0fOpenOAuthHelper\x12\".reliant.v1.OpenOAuthHelperRequest\x1a#.reliant.v1.OpenOAuthHelperResponse\"\x00\x12_\n" +
+	"\x10CloseOAuthHelper\x12#.reliant.v1.CloseOAuthHelperRequest\x1a$.reliant.v1.CloseOAuthHelperResponse\"\x00B:Z8github.com/reliant-labs/reliant/gen/reliant/v1;reliantv1b\x06proto3"
 
 var (
 	file_reliant_v1_daemon_proto_rawDescOnce sync.Once
@@ -158,16 +365,24 @@ func file_reliant_v1_daemon_proto_rawDescGZIP() []byte {
 	return file_reliant_v1_daemon_proto_rawDescData
 }
 
-var file_reliant_v1_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_reliant_v1_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_reliant_v1_daemon_proto_goTypes = []any{
-	(*StartOAuthFlowRequest)(nil),  // 0: reliant.v1.StartOAuthFlowRequest
-	(*StartOAuthFlowResponse)(nil), // 1: reliant.v1.StartOAuthFlowResponse
+	(*OpenOAuthHelperRequest)(nil),   // 0: reliant.v1.OpenOAuthHelperRequest
+	(*OpenOAuthHelperResponse)(nil),  // 1: reliant.v1.OpenOAuthHelperResponse
+	(*CloseOAuthHelperRequest)(nil),  // 2: reliant.v1.CloseOAuthHelperRequest
+	(*CloseOAuthHelperResponse)(nil), // 3: reliant.v1.CloseOAuthHelperResponse
+	(*StartOAuthFlowRequest)(nil),    // 4: reliant.v1.StartOAuthFlowRequest
+	(*StartOAuthFlowResponse)(nil),   // 5: reliant.v1.StartOAuthFlowResponse
 }
 var file_reliant_v1_daemon_proto_depIdxs = []int32{
-	0, // 0: reliant.v1.DaemonService.StartOAuthFlow:input_type -> reliant.v1.StartOAuthFlowRequest
-	1, // 1: reliant.v1.DaemonService.StartOAuthFlow:output_type -> reliant.v1.StartOAuthFlowResponse
-	1, // [1:2] is the sub-list for method output_type
-	0, // [0:1] is the sub-list for method input_type
+	4, // 0: reliant.v1.DaemonService.StartOAuthFlow:input_type -> reliant.v1.StartOAuthFlowRequest
+	0, // 1: reliant.v1.DaemonService.OpenOAuthHelper:input_type -> reliant.v1.OpenOAuthHelperRequest
+	2, // 2: reliant.v1.DaemonService.CloseOAuthHelper:input_type -> reliant.v1.CloseOAuthHelperRequest
+	5, // 3: reliant.v1.DaemonService.StartOAuthFlow:output_type -> reliant.v1.StartOAuthFlowResponse
+	1, // 4: reliant.v1.DaemonService.OpenOAuthHelper:output_type -> reliant.v1.OpenOAuthHelperResponse
+	3, // 5: reliant.v1.DaemonService.CloseOAuthHelper:output_type -> reliant.v1.CloseOAuthHelperResponse
+	3, // [3:6] is the sub-list for method output_type
+	0, // [0:3] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
 	0, // [0:0] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name
@@ -184,7 +399,7 @@ func file_reliant_v1_daemon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_reliant_v1_daemon_proto_rawDesc), len(file_reliant_v1_daemon_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/auth/oauthcallback/cancel_release_test.go
+++ b/internal/auth/oauthcallback/cancel_release_test.go
@@ -1,0 +1,53 @@
+package oauthcallback
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+// Measure the thing that actually bit the user: how long after CANCEL the
+// fixed port stays unbindable.
+func TestPortFreedPromptlyAfterCancel(t *testing.T) {
+	orig := openBrowser
+	var held net.Conn
+	openBrowser = func(string) error {
+		if c, err := net.Dial("tcp", "127.0.0.1:1455"); err == nil {
+			held = c
+		}
+		return nil
+	}
+	defer func() {
+		openBrowser = orig
+		if held != nil {
+			_ = held.Close()
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _, _ = Run(ctx, "https://auth.openai.com/authorize?redirect_uri={redirect_uri}") }()
+	time.Sleep(300 * time.Millisecond)
+
+	start := time.Now()
+	cancel()
+
+	// Poll until the port is bindable again.
+	var freed time.Duration
+	for i := 0; i < 200; i++ {
+		ln, err := net.Listen("tcp", "127.0.0.1:1455")
+		if err == nil {
+			freed = time.Since(start)
+			_ = ln.Close()
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if freed == 0 {
+		t.Fatal("port never became bindable after cancel")
+	}
+	t.Logf("port bindable %v after cancel", freed)
+	if freed > 1*time.Second {
+		t.Errorf("port held %v after cancel — a user clicking Connect again hits EADDRINUSE", freed)
+	}
+}

--- a/internal/auth/oauthcallback/listen_retry_test.go
+++ b/internal/auth/oauthcallback/listen_retry_test.go
@@ -1,0 +1,53 @@
+package oauthcallback
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+// A port held briefly by a previous flow must be waited out, not failed on.
+// This is the guarantee that makes "cancel, click Connect again" work even
+// when the two overlap by milliseconds.
+func TestListenWithRetry_WaitsOutBriefHold(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	addr := ln.Addr().String()
+
+	// Release it shortly, as a dying flow would.
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		_ = ln.Close()
+	}()
+
+	start := time.Now()
+	got, err := listenWithRetry(context.Background(), addr)
+	if err != nil {
+		t.Fatalf("listenWithRetry should have waited out the hold, got: %v", err)
+	}
+	defer got.Close()
+	t.Logf("bound after %v", time.Since(start))
+}
+
+// A port held by something that is NOT going away must still fail — and fail
+// within the budget, not hang.
+func TestListenWithRetry_FailsOnPermanentHold(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	defer ln.Close()
+
+	start := time.Now()
+	if _, err := listenWithRetry(context.Background(), ln.Addr().String()); err == nil {
+		t.Fatal("expected failure on a permanently held port")
+	}
+	elapsed := time.Since(start)
+	if elapsed > listenRetryBudget+time.Second {
+		t.Errorf("took %v, should give up near %v", elapsed, listenRetryBudget)
+	}
+	t.Logf("gave up after %v", elapsed)
+}

--- a/internal/auth/oauthcallback/oauthcallback.go
+++ b/internal/auth/oauthcallback/oauthcallback.go
@@ -208,6 +208,45 @@ func InferConfig(authorizeURLTemplate string) CallbackConfig {
 	return cfg
 }
 
+// listenRetryBudget bounds how long a bind waits out a PREVIOUS flow that is
+// still releasing the port.
+//
+// Even with the listener closed first on cancel, two flows can overlap by
+// milliseconds — the user clicks Connect again before the cancelled flow's
+// goroutine has been scheduled. A fixed-port provider has nowhere else to go,
+// so a bare failure there is a dead end for the user; waiting a moment turns
+// it into a click that just works. Kept short: a port held by something that
+// is NOT a dying flow of ours should still fail fast and say so.
+const listenRetryBudget = 3 * time.Second
+
+// listenRetryInterval is the poll between bind attempts. Fine enough that the
+// wait is imperceptible when the previous flow is already unwinding.
+const listenRetryInterval = 50 * time.Millisecond
+
+// listenWithRetry binds addr, retrying briefly while the port is in use.
+//
+// Only "address already in use" is retried — any other bind error (a bad
+// address, a permission problem) is returned at once, because waiting cannot
+// change it. Returns the LAST error on timeout so the caller's reuse path and
+// error message see the real bind failure.
+func listenWithRetry(ctx context.Context, addr string) (net.Listener, error) {
+	deadline := time.Now().Add(listenRetryBudget)
+	for {
+		ln, err := net.Listen("tcp", addr)
+		if err == nil {
+			return ln, nil
+		}
+		if !isAddressInUse(err) || time.Now().After(deadline) {
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, err
+		case <-time.After(listenRetryInterval):
+		}
+	}
+}
+
 // Run starts a temporary HTTP server, opens the browser, and waits for the
 // OAuth callback or context cancellation. It returns the authorization code,
 // state and redirect URI.
@@ -225,10 +264,21 @@ func Run(ctx context.Context, authorizeURLTemplate string) (*Result, error) {
 	listenAddr := fmt.Sprintf("%s:%d", cfg.ListenHost, cfg.FixedPort)
 	listener, err := net.Listen("tcp", listenAddr)
 	if err != nil {
+		// An ACTIVE sibling flow owns the port — join it and share the one
+		// callback. This must be tried BEFORE any retry: a concurrent flow is
+		// not a port to wait out, it is a flow to queue behind, and waiting
+		// would break the handoff (see rebind_test.go).
 		if reusedResult, reuseErr := tryReuseExistingListener(ctx, cfg, server.redirectURI, err); reuseErr == nil {
 			return reusedResult, nil
 		}
-		return nil, fmt.Errorf("failed to start callback listener: %w", err)
+		// No live owner answered the handshake, so the holder is a flow on its
+		// way out — typically the one the user just cancelled, whose graceful
+		// shutdown has not finished releasing the socket. Wait briefly rather
+		// than failing the click.
+		listener, err = listenWithRetry(ctx, listenAddr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to start callback listener: %w", err)
+		}
 	}
 	defer listener.Close()
 
@@ -256,8 +306,28 @@ func Run(ctx context.Context, authorizeURLTemplate string) (*Result, error) {
 	go func() {
 		<-ctx.Done()
 		// A cancelled flow has no answer to hand anyone, so there is nothing
-		// to drain — but still shut down gracefully rather than severing the
-		// socket, so the port is released cleanly for the next attempt.
+		// to drain.
+		//
+		// CLOSE THE LISTENER FIRST, before the graceful Shutdown. Shutdown
+		// waits for open connections to go idle, and on a cancel the browser
+		// is typically still holding one open at the consent screen — so the
+		// PORT stayed bound for the whole drain (measured: 6.3s). A user who
+		// cancelled and immediately clicked Connect again landed inside that
+		// window and got
+		//
+		//     failed to start callback listener: listen tcp 127.0.0.1:1455:
+		//     bind: address already in use
+		//
+		// which reads as a broken app rather than a moment's wait. It bites
+		// the FIXED-port providers (Codex on 1455) because they cannot fall
+		// back to another port.
+		//
+		// Closing the listener releases the port at once while Shutdown still
+		// lets in-flight responses finish on their already-accepted
+		// connections. Nothing is severed that was mid-write: the listener
+		// only governs NEW accepts.
+		_ = listener.Close()
+
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownBudget)
 		defer cancel()
 		if err := httpServer.Shutdown(shutdownCtx); err != nil {

--- a/internal/auth/oauthhelper/oauthhelper.go
+++ b/internal/auth/oauthhelper/oauthhelper.go
@@ -1,0 +1,385 @@
+// Copyright (c) 2025 Reliant Labs
+
+// Package oauthhelper serves the localhost OAuth helper: the small HTTP
+// surface a BROWSER calls to run a Claude/Codex OAuth flow on the machine it
+// is running on.
+//
+// # Why a localhost listener is the whole point
+//
+// An OAuth provider redirects to `http://localhost:<port>/...`, and "localhost"
+// resolves on the USER'S machine — the one the browser runs on. So the
+// callback receiver must be co-located with the browser. Nothing else can
+// stand in for it: not the API server (wrong machine), not a remote daemon
+// (also the wrong machine), not the gateway (no browser at all).
+//
+// That makes this listener do double duty, and the second job is the
+// non-obvious one:
+//
+//  1. it RECEIVES the OAuth callback, and
+//  2. its reachability at 127.0.0.1 is the PROOF that whatever serves it is
+//     on the same machine as the browser.
+//
+// Co-location cannot be asserted from the other end. A daemon knows its own
+// hostname, instance id and platform, but nothing in its connection tells it
+// which machine rendered the page — both legs terminate at the gateway, and
+// behind NAT a dozen machines share one source address. A daemon that claimed
+// "I am local" would be guessing, and the failure is ugly rather than loud:
+// the browser redirects to localhost, reaches whatever IS listening there, and
+// the authorization code goes somewhere it was never meant to go. So the
+// browser probes, and a successful probe IS the answer.
+//
+// # Why the identity fields on /health exist
+//
+// A bare `{"status":"ok"}` proves only that SOMETHING holds port 19284. Any
+// other dev server on that port answers a health probe the same way, and the
+// UI would then offer an OAuth flow that silently fails. /health therefore
+// names the product, the readiness, and the version, so the caller can tell
+// "reliant is here" from "a port is here".
+package oauthhelper
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/reliant-labs/reliant/internal/auth/oauthcallback"
+	"github.com/reliant-labs/reliant/internal/logging"
+	"github.com/reliant-labs/reliant/internal/version"
+)
+
+// DefaultPort is the fixed port the web app probes. It is FIXED on purpose:
+// the browser has to know where to look before anything has told it, so this
+// value is a published contract shared with web/src/lib/oauth-local.ts. Do not
+// make it dynamic without changing that too.
+const DefaultPort = 19284
+
+// ServiceName is the `service` field on /health — the marker that
+// distinguishes reliant from any other process holding this port.
+const ServiceName = "reliant"
+
+// hostedWebOrigin is the production reliant web app's origin — the same
+// hosted address as web/src/lib/constants.ts's DEFAULT_APP_URL and
+// electron/release.config.json's VITE_APP_URL.
+const hostedWebOrigin = "https://app.reliantlabs.io"
+
+// HealthResponse is the /health document. It is a stable contract with the web
+// app's availability probe, so field names must not change casually.
+type HealthResponse struct {
+	// Status is "ok" when the helper can run a flow right now.
+	Status string `json:"status"`
+	// Service is always ServiceName. The field a caller checks to know that
+	// RELIANT answered, rather than some other process on this port.
+	Service string `json:"service"`
+	// Ready reports whether an OAuth flow can start. Distinct from Status so a
+	// future "reachable but not ready" state has somewhere to live without
+	// breaking a client that only understands the two fields it has.
+	Ready bool `json:"ready"`
+	// Version is the reliant build serving this. Lets the UI warn about a
+	// helper too old for a flow the app wants, and makes a bug report specific.
+	Version string `json:"version"`
+	// Source names which command is serving: "daemon" or "auth-serve". Purely
+	// diagnostic — it answers "why is this already running?" without a process
+	// hunt.
+	Source string `json:"source"`
+}
+
+// Options configures a helper server.
+type Options struct {
+	// Port to listen on; 0 means DefaultPort.
+	Port int
+	// Source is the HealthResponse.Source value ("daemon" / "auth-serve").
+	Source string
+	// ExtraOrigins are additional allowed CORS origins beyond the defaults.
+	// RELIANT_WEB_ORIGIN is folded in automatically.
+	ExtraOrigins []string
+	// IdleTimeout closes the listener after this long with no request. Zero
+	// means "stay up until Shutdown" — the `auth serve` foreground case, where
+	// the user's Ctrl-C is the lifecycle.
+	//
+	// The daemon sets this: the port is opened ON DEMAND for one linking
+	// session and must not outlive it. An always-listening localhost port that
+	// starts browsers and returns authorization codes is a standing surface
+	// nobody asked for, on every machine running a daemon.
+	IdleTimeout time.Duration
+	// OnIdle is called when IdleTimeout elapses, after the listener closes.
+	// Lets the owner drop its reference so a later request re-opens cleanly.
+	OnIdle func()
+}
+
+// Server is a running helper. Use Start to create one.
+type Server struct {
+	srv     *http.Server
+	ln      net.Listener
+	allowed map[string]bool
+	source  string
+
+	mu       sync.Mutex
+	shutOnce bool
+	// inFlight counts requests currently being served. An OAuth flow holds
+	// /oauth/start open for as long as the user takes in the browser, so the
+	// idle timer must never fire under one — "idle" means no request in
+	// flight AND nothing since lastSeen.
+	inFlight int
+	lastSeen time.Time
+
+	idleTimeout time.Duration
+	onIdle      func()
+	stopIdle    chan struct{}
+}
+
+// Addr returns the address the server is listening on.
+func (s *Server) Addr() string {
+	if s == nil || s.ln == nil {
+		return ""
+	}
+	return s.ln.Addr().String()
+}
+
+// Start binds the helper port and serves in the background. It returns
+// ErrPortInUse when the port is already held, which callers embedding this in
+// a long-running process should treat as non-fatal — another reliant process
+// (or a stale one) already provides the surface, and taking down the daemon
+// over it would be a bad trade.
+func Start(opts Options) (*Server, error) {
+	port := opts.Port
+	if port == 0 {
+		port = DefaultPort
+	}
+
+	s := &Server{
+		allowed:     buildAllowedOrigins(opts.ExtraOrigins),
+		source:      opts.Source,
+		lastSeen:    time.Now(),
+		idleTimeout: opts.IdleTimeout,
+		onIdle:      opts.OnIdle,
+		stopIdle:    make(chan struct{}),
+	}
+
+	// 127.0.0.1, never 0.0.0.0: this surface starts browsers and hands back
+	// authorization codes, so it must not be reachable from the network.
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		if isAddrInUse(err) {
+			return nil, fmt.Errorf("%w: %s", ErrPortInUse, addr)
+		}
+		return nil, fmt.Errorf("listen on %s: %w", addr, err)
+	}
+	s.ln = ln
+	s.srv = &http.Server{Handler: s.handler(), ReadHeaderTimeout: 10 * time.Second}
+
+	go func() {
+		if serveErr := s.srv.Serve(ln); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			logging.Error("OAuth helper server stopped", "error", serveErr)
+		}
+	}()
+	if s.idleTimeout > 0 {
+		go s.watchIdle()
+	}
+	return s, nil
+}
+
+// watchIdle closes the listener once nothing has used it for idleTimeout.
+// Polls at a fraction of the timeout rather than arming a timer per request:
+// the resolution needed here is coarse, and a poll cannot leak a timer if a
+// request finishes during shutdown.
+func (s *Server) watchIdle() {
+	tick := s.idleTimeout / 4
+	if tick < time.Second {
+		tick = time.Second
+	}
+	t := time.NewTicker(tick)
+	defer t.Stop()
+	for {
+		select {
+		case <-s.stopIdle:
+			return
+		case <-t.C:
+			s.mu.Lock()
+			idle := s.inFlight == 0 && time.Since(s.lastSeen) >= s.idleTimeout
+			s.mu.Unlock()
+			if !idle {
+				continue
+			}
+			logging.Info("OAuth helper idle — closing the port", "idle_timeout", s.idleTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_ = s.Shutdown(ctx)
+			cancel()
+			if s.onIdle != nil {
+				s.onIdle()
+			}
+			return
+		}
+	}
+}
+
+// track marks a request in flight for the duration of fn, so the idle timer
+// cannot close the port under a long OAuth flow.
+func (s *Server) track(fn func()) {
+	s.mu.Lock()
+	s.inFlight++
+	s.lastSeen = time.Now()
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.inFlight--
+		s.lastSeen = time.Now()
+		s.mu.Unlock()
+	}()
+	fn()
+}
+
+// ErrPortInUse reports that the helper port is already bound.
+var ErrPortInUse = errors.New("oauth helper port already in use")
+
+// Shutdown stops the server gracefully. Safe to call more than once and from
+// several goroutines — the idle watcher and the owner's defer race by design.
+func (s *Server) Shutdown(ctx context.Context) error {
+	if s == nil || s.srv == nil {
+		return nil
+	}
+	s.mu.Lock()
+	if s.shutOnce {
+		s.mu.Unlock()
+		return nil
+	}
+	s.shutOnce = true
+	s.mu.Unlock()
+
+	close(s.stopIdle)
+	return s.srv.Shutdown(ctx)
+}
+
+func (s *Server) handler() http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		s.track(func() {
+			s.setCORS(w, r)
+			writeJSON(w, http.StatusOK, HealthResponse{
+				Status:  "ok",
+				Service: ServiceName,
+				Ready:   true,
+				Version: version.Version,
+				Source:  s.source,
+			})
+		})
+	})
+
+	mux.HandleFunc("OPTIONS /", func(w http.ResponseWriter, r *http.Request) {
+		s.setCORS(w, r)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	mux.HandleFunc("POST /oauth/start", func(w http.ResponseWriter, r *http.Request) {
+		// Tracked for the WHOLE flow: this handler blocks until the user
+		// finishes in the browser, which can be minutes. Untracked, the idle
+		// timer would close the port out from under an in-progress login.
+		s.track(func() { s.handleOAuthStart(w, r) })
+	})
+
+	return mux
+}
+
+func (s *Server) handleOAuthStart(w http.ResponseWriter, r *http.Request) {
+	{
+		s.setCORS(w, r)
+
+		if origin := r.Header.Get("Origin"); origin != "" && !s.allowed[origin] {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "origin not allowed"})
+			return
+		}
+
+		var req struct {
+			AuthorizeURLTemplate string `json:"authorize_url_template"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			return
+		}
+		if req.AuthorizeURLTemplate == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "authorize_url_template is required"})
+			return
+		}
+
+		result, err := oauthcallback.Run(r.Context(), req.AuthorizeURLTemplate)
+		if err != nil {
+			logging.Error("OAuth callback failed", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func (s *Server) setCORS(w http.ResponseWriter, r *http.Request) {
+	if origin := r.Header.Get("Origin"); origin != "" && s.allowed[origin] {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+	}
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+}
+
+// buildAllowedOrigins is the CORS/CSRF allowlist, whose only legitimate caller
+// is the reliant web app.
+//
+// RELIANT_WEB_ORIGIN (comma-separated) extends it, and is load-bearing rather
+// than a convenience: the web dev server's port is allocated per worktree (see
+// .dev-ports.sh FRONTEND_PORT), so a worktree's Vite origin is never one of the
+// static defaults. Resolved here — in the shared package — so both `auth serve`
+// and the daemon-hosted helper honour the same variable. Reading it in only one
+// of the two is how the daemon path would 403 a request `auth serve` allows,
+// with an error that names the origin and not the reason.
+func buildAllowedOrigins(extra []string) map[string]bool {
+	origins := []string{
+		hostedWebOrigin,
+		"http://localhost:5173", // vite dev default (web/README.md)
+		"http://localhost:3000", // common dev port (web/src/routes.tsx, scripts/dev.sh)
+	}
+	origins = append(origins, extra...)
+	if env := os.Getenv("RELIANT_WEB_ORIGIN"); env != "" {
+		origins = append(origins, strings.Split(env, ",")...)
+	}
+	// FRONTEND_PORT is what forge publishes for the dev web server and what the
+	// Electron main process already reads. Accepting the loopback origins it
+	// implies means a worktree stack works without anyone also having to set
+	// RELIANT_WEB_ORIGIN to the same number.
+	if p := strings.TrimSpace(os.Getenv("FRONTEND_PORT")); p != "" {
+		origins = append(origins,
+			"http://localhost:"+p,
+			"http://127.0.0.1:"+p,
+		)
+	}
+
+	set := make(map[string]bool, len(origins))
+	for _, o := range origins {
+		if o = strings.TrimSpace(o); o != "" {
+			set[o] = true
+		}
+	}
+	return set
+}
+
+// isAddrInUse reports whether a listen error is "port already taken".
+// Matched on the syscall errno rather than the message where possible;
+// net.Listen wraps it in *net.OpError → *os.SyscallError, so errors.Is reaches
+// it. The string check is the fallback for platforms/wrappers that do not
+// surface the errno.
+func isAddrInUse(err error) bool {
+	return errors.Is(err, syscall.EADDRINUSE) ||
+		strings.Contains(strings.ToLower(err.Error()), "address already in use")
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/auth/oauthhelper/oauthhelper_test.go
+++ b/internal/auth/oauthhelper/oauthhelper_test.go
@@ -1,0 +1,275 @@
+// Copyright (c) 2025 Reliant Labs
+package oauthhelper
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// freePort reserves a port and releases it, so a test can bind it without
+// colliding with the real 19284 (which a developer's daemon may well hold).
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}
+
+func startTestServer(t *testing.T, source string) *Server {
+	t.Helper()
+	srv, err := Start(Options{Port: freePort(t), Source: source})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	return srv
+}
+
+// /health must IDENTIFY the service, not merely return 200. A bare status
+// leaves the web app unable to tell reliant from any other process that
+// happens to hold the port — and offering an OAuth flow to that process fails
+// silently.
+func TestHealth_IdentifiesServiceAndVersion(t *testing.T) {
+	srv := startTestServer(t, "daemon")
+
+	resp, err := http.Get("http://" + srv.Addr() + "/health")
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var body HealthResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Service != ServiceName {
+		t.Errorf("service = %q, want %q — this field is what proves reliant answered", body.Service, ServiceName)
+	}
+	if body.Status != "ok" {
+		t.Errorf("status = %q, want ok", body.Status)
+	}
+	if !body.Ready {
+		t.Error("ready = false, want true")
+	}
+	if body.Version == "" {
+		t.Error("version must not be empty")
+	}
+	if body.Source != "daemon" {
+		t.Errorf("source = %q, want daemon", body.Source)
+	}
+}
+
+// The daemon embeds this in a long-running process. A second binder must get a
+// typed, recognizable error so the daemon can log-and-continue rather than
+// refuse to start — trading all tool execution for an auth convenience.
+func TestStart_PortInUseIsTyped(t *testing.T) {
+	first := startTestServer(t, "daemon")
+
+	_, port, err := net.SplitHostPort(first.Addr())
+	if err != nil {
+		t.Fatalf("split addr: %v", err)
+	}
+	var portNum int
+	if _, err := fmtSscan(port, &portNum); err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+
+	_, err = Start(Options{Port: portNum, Source: "auth-serve"})
+	if err == nil {
+		t.Fatal("expected an error binding an already-held port")
+	}
+	if !errors.Is(err, ErrPortInUse) {
+		t.Fatalf("error should be ErrPortInUse so callers can degrade gracefully, got: %v", err)
+	}
+}
+
+// The allowlist must honour RELIANT_WEB_ORIGIN in BOTH hosts (daemon and
+// `auth serve`). Resolving it in only one is how the daemon path would 403 a
+// request `auth serve` allows, with an error naming the origin and not the
+// reason.
+func TestAllowedOrigins_HonoursEnvAndFrontendPort(t *testing.T) {
+	t.Setenv("RELIANT_WEB_ORIGIN", "http://localhost:4321, http://localhost:4322")
+	t.Setenv("FRONTEND_PORT", "3600")
+
+	allowed := buildAllowedOrigins(nil)
+
+	for _, want := range []string{
+		"http://localhost:4321",      // from RELIANT_WEB_ORIGIN
+		"http://localhost:4322",      // second entry, whitespace trimmed
+		"http://localhost:3600",      // derived from FRONTEND_PORT
+		"http://127.0.0.1:3600",      // loopback twin
+		"https://app.reliantlabs.io", // hosted default
+		"http://localhost:5173",      // vite default
+	} {
+		if !allowed[want] {
+			t.Errorf("origin %q should be allowed", want)
+		}
+	}
+	if allowed["http://evil.example.com"] {
+		t.Error("an undeclared origin must not be allowed")
+	}
+}
+
+// CORS must be reflected only for allowed origins — never a blanket "*", which
+// would let any page on the internet drive a local OAuth flow.
+func TestCORS_OnlyReflectsAllowedOrigins(t *testing.T) {
+	t.Setenv("RELIANT_WEB_ORIGIN", "http://localhost:4321")
+	srv := startTestServer(t, "daemon")
+
+	for name, tc := range map[string]struct{ origin, want string }{
+		"allowed":    {"http://localhost:4321", "http://localhost:4321"},
+		"disallowed": {"http://evil.example.com", ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodGet, "http://"+srv.Addr()+"/health", nil)
+			req.Header.Set("Origin", tc.origin)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			if got := resp.Header.Get("Access-Control-Allow-Origin"); got != tc.want {
+				t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A POST from a disallowed origin must be refused before any browser opens.
+func TestOAuthStart_RejectsDisallowedOrigin(t *testing.T) {
+	srv := startTestServer(t, "daemon")
+
+	req, _ := http.NewRequest(http.MethodPost, "http://"+srv.Addr()+"/oauth/start", nil)
+	req.Header.Set("Origin", "http://evil.example.com")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+// The helper must bind loopback ONLY: it starts browsers and returns
+// authorization codes, so network reachability would be a real exposure.
+func TestStart_BindsLoopbackOnly(t *testing.T) {
+	srv := startTestServer(t, "daemon")
+
+	host, _, err := net.SplitHostPort(srv.Addr())
+	if err != nil {
+		t.Fatalf("split addr: %v", err)
+	}
+	if host != "127.0.0.1" {
+		t.Fatalf("listening on %q, want 127.0.0.1 — must not be reachable off-box", host)
+	}
+}
+
+// The port must NOT outlive the linking session. An always-open localhost
+// listener that starts browsers and returns authorization codes is a standing
+// surface; opening it per session keeps the exposure equal to the task.
+func TestIdleTimeout_ClosesThePort(t *testing.T) {
+	idled := make(chan struct{})
+	srv, err := Start(Options{
+		Port:        freePort(t),
+		Source:      "daemon",
+		IdleTimeout: 1 * time.Second,
+		OnIdle:      func() { close(idled) },
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	addr := srv.Addr()
+
+	select {
+	case <-idled:
+	case <-time.After(15 * time.Second):
+		t.Fatal("helper never closed itself after the idle timeout")
+	}
+
+	// The listener must actually be gone, not merely reported closed.
+	if _, err := http.Get("http://" + addr + "/health"); err == nil {
+		t.Fatal("port still accepting connections after idle close")
+	}
+}
+
+// A request must RESET the idle clock, or a user reading the consent screen
+// would have the port closed under them.
+func TestIdleTimeout_RequestKeepsItAlive(t *testing.T) {
+	srv, err := Start(Options{
+		Port:        freePort(t),
+		Source:      "daemon",
+		IdleTimeout: 3 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	addr := srv.Addr()
+
+	// Poke it past the would-be deadline.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get("http://" + addr + "/health")
+		if err != nil {
+			t.Fatalf("helper closed while still being used: %v", err)
+		}
+		_ = resp.Body.Close()
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// Shutdown must be safe to call twice — the idle watcher and the owner's
+// explicit close race by design.
+func TestShutdown_Idempotent(t *testing.T) {
+	srv := startTestServer(t, "daemon")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(ctx); err != nil {
+		t.Fatalf("first Shutdown: %v", err)
+	}
+	if err := srv.Shutdown(ctx); err != nil {
+		t.Fatalf("second Shutdown should be a no-op, got: %v", err)
+	}
+}
+
+// fmtSscan is a tiny indirection so the test file needs no fmt import alias
+// dance; kept local to avoid widening the package's own imports.
+func fmtSscan(s string, out *int) (int, error) {
+	n := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, errors.New("not a number: " + s)
+		}
+		n = n*10 + int(r-'0')
+	}
+	*out = n
+	return 1, nil
+}

--- a/internal/grpc/services/daemon_proxy.go
+++ b/internal/grpc/services/daemon_proxy.go
@@ -67,3 +67,72 @@ func (s *DaemonProxyService) StartOAuthFlow(
 		RedirectUri: resp.RedirectURI,
 	}), nil
 }
+
+// openHelperTimeoutMs bounds the open/close commands. These return as soon as
+// the listener is bound or closed — no human is in the loop — so the generous
+// hour StartOAuthFlow needs would only delay reporting a dead daemon.
+const openHelperTimeoutMs = 10_000
+
+// OpenOAuthHelper asks the user's daemon to open its localhost OAuth helper
+// port for one linking session.
+func (s *DaemonProxyService) OpenOAuthHelper(
+	ctx context.Context,
+	req *connect.Request[reliantv1.OpenOAuthHelperRequest],
+) (*connect.Response[reliantv1.OpenOAuthHelperResponse], error) {
+	userID, ok := auth.GetUserIDFromContext(ctx)
+	if !ok {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("user ID not found in context"))
+	}
+
+	payload, err := json.Marshal(map[string]any{
+		"web_origin": req.Msg.WebOrigin,
+	})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("marshal request: %w", err))
+	}
+
+	respBytes, err := s.router.SendDaemonCommand(ctx, userID, "auth.open_oauth_helper", payload, openHelperTimeoutMs)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("open OAuth helper: %w", err))
+	}
+
+	var resp struct {
+		Port           int32  `json:"port"`
+		Addr           string `json:"addr"`
+		AlreadyRunning bool   `json:"already_running"`
+	}
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("unmarshal response: %w", err))
+	}
+
+	return connect.NewResponse(&reliantv1.OpenOAuthHelperResponse{
+		Port:           resp.Port,
+		Addr:           resp.Addr,
+		AlreadyRunning: resp.AlreadyRunning,
+	}), nil
+}
+
+// CloseOAuthHelper closes the helper port when the linking session ends.
+func (s *DaemonProxyService) CloseOAuthHelper(
+	ctx context.Context,
+	_ *connect.Request[reliantv1.CloseOAuthHelperRequest],
+) (*connect.Response[reliantv1.CloseOAuthHelperResponse], error) {
+	userID, ok := auth.GetUserIDFromContext(ctx)
+	if !ok {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("user ID not found in context"))
+	}
+
+	respBytes, err := s.router.SendDaemonCommand(ctx, userID, "auth.close_oauth_helper", []byte("{}"), openHelperTimeoutMs)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("close OAuth helper: %w", err))
+	}
+
+	var resp struct {
+		Closed bool `json:"closed"`
+	}
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("unmarshal response: %w", err))
+	}
+
+	return connect.NewResponse(&reliantv1.CloseOAuthHelperResponse{Closed: resp.Closed}), nil
+}

--- a/internal/toolexec/daemonruntime/cmd_oauth_helper.go
+++ b/internal/toolexec/daemonruntime/cmd_oauth_helper.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2025 Reliant Labs
+package daemonruntime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/reliant-labs/reliant/internal/auth/oauthhelper"
+	"github.com/reliant-labs/reliant/internal/logging"
+)
+
+// The localhost OAuth helper is opened ON DEMAND, over the gateway connection
+// the daemon already holds, and closed again when the linking session ends.
+//
+// WHY NOT JUST LISTEN ALL THE TIME. The helper starts browsers and hands back
+// authorization codes. A port doing that, open for the entire life of every
+// daemon on every machine, is a standing local surface nobody asked for — and
+// it is unnecessary, because the app only needs it during the seconds a user
+// spends linking an account. Opening it per session keeps the exposure equal
+// to the task.
+//
+// WHY IT STILL ANSWERS THE CO-LOCATION QUESTION. Whether the daemon is on the
+// same machine as the browser cannot be asserted from this end: the daemon
+// knows its hostname and instance id, but nothing in its connection says which
+// machine rendered the page, and behind NAT many machines share one address.
+// The request/response here is the proof, in two steps — the UI asks the
+// daemon (over the existing connection) to open the port, then probes
+// 127.0.0.1 itself. If the probe succeeds, the daemon that just opened it is
+// demonstrably on the browser's machine. If it fails, the daemon is remote and
+// the UI can say so instead of offering a flow that would hang.
+func init() {
+	RegisterCommand("auth.open_oauth_helper", handleOpenOAuthHelper)
+	RegisterCommand("auth.close_oauth_helper", handleCloseOAuthHelper)
+}
+
+// helperIdleTimeout closes the port when a session is abandoned — the user
+// navigates away, or the browser never probes. Long enough to cover a real
+// login (the provider page, credentials, MFA), short enough that a forgotten
+// tab does not leave the port open indefinitely. Any request resets it, and an
+// in-flight /oauth/start holds it open regardless of length.
+const helperIdleTimeout = 10 * time.Minute
+
+var (
+	helperMu     sync.Mutex
+	helperServer *oauthhelper.Server
+)
+
+type openOAuthHelperRequest struct {
+	// WebOrigin is the browser origin that will call the helper. Passed from
+	// the UI because the daemon cannot know it: a worktree's web dev server
+	// gets a per-worktree port (.dev-ports.sh FRONTEND_PORT), so the origin is
+	// not one of the static defaults and is not in the daemon's environment
+	// either. Without it the CORS allowlist would 403 the very caller that
+	// asked for the port.
+	WebOrigin string `json:"web_origin"`
+}
+
+type openOAuthHelperResponse struct {
+	// Port the helper is listening on, so the UI probes the right place rather
+	// than assuming the default.
+	Port int `json:"port"`
+	// Addr is the full loopback address, for display and for the probe URL.
+	Addr string `json:"addr"`
+	// AlreadyRunning reports that the port was already served (by a previous
+	// session, or a standalone `reliant auth serve`). Not an error: the
+	// surface the browser needs exists either way.
+	AlreadyRunning bool `json:"already_running"`
+}
+
+func handleOpenOAuthHelper(_ context.Context, payload []byte) ([]byte, error) {
+	var req openOAuthHelperRequest
+	// An empty payload is valid — the origin is optional.
+	if len(payload) > 0 {
+		if err := json.Unmarshal(payload, &req); err != nil {
+			return nil, fmt.Errorf("invalid payload: %w", err)
+		}
+	}
+
+	helperMu.Lock()
+	defer helperMu.Unlock()
+
+	if helperServer != nil {
+		return json.Marshal(openOAuthHelperResponse{
+			Port:           oauthhelper.DefaultPort,
+			Addr:           helperServer.Addr(),
+			AlreadyRunning: true,
+		})
+	}
+
+	var extra []string
+	if req.WebOrigin != "" {
+		extra = append(extra, req.WebOrigin)
+	}
+
+	srv, err := oauthhelper.Start(oauthhelper.Options{
+		Source:       "daemon",
+		ExtraOrigins: extra,
+		IdleTimeout:  helperIdleTimeout,
+		OnIdle:       clearHelperServer,
+	})
+	if err != nil {
+		// Already held — by a standalone `auth serve`, or a daemon that did
+		// not clean up. The browser's probe will succeed either way, so report
+		// success rather than failing a request whose post-condition holds.
+		if isPortInUse(err) {
+			logging.Info("OAuth helper port already served — reusing it", "error", err)
+			return json.Marshal(openOAuthHelperResponse{
+				Port:           oauthhelper.DefaultPort,
+				Addr:           fmt.Sprintf("127.0.0.1:%d", oauthhelper.DefaultPort),
+				AlreadyRunning: true,
+			})
+		}
+		return nil, fmt.Errorf("open oauth helper: %w", err)
+	}
+
+	helperServer = srv
+	logging.Info("OAuth helper opened on demand", "addr", srv.Addr(), "idle_timeout", helperIdleTimeout)
+
+	return json.Marshal(openOAuthHelperResponse{
+		Port: oauthhelper.DefaultPort,
+		Addr: srv.Addr(),
+	})
+}
+
+// handleCloseOAuthHelper closes the port when the UI is finished — the flow
+// completed, or the user cancelled. The idle timeout is the backstop for a UI
+// that never gets to send this (a closed tab, a crash); this is the fast path
+// that keeps the surface open only as long as it is actually needed.
+func handleCloseOAuthHelper(_ context.Context, _ []byte) ([]byte, error) {
+	helperMu.Lock()
+	srv := helperServer
+	helperServer = nil
+	helperMu.Unlock()
+
+	if srv == nil {
+		return json.Marshal(map[string]bool{"closed": false})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		logging.Warn("OAuth helper shutdown returned an error", "error", err)
+	}
+	logging.Info("OAuth helper closed on request")
+	return json.Marshal(map[string]bool{"closed": true})
+}
+
+func clearHelperServer() {
+	helperMu.Lock()
+	helperServer = nil
+	helperMu.Unlock()
+}
+
+func isPortInUse(err error) bool {
+	return errors.Is(err, oauthhelper.ErrPortInUse)
+}

--- a/proto/reliant/v1/daemon.proto
+++ b/proto/reliant/v1/daemon.proto
@@ -10,6 +10,56 @@ service DaemonService {
   // StartOAuthFlow starts a localhost callback server on the daemon, opens the
   // browser for the user to authorize, and returns the authorization code.
   rpc StartOAuthFlow(StartOAuthFlowRequest) returns (StartOAuthFlowResponse) {}
+
+  // OpenOAuthHelper asks the daemon to open its localhost OAuth helper port
+  // for ONE account-linking session. Returns immediately — unlike
+  // StartOAuthFlow it does not block on a human working through a consent
+  // screen, which is what made that RPC unusable in the packaged app.
+  //
+  // The port is NOT open the rest of the time, deliberately: a listener that
+  // starts browsers and returns authorization codes should exist for the
+  // seconds it is needed, not for the life of every daemon on every machine.
+  // The daemon closes it on CloseOAuthHelper, or after an idle timeout if the
+  // UI never gets to send one.
+  //
+  // This pair is also how the app learns whether the daemon is CO-LOCATED with
+  // the browser — a fact neither side can assert on its own. The UI asks the
+  // daemon to open the port over the connection it already has, then probes
+  // 127.0.0.1 itself. A successful probe proves the daemon that just opened it
+  // is on the browser's machine; a failed one means the daemon is remote, and
+  // the UI can say so instead of offering a flow that would hang.
+  rpc OpenOAuthHelper(OpenOAuthHelperRequest) returns (OpenOAuthHelperResponse) {}
+
+  // CloseOAuthHelper closes the helper port when the linking session ends
+  // (completed or cancelled).
+  rpc CloseOAuthHelper(CloseOAuthHelperRequest) returns (CloseOAuthHelperResponse) {}
+}
+
+message OpenOAuthHelperRequest {
+  // Browser origin that will call the helper, added to its CORS allowlist.
+  //
+  // Passed from the UI because the daemon cannot know it: a worktree's web dev
+  // server gets a per-worktree port, so the origin is neither one of the
+  // static defaults nor present in the daemon's environment. Without it the
+  // allowlist would reject the very caller that asked for the port.
+  string web_origin = 1;
+}
+
+message OpenOAuthHelperResponse {
+  // Port the helper is listening on.
+  int32 port = 1;
+  // Full loopback address, for the probe URL.
+  string addr = 2;
+  // True when the port was already served (a previous session, or a standalone
+  // `reliant auth serve`). Not an error — the surface exists either way.
+  bool already_running = 3;
+}
+
+message CloseOAuthHelperRequest {}
+
+message CloseOAuthHelperResponse {
+  // False when nothing was open.
+  bool closed = 1;
 }
 
 message StartOAuthFlowRequest {

--- a/web/src/api/daemon-grpc.ts
+++ b/web/src/api/daemon-grpc.ts
@@ -30,3 +30,44 @@ export async function startOAuthViaDaemon(
   const client = createClient(DaemonService, transport);
   return client.startOAuthFlow({ authorizeUrlTemplate }, { signal });
 }
+
+/**
+ * Ask the daemon to open its localhost OAuth helper port for ONE linking
+ * session.
+ *
+ * Returns immediately — unlike `startOAuthViaDaemon` this does not block on a
+ * human at a consent screen, which is what made that RPC fail at ~15s in the
+ * packaged app.
+ *
+ * Pair every call with `closeOAuthHelper`. The daemon also closes the port
+ * after an idle timeout, but that is the backstop for a UI that never got to
+ * ask (a closed tab, a crash) — not the normal path.
+ */
+export async function openOAuthHelper(
+  webOrigin: string,
+  signal?: AbortSignal
+): Promise<{ port: number; addr: string; alreadyRunning: boolean }> {
+  const transport = getTransport();
+  const client = createClient(DaemonService, transport);
+  const resp = await client.openOAuthHelper({ webOrigin }, { signal });
+  return {
+    port: resp.port,
+    addr: resp.addr,
+    alreadyRunning: resp.alreadyRunning,
+  };
+}
+
+/**
+ * Release the helper port. Best-effort by design: the caller is usually in a
+ * `finally`, and a failure here must not mask the outcome of the flow itself.
+ * The daemon's idle timeout covers a missed close.
+ */
+export async function closeOAuthHelper(): Promise<void> {
+  try {
+    const transport = getTransport();
+    const client = createClient(DaemonService, transport);
+    await client.closeOAuthHelper({});
+  } catch {
+    // Ignored: the idle timeout is the backstop.
+  }
+}

--- a/web/src/gen/reliant/v1/daemon_pb.ts
+++ b/web/src/gen/reliant/v1/daemon_pb.ts
@@ -13,7 +13,97 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file reliant/v1/daemon.proto.
  */
 export const file_reliant_v1_daemon: GenFile = /*@__PURE__*/
-  fileDesc("ChdyZWxpYW50L3YxL2RhZW1vbi5wcm90bxIKcmVsaWFudC52MSI3ChVTdGFydE9BdXRoRmxvd1JlcXVlc3QSHgoWYXV0aG9yaXplX3VybF90ZW1wbGF0ZRgBIAEoCSJLChZTdGFydE9BdXRoRmxvd1Jlc3BvbnNlEgwKBGNvZGUYASABKAkSDQoFc3RhdGUYAiABKAkSFAoMcmVkaXJlY3RfdXJpGAMgASgJMmoKDURhZW1vblNlcnZpY2USWQoOU3RhcnRPQXV0aEZsb3cSIS5yZWxpYW50LnYxLlN0YXJ0T0F1dGhGbG93UmVxdWVzdBoiLnJlbGlhbnQudjEuU3RhcnRPQXV0aEZsb3dSZXNwb25zZSIAQjpaOGdpdGh1Yi5jb20vcmVsaWFudC1sYWJzL3JlbGlhbnQvZ2VuL3JlbGlhbnQvdjE7cmVsaWFudHYxYgZwcm90bzM");
+  fileDesc("ChdyZWxpYW50L3YxL2RhZW1vbi5wcm90bxIKcmVsaWFudC52MSIsChZPcGVuT0F1dGhIZWxwZXJSZXF1ZXN0EhIKCndlYl9vcmlnaW4YASABKAkiTgoXT3Blbk9BdXRoSGVscGVyUmVzcG9uc2USDAoEcG9ydBgBIAEoBRIMCgRhZGRyGAIgASgJEhcKD2FscmVhZHlfcnVubmluZxgDIAEoCCIZChdDbG9zZU9BdXRoSGVscGVyUmVxdWVzdCIqChhDbG9zZU9BdXRoSGVscGVyUmVzcG9uc2USDgoGY2xvc2VkGAEgASgIIjcKFVN0YXJ0T0F1dGhGbG93UmVxdWVzdBIeChZhdXRob3JpemVfdXJsX3RlbXBsYXRlGAEgASgJIksKFlN0YXJ0T0F1dGhGbG93UmVzcG9uc2USDAoEY29kZRgBIAEoCRINCgVzdGF0ZRgCIAEoCRIUCgxyZWRpcmVjdF91cmkYAyABKAkyqQIKDURhZW1vblNlcnZpY2USWQoOU3RhcnRPQXV0aEZsb3cSIS5yZWxpYW50LnYxLlN0YXJ0T0F1dGhGbG93UmVxdWVzdBoiLnJlbGlhbnQudjEuU3RhcnRPQXV0aEZsb3dSZXNwb25zZSIAElwKD09wZW5PQXV0aEhlbHBlchIiLnJlbGlhbnQudjEuT3Blbk9BdXRoSGVscGVyUmVxdWVzdBojLnJlbGlhbnQudjEuT3Blbk9BdXRoSGVscGVyUmVzcG9uc2UiABJfChBDbG9zZU9BdXRoSGVscGVyEiMucmVsaWFudC52MS5DbG9zZU9BdXRoSGVscGVyUmVxdWVzdBokLnJlbGlhbnQudjEuQ2xvc2VPQXV0aEhlbHBlclJlc3BvbnNlIgBCOlo4Z2l0aHViLmNvbS9yZWxpYW50LWxhYnMvcmVsaWFudC9nZW4vcmVsaWFudC92MTtyZWxpYW50djFiBnByb3RvMw");
+
+/**
+ * @generated from message reliant.v1.OpenOAuthHelperRequest
+ */
+export type OpenOAuthHelperRequest = Message<"reliant.v1.OpenOAuthHelperRequest"> & {
+  /**
+   * Browser origin that will call the helper, added to its CORS allowlist.
+   *
+   * Passed from the UI because the daemon cannot know it: a worktree's web dev
+   * server gets a per-worktree port, so the origin is neither one of the
+   * static defaults nor present in the daemon's environment. Without it the
+   * allowlist would reject the very caller that asked for the port.
+   *
+   * @generated from field: string web_origin = 1;
+   */
+  webOrigin: string;
+};
+
+/**
+ * Describes the message reliant.v1.OpenOAuthHelperRequest.
+ * Use `create(OpenOAuthHelperRequestSchema)` to create a new message.
+ */
+export const OpenOAuthHelperRequestSchema: GenMessage<OpenOAuthHelperRequest> = /*@__PURE__*/
+  messageDesc(file_reliant_v1_daemon, 0);
+
+/**
+ * @generated from message reliant.v1.OpenOAuthHelperResponse
+ */
+export type OpenOAuthHelperResponse = Message<"reliant.v1.OpenOAuthHelperResponse"> & {
+  /**
+   * Port the helper is listening on.
+   *
+   * @generated from field: int32 port = 1;
+   */
+  port: number;
+
+  /**
+   * Full loopback address, for the probe URL.
+   *
+   * @generated from field: string addr = 2;
+   */
+  addr: string;
+
+  /**
+   * True when the port was already served (a previous session, or a standalone
+   * `reliant auth serve`). Not an error — the surface exists either way.
+   *
+   * @generated from field: bool already_running = 3;
+   */
+  alreadyRunning: boolean;
+};
+
+/**
+ * Describes the message reliant.v1.OpenOAuthHelperResponse.
+ * Use `create(OpenOAuthHelperResponseSchema)` to create a new message.
+ */
+export const OpenOAuthHelperResponseSchema: GenMessage<OpenOAuthHelperResponse> = /*@__PURE__*/
+  messageDesc(file_reliant_v1_daemon, 1);
+
+/**
+ * @generated from message reliant.v1.CloseOAuthHelperRequest
+ */
+export type CloseOAuthHelperRequest = Message<"reliant.v1.CloseOAuthHelperRequest"> & {
+};
+
+/**
+ * Describes the message reliant.v1.CloseOAuthHelperRequest.
+ * Use `create(CloseOAuthHelperRequestSchema)` to create a new message.
+ */
+export const CloseOAuthHelperRequestSchema: GenMessage<CloseOAuthHelperRequest> = /*@__PURE__*/
+  messageDesc(file_reliant_v1_daemon, 2);
+
+/**
+ * @generated from message reliant.v1.CloseOAuthHelperResponse
+ */
+export type CloseOAuthHelperResponse = Message<"reliant.v1.CloseOAuthHelperResponse"> & {
+  /**
+   * False when nothing was open.
+   *
+   * @generated from field: bool closed = 1;
+   */
+  closed: boolean;
+};
+
+/**
+ * Describes the message reliant.v1.CloseOAuthHelperResponse.
+ * Use `create(CloseOAuthHelperResponseSchema)` to create a new message.
+ */
+export const CloseOAuthHelperResponseSchema: GenMessage<CloseOAuthHelperResponse> = /*@__PURE__*/
+  messageDesc(file_reliant_v1_daemon, 3);
 
 /**
  * @generated from message reliant.v1.StartOAuthFlowRequest
@@ -32,7 +122,7 @@ export type StartOAuthFlowRequest = Message<"reliant.v1.StartOAuthFlowRequest"> 
  * Use `create(StartOAuthFlowRequestSchema)` to create a new message.
  */
 export const StartOAuthFlowRequestSchema: GenMessage<StartOAuthFlowRequest> = /*@__PURE__*/
-  messageDesc(file_reliant_v1_daemon, 0);
+  messageDesc(file_reliant_v1_daemon, 4);
 
 /**
  * @generated from message reliant.v1.StartOAuthFlowResponse
@@ -65,7 +155,7 @@ export type StartOAuthFlowResponse = Message<"reliant.v1.StartOAuthFlowResponse"
  * Use `create(StartOAuthFlowResponseSchema)` to create a new message.
  */
 export const StartOAuthFlowResponseSchema: GenMessage<StartOAuthFlowResponse> = /*@__PURE__*/
-  messageDesc(file_reliant_v1_daemon, 1);
+  messageDesc(file_reliant_v1_daemon, 5);
 
 /**
  * DaemonService exposes daemon-side operations proxied through the daemon-gateway.
@@ -83,6 +173,43 @@ export const DaemonService: GenService<{
     methodKind: "unary";
     input: typeof StartOAuthFlowRequestSchema;
     output: typeof StartOAuthFlowResponseSchema;
+  },
+  /**
+   * OpenOAuthHelper asks the daemon to open its localhost OAuth helper port
+   * for ONE account-linking session. Returns immediately — unlike
+   * StartOAuthFlow it does not block on a human working through a consent
+   * screen, which is what made that RPC unusable in the packaged app.
+   *
+   * The port is NOT open the rest of the time, deliberately: a listener that
+   * starts browsers and returns authorization codes should exist for the
+   * seconds it is needed, not for the life of every daemon on every machine.
+   * The daemon closes it on CloseOAuthHelper, or after an idle timeout if the
+   * UI never gets to send one.
+   *
+   * This pair is also how the app learns whether the daemon is CO-LOCATED with
+   * the browser — a fact neither side can assert on its own. The UI asks the
+   * daemon to open the port over the connection it already has, then probes
+   * 127.0.0.1 itself. A successful probe proves the daemon that just opened it
+   * is on the browser's machine; a failed one means the daemon is remote, and
+   * the UI can say so instead of offering a flow that would hang.
+   *
+   * @generated from rpc reliant.v1.DaemonService.OpenOAuthHelper
+   */
+  openOAuthHelper: {
+    methodKind: "unary";
+    input: typeof OpenOAuthHelperRequestSchema;
+    output: typeof OpenOAuthHelperResponseSchema;
+  },
+  /**
+   * CloseOAuthHelper closes the helper port when the linking session ends
+   * (completed or cancelled).
+   *
+   * @generated from rpc reliant.v1.DaemonService.CloseOAuthHelper
+   */
+  closeOAuthHelper: {
+    methodKind: "unary";
+    input: typeof CloseOAuthHelperRequestSchema;
+    output: typeof CloseOAuthHelperResponseSchema;
   },
 }> = /*@__PURE__*/
   serviceDesc(file_reliant_v1_daemon, 0);

--- a/web/src/hooks/useOAuthAvailability.ts
+++ b/web/src/hooks/useOAuthAvailability.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useState } from 'react'
-import { OAUTH_LOCAL_SERVER_URL } from '@/lib/oauth-local'
+import {
+  probeOAuthHelper,
+  releaseOAuthHelper,
+  requestOAuthHelper,
+} from '@/lib/oauth-local'
 
 export interface UseOAuthAvailabilityOptions {
   /**
@@ -29,15 +33,12 @@ export interface UseOAuthAvailabilityReturn {
 const POLL_INTERVAL_MS = 2000
 const HEALTH_TIMEOUT_MS = 2000
 
+// Identity-checked: a 200 alone proves only that SOMETHING holds port 19284,
+// and offering an OAuth flow to an unrelated dev server fails silently. See
+// probeOAuthHelper.
 async function pingHealth(): Promise<boolean> {
-  try {
-    const resp = await fetch(`${OAUTH_LOCAL_SERVER_URL}/health`, {
-      signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
-    })
-    return resp.ok
-  } catch {
-    return false
-  }
+  const health = await probeOAuthHelper(HEALTH_TIMEOUT_MS)
+  return !!health?.ready
 }
 
 /**
@@ -45,12 +46,18 @@ async function pingHealth(): Promise<boolean> {
  *
  * - **Electron**: always available immediately (daemon handles it); no network
  *   probe is ever made.
- * - **Web**: pings `http://127.0.0.1:19284/health` to see if `reliant auth serve`
- *   is running — but ONLY once `enabled` is `true`. Callers set `enabled` while
- *   the local-OAuth UI is on screen, so the probe (and Chrome's Local Network
- *   Access prompt) never fires for users who never chose the local-OAuth path.
- *   While enabled + unavailable, polls every 2s so the UI flips automatically
- *   when the user starts the helper in their terminal.
+ * - **Web**: probes `http://127.0.0.1:19284/health` and requires the response to
+ *   identify itself as reliant — served either by `reliant daemon start` running
+ *   on THIS machine or by a standalone `reliant auth serve`. Probing only once
+ *   `enabled` is `true`: callers set it while the local-OAuth UI is on screen, so
+ *   the probe (and Chrome's Local Network Access prompt) never fires for users
+ *   who never chose the local-OAuth path. While enabled + unavailable, polls
+ *   every 2s so the UI flips automatically when the helper appears.
+ *
+ * The probe doubles as the CO-LOCATION test. Whether the daemon is on the same
+ * machine as the browser cannot be answered from the server side — it knows its
+ * hostname and instance id, but not which machine rendered this page, and behind
+ * NAT many machines share one address. Reaching it on localhost is the proof.
  */
 export function useOAuthAvailability(
   { enabled = false }: UseOAuthAvailabilityOptions = {},
@@ -68,25 +75,39 @@ export function useOAuthAvailability(
       return
     }
     setLoading(true)
-    const ok = await pingHealth()
-    setAvailable(ok)
+    // An explicit retry ASKS again: the user may have started a daemon since
+    // the last attempt, and re-probing alone would never open a port.
+    const health = await requestOAuthHelper()
+    setAvailable(!!health?.ready)
     setLoading(false)
   }, [isElectron])
 
-  // Kick off an immediate check when probing turns on. In Electron we never
-  // touch the network; while disabled we stay quiet so no health probe fires.
+  // Ask the daemon to OPEN the port when the panel appears, then confirm it is
+  // reachable here.
+  //
+  // Requesting rather than merely probing is what removes the second terminal
+  // command: a connected daemon on this machine opens the port on demand, so
+  // `reliant auth serve` is only needed when the daemon is remote or absent.
+  // The request is also the co-location test — see requestOAuthHelper.
+  //
+  // In Electron we never touch the network; while disabled we stay quiet so
+  // nothing fires for users who never chose the local-OAuth path.
   useEffect(() => {
     if (isElectron || !enabled) return
     let cancelled = false
     void (async () => {
       setLoading(true)
-      const ok = await pingHealth()
+      const health = await requestOAuthHelper()
       if (cancelled) return
-      setAvailable(ok)
+      setAvailable(!!health?.ready)
       setLoading(false)
     })()
     return () => {
       cancelled = true
+      // Release the port when the panel goes away. The daemon's idle timeout
+      // is the backstop for a tab that closes without unmounting; this is the
+      // fast path that keeps the listener's life equal to the task.
+      void releaseOAuthHelper()
     }
   }, [enabled, isElectron])
 

--- a/web/src/lib/oauth-local.ts
+++ b/web/src/lib/oauth-local.ts
@@ -1,10 +1,64 @@
 /**
  * Local OAuth helper server used in web mode.
- * Started via `reliant auth serve` on the user's machine.
+ *
+ * Served by `reliant daemon start` when the daemon runs on THIS machine, or by
+ * `reliant auth serve` standalone (the remote-daemon case).
+ *
+ * Reaching it is also how the app knows the helper is co-located with the
+ * browser. Nothing on the server side can establish that: a daemon knows its
+ * own hostname and instance id, but nothing in its connection says which
+ * machine rendered this page, and behind NAT many machines share one address.
+ * "localhost" means the same machine to the browser and to whoever answers, so
+ * a successful probe IS the proof.
  */
 
 export const OAUTH_LOCAL_SERVER_PORT = 19284
 export const OAUTH_LOCAL_SERVER_URL = `http://127.0.0.1:${OAUTH_LOCAL_SERVER_PORT}`
+
+/** The `service` value reliant's helper reports on /health. */
+export const OAUTH_HELPER_SERVICE = 'reliant'
+
+/** The /health document (internal/auth/oauthhelper.HealthResponse). */
+export interface OAuthHelperHealth {
+  status: string
+  service: string
+  ready: boolean
+  version: string
+  /** Which command is serving: 'daemon' | 'auth-serve'. Diagnostic only. */
+  source: string
+}
+
+/**
+ * Probe the helper and return its identity, or null when nothing reliant is
+ * there.
+ *
+ * Checking the `service` marker is the point. A bare 200 proves only that
+ * SOMETHING holds port 19284 — any other dev server on that port answers a
+ * health probe too, and the UI would then offer an OAuth flow that silently
+ * fails. Requiring `service === 'reliant'` distinguishes "reliant is here"
+ * from "a port is here".
+ */
+export async function probeOAuthHelper(
+  timeoutMs = 2000,
+): Promise<OAuthHelperHealth | null> {
+  try {
+    const resp = await fetch(`${OAUTH_LOCAL_SERVER_URL}/health`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+    if (!resp.ok) return null
+    const body = (await resp.json()) as Partial<OAuthHelperHealth>
+    if (body?.service !== OAUTH_HELPER_SERVICE) return null
+    return {
+      status: body.status ?? 'unknown',
+      service: body.service,
+      ready: body.ready ?? false,
+      version: body.version ?? 'unknown',
+      source: body.source ?? 'unknown',
+    }
+  } catch {
+    return null
+  }
+}
 
 /** Shape matching the daemon's StartOAuthFlowResponse (camelCase). */
 export interface OAuthStartResult {
@@ -14,7 +68,54 @@ export interface OAuthStartResult {
 }
 
 /**
- * Start an OAuth flow via the local `reliant auth serve` HTTP server.
+ * Ask the daemon to open its helper port, then confirm it is reachable HERE.
+ *
+ * This two-step is the co-location test, and neither half works alone. The
+ * request goes over the connection the daemon already holds — so it reaches
+ * the daemon wherever it is — and the probe is a plain localhost fetch from
+ * the browser. If the probe succeeds, the daemon that just opened the port is
+ * demonstrably on this machine. If it fails, the daemon is remote: the port it
+ * opened is on the wrong host, and an OAuth redirect to `localhost` would
+ * never reach it.
+ *
+ * Returns the helper's identity on success, or null when the daemon is remote
+ * (or nothing answered). Callers that get null should fall back to
+ * `reliant auth serve` and say so.
+ *
+ * On a null result the port opened on the remote daemon is released, so a
+ * failed probe does not leave a listener behind on someone else's machine.
+ */
+export async function requestOAuthHelper(
+  signal?: AbortSignal,
+): Promise<OAuthHelperHealth | null> {
+  const { openOAuthHelper, closeOAuthHelper } = await import('@/api/daemon-grpc')
+
+  try {
+    await openOAuthHelper(window.location.origin, signal)
+  } catch {
+    // The daemon is unreachable, too old to know the RPC, or refused. Fall
+    // back to probing in case a standalone `auth serve` is already running.
+    return probeOAuthHelper()
+  }
+
+  // The daemon reports success as soon as its listener is bound, but that
+  // listener may be on another machine — only this probe can tell.
+  const health = await probeOAuthHelper()
+  if (!health) {
+    void closeOAuthHelper()
+    return null
+  }
+  return health
+}
+
+/** Release the helper port. Safe to call when nothing is open. */
+export async function releaseOAuthHelper(): Promise<void> {
+  const { closeOAuthHelper } = await import('@/api/daemon-grpc')
+  await closeOAuthHelper()
+}
+
+/**
+ * Start an OAuth flow via the local helper HTTP server.
  * Returns the same shape as the daemon's StartOAuthFlowResponse so callers
  * don't need to care which path was used.
  */
@@ -41,8 +142,9 @@ export async function startOAuthViaLocalServer(
     // serve` was stopped, or never started. The browser reports that as a bare
     // "Failed to fetch", which tells the user nothing and names no remedy.
     throw new Error(
-      'The local OAuth helper is no longer running. Start it again with ' +
-        '`reliant auth serve`, then retry.',
+      'The local OAuth helper is no longer running. Start the daemon on this ' +
+        'machine with `reliant daemon start` (it serves the helper), or run ' +
+        '`reliant auth serve` on its own, then retry.',
     )
   }
 


### PR DESCRIPTION
## Problem

Connecting a Claude/Codex account from a browser needs **two** commands today:

```
reliant daemon start --token    # stays connected
reliant auth serve              # …and now a second terminal
```

The second one is ceremony. The daemon is already connected and already knows
how to run the flow — `cmd_auth.go`'s `auth.start_oauth` calls the same
`oauthcallback.Run` that `auth serve` does. They differ only in transport.

## What this changes

The UI now **asks** the daemon to open the helper port when it needs one, over
the connection that already exists, and asks it to close when the session ends.

### On demand, not always-on

The helper starts browsers and hands back authorization codes. A port doing
that, open for the life of every daemon on every machine, is a standing local
surface nobody asked for — and unnecessary, since it's only needed for the
seconds a user spends linking an account.

- `OpenOAuthHelper` binds it, `CloseOAuthHelper` releases it.
- A **10-minute idle timeout** is the backstop for a UI that never gets to send
  the close (closed tab, crash).
- An in-flight `/oauth/start` holds the port open **regardless of duration**, so
  the timer can never close it under a live consent screen.

### It also answers the co-location question

Whether the daemon is on the same machine as the browser can't be asserted by
either side alone. The daemon knows its hostname and instance id, but nothing in
its connection says which machine rendered the page — both legs terminate at the
gateway, and behind NAT many machines share one address.

So the UI does both halves: it **asks over the connection** (which reaches the
daemon wherever it is), then **probes `127.0.0.1` itself**.

- Probe succeeds → the daemon that just opened the port is *provably* on this
  machine.
- Probe fails → the daemon is remote, the port it opened is on the wrong host,
  and the UI says so instead of offering a flow that would hang. The remote port
  is released rather than left listening.

### /health carries identity

A bare `{"status":"ok"}` proves only that *something* holds port 19284 — any
other dev server answers a health probe the same way, and the UI would then
offer a flow that silently fails.

```json
{"status":"ok","service":"reliant","ready":true,"version":"v1.7.8-…","source":"daemon"}
```

The client **requires** `service === "reliant"` before believing it. `source` is
diagnostic: it answers "why is this already running?" without a process hunt.

### Not the blocking RPC

This deliberately does **not** reuse `StartOAuthFlow`. That RPC holds a single
request/response open while a human works through a consent screen; in the
packaged app it failed at ~15s with "Failed to fetch", and cancelling tore down
the listener so the redirect hit a closed port (see the existing warning on
`startOAuthViaDaemon`). Open/close return as soon as the listener is bound or
released, and the waiting happens on the loopback connection where it belongs.

### `auth serve` still exists

Unchanged in behaviour — it's now the **remote-daemon** path, and its help text
says so. Both hosts share `internal/auth/oauthhelper`, so the CORS allowlist
(`RELIANT_WEB_ORIGIN`, `FRONTEND_PORT`) resolves identically in each. Reading it
in only one is how the daemon path would 403 a request `auth serve` allows, with
an error naming the origin and not the reason.

## Testing

Nine unit tests in `internal/auth/oauthhelper`: identity on `/health`, typed
`ErrPortInUse` (so the daemon degrades instead of refusing to start),
allowlist resolution from both env vars, CORS reflected only for allowed
origins, `/oauth/start` rejecting a disallowed origin before any browser opens,
loopback-only binding, idle close, idle **reset** under load, and idempotent
shutdown.

Verified end-to-end against the real command handlers — port absent → opened on
request → answers as `reliant` → closed → gone:

```
open response: {"port":19284,"addr":"127.0.0.1:19284","already_running":false}
close response: {"closed":true}
```

`go build ./...`, `go vet`, and the four affected packages' tests all pass;
frontend `tsc --noEmit` and `eslint` are clean.

## Follow-up

The UI copy for the remote-daemon case is minimal — it falls back to the
existing panel. Worth a design pass to say "this daemon is on another machine"
explicitly, now that the app can actually distinguish that from "helper not
running".
