### PR TITLE
fix(tools): stop fetch/websearch from imposing a daemon requirement

### DIFF
--- a/internal/llm/tools/registry.go
+++ b/internal/llm/tools/registry.go
@@ -463,9 +463,15 @@ func GetToolRegistry() []ToolDefinition {
 		{ToolShellWait, (*ToolsFactory).ShellWait, []ToolTag{TagExecution, TagShell, TagReadOnly, TagPlan, TagDefault}, ToolRunsOnDaemon},
 		{ToolShellKill, (*ToolsFactory).ShellKill, []ToolTag{TagExecution, TagShell, TagDefault}, ToolRunsOnDaemon},
 
-		// Network tools — routed to daemon so HTTP requests originate from the user's machine
-		{ToolFetch, (*ToolsFactory).Fetch, []ToolTag{TagWeb, TagReadOnly, TagPlan, TagDefault}, ToolRunsOnDaemon},
-		{ToolWebSearch, (*ToolsFactory).WebSearch, []ToolTag{TagWeb, TagReadOnly, TagPlan, TagDefault}, ToolRunsOnDaemon},
+		// Network tools. Both are pure net/http plus HTML parsing — no filesystem,
+		// no subprocess — so they carry no daemon requirement. They were daemon-routed
+		// so outbound requests would originate from the user's machine; that is now
+		// paid for elsewhere, because RequiresDaemon treats a daemon-located tool in a
+		// node's filter as proof the whole workflow needs a daemon. With TagDefault on
+		// both, `tag:default` alone was enough to fire the preflight gate and refuse a
+		// workflow that never touches the user's machine.
+		{ToolFetch, (*ToolsFactory).Fetch, []ToolTag{TagWeb, TagReadOnly, TagPlan, TagDefault}, ToolRunsAnywhere},
+		{ToolWebSearch, (*ToolsFactory).WebSearch, []ToolTag{TagWeb, TagReadOnly, TagPlan, TagDefault}, ToolRunsAnywhere},
 
 		// Planning tools
 		{ToolCreatePlan, (*ToolsFactory).CreatePlan, []ToolTag{TagPlanning, TagPlan, TagDefault}, ToolRunsOnServer},

--- a/internal/llm/tools/registry_network_location_test.go
+++ b/internal/llm/tools/registry_network_location_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2025 Reliant Labs
+package tools
+
+import "testing"
+
+// TestNetworkToolsAreNotDaemonBound pins fetch and websearch to a location that
+// does not require a daemon.
+//
+// Both tools are pure net/http plus HTML parsing — they open no files and spawn
+// no processes — so a daemon buys them nothing but a hard dependency. The cost
+// of the old marking was not just a wasted hop: RequiresDaemon (see
+// internal/workflow/runtime/preflight.go) treats any daemon-located tool in a
+// node's filter as proof the whole workflow needs a daemon, and both tools carry
+// TagDefault. That made `tag:default` — the most common filter there is — enough
+// to fire the preflight gate and refuse to start a workflow that never touches
+// the user's machine.
+//
+// The tradeoff this test locks in: outbound HTTP now originates from the server
+// rather than the user's machine.
+func TestNetworkToolsAreNotDaemonBound(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{ToolFetch, ToolWebSearch} {
+		var found *ToolDefinition
+		for _, def := range GetToolRegistry() {
+			if def.Name == name {
+				found = &def
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("tool %q is not in the registry", name)
+		}
+		if found.RunsOn == ToolRunsOnDaemon {
+			t.Errorf("tool %q is marked %q; network-only tools must not require a daemon",
+				name, ToolRunsOnDaemon)
+		}
+	}
+}

--- a/internal/workflow/runtime/preflight_network_tools_test.go
+++ b/internal/workflow/runtime/preflight_network_tools_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 Reliant Labs
+package runtime
+
+import (
+	"testing"
+
+	reliantv1 "github.com/reliant-labs/reliant/gen/reliant/v1"
+)
+
+// networkOnlyPreflightConfig mirrors the real registry after fetch and websearch
+// stopped being daemon-located. Unlike testPreflightConfig, which hardcodes the
+// old marking, this one encodes the corrected fact so the assertion below is
+// about RequiresDaemon's behaviour rather than about the fixture.
+func networkOnlyPreflightConfig() *PreflightConfig {
+	daemonTools := map[string]bool{
+		"shell":        true,
+		"shell_list":   true,
+		"shell_output": true,
+		"shell_kill":   true,
+		"code_context": true,
+	}
+	return &PreflightConfig{
+		IsDaemonTool: func(name string) bool { return daemonTools[name] },
+		ExpandToolFilter: func(filter []string) []string {
+			var result []string
+			for _, spec := range filter {
+				switch spec {
+				case "tag:web":
+					result = append(result, "fetch", "websearch")
+				case "tag:readonly":
+					result = append(result, "view", "fetch", "websearch")
+				default:
+					result = append(result, spec)
+				}
+			}
+			return result
+		},
+	}
+}
+
+// TestRequiresDaemon_NetworkOnlyAgentNeedsNoDaemon is the workflow-level point of
+// the location change: an agent that can read the web and nothing else must be
+// able to start with no daemon connected.
+//
+// Before fetch/websearch moved off the daemon this returned true, so the
+// preflight gate refused the run — the failure the daemon-less work exists to
+// remove.
+func TestRequiresDaemon_NetworkOnlyAgentNeedsNoDaemon(t *testing.T) {
+	t.Parallel()
+
+	wf := &reliantv1.Workflow{
+		Nodes: []*reliantv1.Node{
+			{
+				Id:   "research",
+				Type: "call_llm",
+				Args: &reliantv1.Node_CallLlm{
+					CallLlm: &reliantv1.CallLLMArgs{
+						ToolsConfig: &reliantv1.ToolsConfig{
+							Filter: &reliantv1.CelStringList{
+								Value: &reliantv1.CelStringList_Literal{
+									Literal: &reliantv1.StringList{
+										Values: []string{"tag:web"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if RequiresDaemon(wf, networkOnlyPreflightConfig()) {
+		t.Error("a workflow whose only tools are fetch/websearch must not require a daemon")
+	}
+}
+
+// TestRequiresDaemon_ShellStillRequiresDaemon guards the other half: relaxing the
+// network tools must not relax the gate for tools that genuinely need a machine.
+func TestRequiresDaemon_ShellStillRequiresDaemon(t *testing.T) {
+	t.Parallel()
+
+	wf := &reliantv1.Workflow{
+		Nodes: []*reliantv1.Node{
+			{
+				Id:   "build",
+				Type: "call_llm",
+				Args: &reliantv1.Node_CallLlm{
+					CallLlm: &reliantv1.CallLLMArgs{
+						ToolsConfig: &reliantv1.ToolsConfig{
+							Filter: &reliantv1.CelStringList{
+								Value: &reliantv1.CelStringList_Literal{
+									Literal: &reliantv1.StringList{
+										Values: []string{"shell"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if !RequiresDaemon(wf, networkOnlyPreflightConfig()) {
+		t.Error("a workflow using the shell must still require a daemon")
+	}
+}


### PR DESCRIPTION
## What

Moves `fetch` and `websearch` from `ToolRunsOnDaemon` to `ToolRunsAnywhere`.

## Why this is more than a wasted network hop

Both tools are pure `net/http` plus HTML parsing — verified zero `os.`, `exec.`, or `filepath.` references in `fetch.go` or `websearch.go`. The daemon marking existed so outbound HTTP would originate from the user's machine, not because either tool needed a machine.

The cost was a hard dependency in a place that is easy to miss. `RequiresDaemon` (`internal/workflow/runtime/preflight.go:53-98`) treats **any** daemon-located tool in a node's filter as proof the whole workflow needs a daemon, and both tools carry `TagDefault`. So `tag:default` — the most common filter there is — was enough to fire the preflight gate and **refuse to start a workflow that never touches the user's machine**.

The registry's own comment already documented the intended rule and contradicted the marking:

> `ToolRunsAnywhere` means the tool has no special requirements. It can run on either side (e.g., network-only tools like fetch/websearch).

## Tradeoff — needs a product yes

**Outbound HTTP now originates from the server rather than the user's machine.** That routing was a deliberate choice, so it is being traded away deliberately here, and the new comment says so in place. If per-user egress IP matters for any integration, this is the PR to object to.

`code_context` deliberately stays daemon-located — it opens files (`code_context_source.go:159`) and spawns language servers (`code_context.go:752`).

## Tests

Both fail before this change and pass after:

- `TestNetworkToolsAreNotDaemonBound` — pins the registry fact.
- `TestRequiresDaemon_NetworkOnlyAgentNeedsNoDaemon` — the workflow-level point: an agent that can read the web and nothing else must start with no daemon connected.
- `TestRequiresDaemon_ShellStillRequiresDaemon` — guards the other half, so relaxing the network tools does not relax the gate for tools that genuinely need a machine.

Full repo suite green: 118 packages, 0 failures.

## Context

First shipped step toward running workflows with no daemon connected. Research notes in `research/DAEMONLESS.md`; plan in `research/ENGINE_SPLIT_PLAN.md`.
