### PR TITLE
fix(tools): scope loaded-tool grants to a run, and fail closed

### DIFF
--- a/internal/llm/tools/load_tool.go
+++ b/internal/llm/tools/load_tool.go
@@ -65,13 +65,16 @@ func (t *loadToolTool) Execute(rctx *rctx.ToolContext, params LoadToolParams) (T
 		return NewTextErrorResponse("Either 'name' or 'query' is required"), nil
 	}
 
-	// Resolve permission from the store (set by call_llm based on preset/workflow inputs)
-	chatID := GetChatID(rctx)
-	permission := GetLoadedToolsStore().GetPermission(chatID)
+	// Resolve permission from the store (set by call_llm based on preset/workflow
+	// inputs). Keyed by scope, not chat: a spawned child shares the chat with its
+	// parent and is distinguished only by thread, so a chat-keyed read would hand
+	// the child whichever level was written last.
+	scopeKey := Scope(GetChatID(rctx), rctx.Thread)
+	permission := GetLoadedToolsStore().GetPermission(scopeKey)
 
 	// Search mode
 	if params.Query != "" {
-		return t.searchTools(chatID, params.Query, permission), nil
+		return t.searchTools(scopeKey, params.Query, permission), nil
 	}
 
 	// Load mode
@@ -107,14 +110,14 @@ func (t *loadToolTool) loadTool(rctx *rctx.ToolContext, name string, permission 
 	}
 
 	// Check if already loaded
-	chatID := GetChatID(rctx)
+	scopeKey := Scope(GetChatID(rctx), rctx.Thread)
 	store := GetLoadedToolsStore()
-	if store.Has(chatID, name) {
+	if store.Has(scopeKey, name) {
 		return NewTextResponse(fmt.Sprintf("Tool '%s' is already loaded.", name))
 	}
 
 	// Add to loaded tools store
-	store.Add(chatID, name)
+	store.Add(scopeKey, name)
 
 	// Return confirmation with metadata for the runtime
 	metadata := LoadToolMetadata{
@@ -128,23 +131,23 @@ func (t *loadToolTool) loadTool(rctx *rctx.ToolContext, name string, permission 
 }
 
 func (t *loadToolTool) loadMCPTool(rctx *rctx.ToolContext, name string) ToolResponse {
-	chatID := GetChatID(rctx)
+	scopeKey := Scope(GetChatID(rctx), rctx.Thread)
 	store := GetLoadedToolsStore()
 
-	if store.Has(chatID, name) {
+	if store.Has(scopeKey, name) {
 		return NewTextResponse(fmt.Sprintf("Tool '%s' is already loaded.", name))
 	}
 
 	// Verify the MCP tool is actually connected in this environment before
 	// loading it. Adding an unavailable name would be silently dropped by the
 	// runtime next turn ("Tools in filter not found"), so fail loudly instead.
-	if !mcpToolAvailable(store.GetAvailableMCPTools(chatID), name) {
+	if !mcpToolAvailable(store.GetAvailableMCPTools(scopeKey), name) {
 		return NewTextErrorResponse(fmt.Sprintf(
 			"MCP tool '%s' is not available in this environment. Use load_tool with a query to discover connected MCP tools.", name))
 	}
 
 	// MCP tools are gated by MCP configuration, not the agent permission ladder.
-	store.Add(chatID, name)
+	store.Add(scopeKey, name)
 
 	metadata := LoadToolMetadata{
 		LoadedTools: []string{name},
@@ -167,8 +170,8 @@ func mcpToolAvailable(available []MCPToolInfo, name string) bool {
 	return false
 }
 
-func (t *loadToolTool) searchTools(chatID, query string, permission string) ToolResponse {
-	mcpTools := GetLoadedToolsStore().GetAvailableMCPTools(chatID)
+func (t *loadToolTool) searchTools(scopeKey, query string, permission string) ToolResponse {
+	mcpTools := GetLoadedToolsStore().GetAvailableMCPTools(scopeKey)
 	results := SearchTools(query, permission, mcpTools)
 
 	if len(results) == 0 {

--- a/internal/llm/tools/load_tool_test.go
+++ b/internal/llm/tools/load_tool_test.go
@@ -16,17 +16,19 @@ import (
 func newLoadToolTestCtx(t *testing.T, permission string) *rctx.ToolContext {
 	t.Helper()
 	chatID := "loadtool-test-" + t.Name()
+	const thread = "0"
+	scopeKey := Scope(chatID, thread)
 
 	store := GetLoadedToolsStore()
-	store.Clear(chatID) // start clean in case a prior run left state
-	store.SetPermission(chatID, permission)
+	store.Clear(scopeKey) // start clean in case a prior run left state
+	store.SetPermission(scopeKey, permission)
 
 	t.Cleanup(func() {
-		store.Clear(chatID)
+		store.Clear(scopeKey)
 	})
 
 	worktree := &rctx.WorktreeInfo{ID: "test", Path: t.TempDir()}
-	return rctx.NewToolContext(context.Background(), chatID, "0", nil, worktree)
+	return rctx.NewToolContext(context.Background(), chatID, thread, nil, worktree)
 }
 
 // ----- Load / search behavior -----
@@ -103,7 +105,7 @@ func TestLoadTool_GeneralPresetAgentCanReachWorkflowTools(t *testing.T) {
 			"a mutating-permission agent must be able to load %q via load_tool: %s", name, loadResp.Content)
 	}
 
-	loaded := GetLoadedToolsStore().Get(ctx.ChatID)
+	loaded := GetLoadedToolsStore().Get(Scope(ctx.ChatID, ctx.Thread))
 	for _, name := range []string{ToolCreateWorkflow, ToolEditWorkflow, ToolListWorkflows, ToolGetWorkflow} {
 		assert.Contains(t, loaded, name, "%q should be recorded as loaded for this chat", name)
 	}
@@ -141,7 +143,7 @@ func TestLoadTool_SearchByQuery_SurfacesConnectedMCPTool(t *testing.T) {
 	tool := &loadToolTool{}
 	ctx := newLoadToolTestCtx(t, PermissionOrchestrator)
 
-	GetLoadedToolsStore().SetAvailableMCPTools(ctx.ChatID, []MCPToolInfo{
+	GetLoadedToolsStore().SetAvailableMCPTools(Scope(ctx.ChatID, ctx.Thread), []MCPToolInfo{
 		{Name: "mcp__chrome-devtools__take_screenshot", Description: "Capture a screenshot"},
 	})
 
@@ -158,7 +160,7 @@ func TestLoadTool_LoadMCPTool_ConnectedSucceeds(t *testing.T) {
 	ctx := newLoadToolTestCtx(t, PermissionOrchestrator)
 
 	const mcpName = "mcp__chrome-devtools__take_screenshot"
-	GetLoadedToolsStore().SetAvailableMCPTools(ctx.ChatID, []MCPToolInfo{
+	GetLoadedToolsStore().SetAvailableMCPTools(Scope(ctx.ChatID, ctx.Thread), []MCPToolInfo{
 		{Name: mcpName, Description: "Capture a screenshot"},
 	})
 
@@ -167,7 +169,7 @@ func TestLoadTool_LoadMCPTool_ConnectedSucceeds(t *testing.T) {
 	assert.False(t, resp.IsError, "connected MCP tool should load: %s", resp.Content)
 	assert.Contains(t, resp.Content, mcpName)
 	assert.Contains(t, resp.Metadata, mcpName, "metadata should announce the loaded MCP tool")
-	assert.True(t, GetLoadedToolsStore().Has(ctx.ChatID, mcpName),
+	assert.True(t, GetLoadedToolsStore().Has(Scope(ctx.ChatID, ctx.Thread), mcpName),
 		"connected MCP tool must be recorded in the store")
 }
 
@@ -264,13 +266,14 @@ func TestLoadTool_StoresInLoadedToolsStore(t *testing.T) {
 	ctx := newLoadToolTestCtx(t, PermissionOrchestrator)
 
 	store := GetLoadedToolsStore()
-	assert.False(t, store.Has(ctx.ChatID, ToolWrite), "precondition: not yet loaded")
+	scopeKey := Scope(ctx.ChatID, ctx.Thread)
+	assert.False(t, store.Has(scopeKey, ToolWrite), "precondition: not yet loaded")
 
 	resp, err := tool.Execute(ctx, LoadToolParams{Name: ToolWrite})
 	require.NoError(t, err)
 	require.False(t, resp.IsError, "load must succeed: %s", resp.Content)
 
-	assert.True(t, store.Has(ctx.ChatID, ToolWrite),
+	assert.True(t, store.Has(scopeKey, ToolWrite),
 		"successfully loaded tool must be recorded in the store")
 }
 
@@ -292,7 +295,7 @@ func TestLoadTool_LoadAlreadyLoadedTool_Idempotent(t *testing.T) {
 
 	// Still exactly one entry.
 	store := GetLoadedToolsStore()
-	loaded := store.Get(ctx.ChatID)
+	loaded := store.Get(Scope(ctx.ChatID, ctx.Thread))
 	assert.Equal(t, []string{ToolWrite}, loaded)
 }
 

--- a/internal/llm/tools/loaded_tools_store.go
+++ b/internal/llm/tools/loaded_tools_store.go
@@ -9,15 +9,40 @@ import (
 	"github.com/reliant-labs/reliant/internal/config"
 )
 
-// LoadedToolsStore tracks which tools have been dynamically loaded per chat.
-// This is an in-memory store that persists across loop iterations within
-// the same server process. Thread-safe for concurrent access.
+// LoadedToolsStore tracks which tools have been dynamically loaded, and at what
+// permission, for one agent scope. This is an in-memory store that persists
+// across loop iterations within the same server process. Thread-safe for
+// concurrent access.
+//
+// Entries are keyed by SCOPE — (chatID, thread) via scope() — not by chat.
+// Thread is what distinguishes the three things a chat-only key conflated:
+// a new run sets targetThread = workflowID, and a spawned child runs on the
+// SAME chat under a new thread. Keying by chat alone therefore let a completed
+// run's grants reappear in the next run, and let a child's grants outlive it
+// into the parent (and vice versa). Callers must pass scope(chatID, thread).
 type LoadedToolsStore struct {
 	mu           sync.RWMutex
-	tools        map[string]map[string]bool      // chatID -> set of tool names
-	permissions  map[string]string               // chatID -> permission level
-	skills       map[string][]config.StoredSkill // chatID -> skills
-	availableMCP map[string][]MCPToolInfo        // chatID -> connected/available MCP tools
+	tools        map[string]map[string]bool      // scope -> set of tool names
+	permissions  map[string]string               // scope -> permission level
+	skills       map[string][]config.StoredSkill // scope -> skills
+	availableMCP map[string][]MCPToolInfo        // scope -> connected/available MCP tools
+}
+
+// scope builds the store key identifying one agent's tool state: a single run of
+// a single thread. Callers that genuinely have no thread (there should be none
+// on the production path) degrade to chat-only keying rather than colliding on
+// an empty key.
+func scope(chatID, thread string) string {
+	if thread == "" {
+		return chatID
+	}
+	return chatID + "\x00" + thread
+}
+
+// Scope exposes the store's key construction to callers outside this package
+// (the workflow activities), so the key shape stays defined in exactly one place.
+func Scope(chatID, thread string) string {
+	return scope(chatID, thread)
 }
 
 // MCPToolInfo carries the minimal metadata needed for progressive discovery of
@@ -41,28 +66,28 @@ func GetLoadedToolsStore() *LoadedToolsStore {
 	return globalLoadedToolsStore
 }
 
-// Add adds a tool to the loaded set for a chat.
+// Add adds a tool to the loaded set for a scope.
 // Returns true if the tool was newly added, false if already loaded.
-func (s *LoadedToolsStore) Add(chatID, toolName string) bool {
+func (s *LoadedToolsStore) Add(scopeKey, toolName string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.tools[chatID] == nil {
-		s.tools[chatID] = make(map[string]bool)
+	if s.tools[scopeKey] == nil {
+		s.tools[scopeKey] = make(map[string]bool)
 	}
-	if s.tools[chatID][toolName] {
+	if s.tools[scopeKey][toolName] {
 		return false
 	}
-	s.tools[chatID][toolName] = true
+	s.tools[scopeKey][toolName] = true
 	return true
 }
 
-// Get returns all loaded tool names for a chat.
-func (s *LoadedToolsStore) Get(chatID string) []string {
+// Get returns all loaded tool names for a scope.
+func (s *LoadedToolsStore) Get(scopeKey string) []string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	set := s.tools[chatID]
+	set := s.tools[scopeKey]
 	if len(set) == 0 {
 		return nil
 	}
@@ -75,29 +100,32 @@ func (s *LoadedToolsStore) Get(chatID string) []string {
 	return names
 }
 
-// Has checks if a tool is loaded for a chat.
-func (s *LoadedToolsStore) Has(chatID, toolName string) bool {
+// Has checks if a tool is loaded for a scope.
+func (s *LoadedToolsStore) Has(scopeKey, toolName string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return s.tools[chatID][toolName]
+	return s.tools[scopeKey][toolName]
 }
 
-// Clear removes all loaded tools, permission, and skills for a chat.
-func (s *LoadedToolsStore) Clear(chatID string) {
+// Clear removes all loaded tools, permission, and skills for a scope. Called
+// when a run reaches a terminal state so its grants do not outlive it; scoped
+// keying makes a missed Clear far less dangerous than it was, but a run that
+// ends should still release its state rather than wait for process exit.
+func (s *LoadedToolsStore) Clear(scopeKey string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	delete(s.tools, chatID)
-	delete(s.permissions, chatID)
-	delete(s.skills, chatID)
-	delete(s.availableMCP, chatID)
+	delete(s.tools, scopeKey)
+	delete(s.permissions, scopeKey)
+	delete(s.skills, scopeKey)
+	delete(s.availableMCP, scopeKey)
 }
 
-// SetAvailableMCPTools records the connected/available MCP tools for a chat so
+// SetAvailableMCPTools records the connected/available MCP tools for a scope so
 // load_tool can search them by keyword and verify they exist before loading.
-// Passing an empty slice clears any previously recorded set for the chat.
-func (s *LoadedToolsStore) SetAvailableMCPTools(chatID string, mcpTools []MCPToolInfo) {
+// Passing an empty slice clears any previously recorded set for the scope.
+func (s *LoadedToolsStore) SetAvailableMCPTools(scopeKey string, mcpTools []MCPToolInfo) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -105,61 +133,66 @@ func (s *LoadedToolsStore) SetAvailableMCPTools(chatID string, mcpTools []MCPToo
 		s.availableMCP = make(map[string][]MCPToolInfo)
 	}
 	if len(mcpTools) == 0 {
-		delete(s.availableMCP, chatID)
+		delete(s.availableMCP, scopeKey)
 		return
 	}
-	s.availableMCP[chatID] = mcpTools
+	s.availableMCP[scopeKey] = mcpTools
 }
 
 // GetAvailableMCPTools returns the connected/available MCP tools recorded for a
-// chat, or nil if none.
-func (s *LoadedToolsStore) GetAvailableMCPTools(chatID string) []MCPToolInfo {
+// scope, or nil if none.
+func (s *LoadedToolsStore) GetAvailableMCPTools(scopeKey string) []MCPToolInfo {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return s.availableMCP[chatID]
+	return s.availableMCP[scopeKey]
 }
 
-// SetSkills stores the project skills for a chat so the executor can access them.
-func (s *LoadedToolsStore) SetSkills(chatID string, skills []config.StoredSkill) {
+// SetSkills stores the project skills for a scope so the executor can access them.
+func (s *LoadedToolsStore) SetSkills(scopeKey string, skills []config.StoredSkill) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.skills[chatID] = skills
+	s.skills[scopeKey] = skills
 }
 
-// GetSkills returns the stored skills for a chat, or nil if none.
-func (s *LoadedToolsStore) GetSkills(chatID string) []config.StoredSkill {
+// GetSkills returns the stored skills for a scope, or nil if none.
+func (s *LoadedToolsStore) GetSkills(scopeKey string) []config.StoredSkill {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return s.skills[chatID]
+	return s.skills[scopeKey]
 }
 
-// SetPermission sets the permission level for a chat.
-func (s *LoadedToolsStore) SetPermission(chatID, permission string) {
+// SetPermission sets the permission level for a scope.
+func (s *LoadedToolsStore) SetPermission(scopeKey, permission string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.permissions[chatID] = permission
+	s.permissions[scopeKey] = permission
 }
 
-// GetPermission returns the permission level for a chat.
-// Returns PermissionOrchestrator if not set (backward compatible default).
-func (s *LoadedToolsStore) GetPermission(chatID string) string {
+// GetPermission returns the permission level for a scope.
+//
+// An unknown scope FAILS CLOSED at PermissionReadOnly. This store is in-memory,
+// so a worker restart empties it while runs are in flight; the previous default
+// of PermissionOrchestrator meant that any execute_tools landing between the
+// restart and the next call_llm — which is what re-populates the scope — was
+// granted maximum privilege precisely because the state had been lost.
+func (s *LoadedToolsStore) GetPermission(scopeKey string) string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if perm, ok := s.permissions[chatID]; ok {
+	if perm, ok := s.permissions[scopeKey]; ok {
 		return perm
 	}
-	return PermissionOrchestrator
+	return PermissionReadOnly
 }
 
 // DeferredToolNames returns tool names from the registry (and available MCP tools)
 // that are NOT in the initial set and NOT already loaded for a given chat.
 // These are the tools the LLM can request via load_tool.
-func DeferredToolNames(chatID string, permission string, initialToolNames []string, mcpToolNames []string) []string {
+func DeferredToolNames(scopeKey string, permission string, initialToolNames []string, mcpToolNames []string) []string {
 	registry := GetToolRegistry()
 	store := GetLoadedToolsStore()
 
@@ -168,7 +201,7 @@ func DeferredToolNames(chatID string, permission string, initialToolNames []stri
 	for _, name := range initialToolNames {
 		loaded[name] = true
 	}
-	for _, name := range store.Get(chatID) {
+	for _, name := range store.Get(scopeKey) {
 		loaded[name] = true
 	}
 

--- a/internal/llm/tools/loaded_tools_store_scope_test.go
+++ b/internal/llm/tools/loaded_tools_store_scope_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 Reliant Labs
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The store is keyed by (chatID, thread) rather than chatID alone. Thread is
+// unique per run — a new run sets targetThread = workflowID
+// (chat_send.go:1005) — and a spawned child runs on the SAME chat with a new
+// thread. Keying by chat alone therefore conflated three different scopes, and
+// each of the tests below pins one of the resulting leaks shut.
+
+// TestLoadedToolsStore_DoesNotLeakAcrossRuns covers the plan-after-auto case: an
+// `auto` run loads `write`, the run ends, and a later `plan` run on the same chat
+// must not inherit it.
+func TestLoadedToolsStore_DoesNotLeakAcrossRuns(t *testing.T) {
+	t.Parallel()
+	s := newTestStore()
+	const chatID = "chat-across-runs"
+
+	s.Add(scope(chatID, "run-1"), "write")
+	assert.True(t, s.Has(scope(chatID, "run-1"), "write"))
+
+	assert.False(t, s.Has(scope(chatID, "run-2"), "write"),
+		"a later run on the same chat must not inherit the previous run's loaded tools")
+}
+
+// TestLoadedToolsStore_DoesNotLeakAcrossSpawn covers both directions of the
+// spawn boundary. A child runs on the same chatID with only a new thread, so
+// under chat-only keying a child's grant outlived the child and a parent's
+// grant silently widened the child.
+func TestLoadedToolsStore_DoesNotLeakAcrossSpawn(t *testing.T) {
+	t.Parallel()
+	s := newTestStore()
+	const chatID = "chat-spawn"
+
+	parent := scope(chatID, "thread:root")
+	child := scope(chatID, "thread:child-1")
+
+	s.Add(parent, "edit")
+	s.Add(child, "write")
+
+	assert.False(t, s.Has(child, "edit"),
+		"a spawned child must not inherit the parent's dynamically loaded tools")
+	assert.False(t, s.Has(parent, "write"),
+		"a child's loaded tool must not persist to the parent after the child returns")
+}
+
+// TestLoadedToolsStore_PermissionIsPerScope pins the parent-cap bug. call_llm
+// computes the cap correctly (call_llm.go:809) but used to store it in a slot
+// the parent and child shared, so concurrent spawns overwrote each other and the
+// cap could be undone by whichever activity wrote last.
+func TestLoadedToolsStore_PermissionIsPerScope(t *testing.T) {
+	t.Parallel()
+	s := newTestStore()
+	const chatID = "chat-perm-scope"
+
+	parent := scope(chatID, "thread:root")
+	child := scope(chatID, "thread:child-1")
+
+	s.SetPermission(parent, PermissionOrchestrator)
+	s.SetPermission(child, PermissionReadOnly)
+
+	assert.Equal(t, PermissionOrchestrator, s.GetPermission(parent),
+		"a child's lower permission must not overwrite the parent's")
+	assert.Equal(t, PermissionReadOnly, s.GetPermission(child),
+		"the child must keep the capped permission it was given")
+}
+
+// TestLoadedToolsStore_UnknownScopeFailsClosed is the fail-open fix. The default
+// used to be PermissionOrchestrator, so a worker restart — which empties this
+// in-memory store — briefly granted maximum privilege to any execute_tools call
+// landing between the restart and the next call_llm.
+func TestLoadedToolsStore_UnknownScopeFailsClosed(t *testing.T) {
+	t.Parallel()
+	s := newTestStore()
+
+	assert.Equal(t, PermissionReadOnly, s.GetPermission(scope("chat-never-seen", "thread:root")),
+		"an unknown scope must fail closed, not grant orchestrator")
+}

--- a/internal/llm/tools/loaded_tools_store_test.go
+++ b/internal/llm/tools/loaded_tools_store_test.go
@@ -117,13 +117,17 @@ func TestLoadedToolsStore_SetAndGetPermission(t *testing.T) {
 	assert.Equal(t, PermissionReadOnly, s.GetPermission(chatID))
 }
 
-func TestLoadedToolsStore_GetPermission_DefaultOrchestrator(t *testing.T) {
+func TestLoadedToolsStore_GetPermission_DefaultFailsClosed(t *testing.T) {
 	t.Parallel()
 	s := newTestStore()
 
-	// No permission ever set -> backward-compatible default of orchestrator.
-	assert.Equal(t, PermissionOrchestrator, s.GetPermission("unknown-chat"),
-		"unset permission should default to orchestrator for backward compat")
+	// An unset scope means "we do not know what this agent was granted", which
+	// happens after a worker restart empties this in-memory store mid-run. The
+	// answer must be the LEAST privilege, not the most: the previous
+	// orchestrator default handed maximum privilege to any execute_tools that
+	// landed before the next call_llm repopulated the scope.
+	assert.Equal(t, PermissionReadOnly, s.GetPermission("unknown-scope"),
+		"unset permission must fail closed at readonly")
 }
 
 func TestLoadedToolsStore_ClearRemovesPermission(t *testing.T) {
@@ -137,9 +141,9 @@ func TestLoadedToolsStore_ClearRemovesPermission(t *testing.T) {
 
 	s.Clear(chatID)
 
-	// Back to the backward-compat default.
-	assert.Equal(t, PermissionOrchestrator, s.GetPermission(chatID),
-		"Clear must remove stored permission, falling back to default")
+	// Back to the fail-closed default.
+	assert.Equal(t, PermissionReadOnly, s.GetPermission(chatID),
+		"Clear must remove stored permission, falling back to the least-privilege default")
 	assert.Nil(t, s.Get(chatID))
 }
 

--- a/internal/llm/tools/registry.go
+++ b/internal/llm/tools/registry.go
@@ -463,9 +463,15 @@ func GetToolRegistry() []ToolDefinition {
 		{ToolShellWait, (*ToolsFactory).ShellWait, []ToolTag{TagExecution, TagShell, TagReadOnly, TagPlan, TagDefault}, ToolRunsOnDaemon},
 		{ToolShellKill, (*ToolsFactory).ShellKill, []ToolTag{TagExecution, TagShell, TagDefault}, ToolRunsOnDaemon},
 
-		// Network tools — routed to daemon so HTTP requests originate from the user's machine
-		{ToolFetch, (*ToolsFactory).Fetch, []ToolTag{TagWeb, TagReadOnly, TagPlan, TagDefault}, ToolRunsOnDaemon},
-		{ToolWebSearch, (*ToolsFactory).WebSearch, []ToolTag{TagWeb, TagReadOnly, TagPlan, TagDefault}, ToolRunsOnDaemon},
+		// Network tools. Both are pure net/http plus HTML parsing — no filesystem,
+		// no subprocess — so they carry no daemon requirement. They were daemon-routed
+		// so outbound requests would originate from the user's machine; that is now
+		// paid for elsewhere, because RequiresDaemon treats a daemon-located tool in a
+		// node's filter as proof the whole workflow needs a daemon. With TagDefault on
+		// both, `tag:default` alone was enough to fire the preflight gate and refuse a
+		// workflow that never touches the user's machine.
+		{ToolFetch, (*ToolsFactory).Fetch, []ToolTag{TagWeb, TagReadOnly, TagPlan, TagDefault}, ToolRunsAnywhere},
+		{ToolWebSearch, (*ToolsFactory).WebSearch, []ToolTag{TagWeb, TagReadOnly, TagPlan, TagDefault}, ToolRunsAnywhere},
 
 		// Planning tools
 		{ToolCreatePlan, (*ToolsFactory).CreatePlan, []ToolTag{TagPlanning, TagPlan, TagDefault}, ToolRunsOnServer},

--- a/internal/llm/tools/registry_network_location_test.go
+++ b/internal/llm/tools/registry_network_location_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2025 Reliant Labs
+package tools
+
+import "testing"
+
+// TestNetworkToolsAreNotDaemonBound pins fetch and websearch to a location that
+// does not require a daemon.
+//
+// Both tools are pure net/http plus HTML parsing — they open no files and spawn
+// no processes — so a daemon buys them nothing but a hard dependency. The cost
+// of the old marking was not just a wasted hop: RequiresDaemon (see
+// internal/workflow/runtime/preflight.go) treats any daemon-located tool in a
+// node's filter as proof the whole workflow needs a daemon, and both tools carry
+// TagDefault. That made `tag:default` — the most common filter there is — enough
+// to fire the preflight gate and refuse to start a workflow that never touches
+// the user's machine.
+//
+// The tradeoff this test locks in: outbound HTTP now originates from the server
+// rather than the user's machine.
+func TestNetworkToolsAreNotDaemonBound(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{ToolFetch, ToolWebSearch} {
+		var found *ToolDefinition
+		for _, def := range GetToolRegistry() {
+			if def.Name == name {
+				found = &def
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("tool %q is not in the registry", name)
+		}
+		if found.RunsOn == ToolRunsOnDaemon {
+			t.Errorf("tool %q is marked %q; network-only tools must not require a daemon",
+				name, ToolRunsOnDaemon)
+		}
+	}
+}

--- a/internal/toolexec/local_executor.go
+++ b/internal/toolexec/local_executor.go
@@ -183,7 +183,7 @@ func (e *LocalToolExecutor) executeTool(
 	// skills per-chat; the executor's factory was created at startup without
 	// them, so we clone with skills here so the skill tool sees them.
 	if toolsFactory != nil && chatID != "" {
-		if skills := tools.GetLoadedToolsStore().GetSkills(chatID); len(skills) > 0 {
+		if skills := tools.GetLoadedToolsStore().GetSkills(tools.Scope(chatID, thread)); len(skills) > 0 {
 			toolsFactory = toolsFactory.WithSkills(skills)
 		}
 	}

--- a/internal/workflow/runtime/activities/handlers/call_llm.go
+++ b/internal/workflow/runtime/activities/handlers/call_llm.go
@@ -814,7 +814,7 @@ func (a *CallLLMActivity) streamLLMResponse(ctx context.Context, chat *db.Chat, 
 		permission = rtx.ParentPermission
 	}
 	if chat != nil {
-		tools.GetLoadedToolsStore().SetPermission(chat.ID, permission)
+		tools.GetLoadedToolsStore().SetPermission(tools.Scope(chat.ID, thread), permission)
 	}
 
 	// Model must be provided via workflow inputs
@@ -1077,7 +1077,7 @@ func (a *CallLLMActivity) streamLLMResponse(ctx context.Context, chat *db.Chat, 
 		for i, t := range availableTools {
 			currentToolNames[i] = t.Name()
 		}
-		deferred := tools.DeferredToolNames(chat.ID, permission, currentToolNames, toolsResult.AllMCPToolNames)
+		deferred := tools.DeferredToolNames(tools.Scope(chat.ID, thread), permission, currentToolNames, toolsResult.AllMCPToolNames)
 		if len(deferred) > 0 {
 			for _, t := range availableTools {
 				if u, ok := t.(interface{ Unwrap() any }); ok {
@@ -1740,7 +1740,7 @@ func validateToolNamesForLLMRequest(availableTools []tools.Tool) error {
 // getAvailableToolsWithSpawn returns available tools and spawn configurations from the filter.
 // Spawn configs are extracted from spawn:workflow(presets) syntax in the filter.
 // Dynamically loaded tools (via load_tool) are automatically included.
-func (a *CallLLMActivity) getAvailableToolsWithSpawn(ctx context.Context, chat *db.Chat, scopePath string, worktreeDaemonID string, projectCfg *cfgpkg.Config, toolFilter []string, _ string, mailboxReachable bool) toolsWithSpawnResult {
+func (a *CallLLMActivity) getAvailableToolsWithSpawn(ctx context.Context, chat *db.Chat, scopePath string, worktreeDaemonID string, projectCfg *cfgpkg.Config, toolFilter []string, thread string, mailboxReachable bool) toolsWithSpawnResult {
 	if a.toolsFactory == nil {
 		return toolsWithSpawnResult{}
 	}
@@ -1767,7 +1767,7 @@ func (a *CallLLMActivity) getAvailableToolsWithSpawn(ctx context.Context, chat *
 		projectScopedToolsFactory = projectScopedToolsFactory.WithSkills(projectCfg.Skills)
 		// Also store skills in the global store so the executor can access them
 		// when creating skill tool instances (the executor uses a different factory).
-		tools.GetLoadedToolsStore().SetSkills(chat.ID, projectCfg.Skills)
+		tools.GetLoadedToolsStore().SetSkills(tools.Scope(chat.ID, thread), projectCfg.Skills)
 	} else {
 		slog.Debug("[CallLLM] No skills available", "projectCfgNil", projectCfg == nil)
 	}
@@ -1824,7 +1824,7 @@ func (a *CallLLMActivity) getAvailableToolsWithSpawn(ctx context.Context, chat *
 				Description: t.Description(),
 			})
 		}
-		tools.GetLoadedToolsStore().SetAvailableMCPTools(chat.ID, mcpToolInfos)
+		tools.GetLoadedToolsStore().SetAvailableMCPTools(tools.Scope(chat.ID, thread), mcpToolInfos)
 	}
 
 	// Expand tool filter with spawn support
@@ -1832,7 +1832,7 @@ func (a *CallLLMActivity) getAvailableToolsWithSpawn(ctx context.Context, chat *
 
 	// Include dynamically loaded tools (via load_tool)
 	if chat != nil {
-		loadedTools := tools.GetLoadedToolsStore().Get(chat.ID)
+		loadedTools := tools.GetLoadedToolsStore().Get(tools.Scope(chat.ID, thread))
 		if len(loadedTools) > 0 {
 			filterResult.ToolNames = append(filterResult.ToolNames, loadedTools...)
 			logDebug("[CallLLM] Including dynamically loaded tools",

--- a/internal/workflow/runtime/activities/handlers/cleanup.go
+++ b/internal/workflow/runtime/activities/handlers/cleanup.go
@@ -11,6 +11,7 @@ import (
 	reliantv1 "github.com/reliant-labs/reliant/gen/reliant/v1"
 	"github.com/reliant-labs/reliant/internal/db"
 	"github.com/reliant-labs/reliant/internal/db/core"
+	"github.com/reliant-labs/reliant/internal/llm/tools"
 	"github.com/reliant-labs/reliant/internal/logging"
 	"github.com/reliant-labs/reliant/internal/workflow/runtime/schema"
 )
@@ -75,6 +76,11 @@ func (a *CleanupActivity) Category() schema.ActivityCategory {
 // Execute cancels pending approvals and notifies UI
 func (a *CleanupActivity) Execute(ctx context.Context, input CleanupInput) (CleanupOutput, error) {
 	logging.Info("[Cleanup] Starting cleanup for chat", "chatID", input.ChatID)
+
+	// Release this run's dynamically loaded tools and its resolved permission.
+	// The store is in-memory and scoped to (chat, thread), so a run that ends
+	// without clearing leaves its grants behind until the process exits.
+	tools.GetLoadedToolsStore().Clear(tools.Scope(input.ChatID, input.Thread))
 
 	// Cancel orphaned tool calls (stops spinning indicators in UI for cancelled tool executions)
 	toolCallsCancelled := a.cancelOrphanedToolCalls(ctx, input.ChatID, input.Thread)

--- a/internal/workflow/runtime/activities/handlers/execute_tools.go
+++ b/internal/workflow/runtime/activities/handlers/execute_tools.go
@@ -215,7 +215,7 @@ func (a *ExecuteToolsActivity) Execute(ctx context.Context, input ActivityInput)
 
 	// Resolve the permission level for tool execution enforcement.
 	// This was set by call_llm when it resolved tools for the LLM request.
-	grantedPermission := tools.GetLoadedToolsStore().GetPermission(rtx.ChatID)
+	grantedPermission := tools.GetLoadedToolsStore().GetPermission(tools.Scope(rtx.ChatID, rtx.Thread))
 
 	// Build set for O(1) response tool lookups in worker goroutines
 	responseToolSet := make(map[string]bool, len(expectedResponseTools))

--- a/internal/workflow/runtime/activities/handlers/execute_tools_validation_test.go
+++ b/internal/workflow/runtime/activities/handlers/execute_tools_validation_test.go
@@ -33,8 +33,8 @@ func TestExecuteToolsActivity_PermissionEnforcement(t *testing.T) {
 		h.CreateTestChat(ctx, chatID, projectID, userID)
 
 		// Set readonly permission (simulates plan mode)
-		tools.GetLoadedToolsStore().SetPermission(chatID, tools.PermissionReadOnly)
-		defer tools.GetLoadedToolsStore().Clear(chatID)
+		tools.GetLoadedToolsStore().SetPermission(tools.Scope(chatID, "0"), tools.PermissionReadOnly)
+		defer tools.GetLoadedToolsStore().Clear(tools.Scope(chatID, "0"))
 
 		mockExecutor := newMockToolExecutor()
 		activity := NewExecuteToolsActivity(h.Repo(), mockExecutor)
@@ -82,8 +82,8 @@ func TestExecuteToolsActivity_PermissionEnforcement(t *testing.T) {
 		h.CreateTestChat(ctx, chatID, projectID, userID)
 
 		// Set readonly permission
-		tools.GetLoadedToolsStore().SetPermission(chatID, tools.PermissionReadOnly)
-		defer tools.GetLoadedToolsStore().Clear(chatID)
+		tools.GetLoadedToolsStore().SetPermission(tools.Scope(chatID, "0"), tools.PermissionReadOnly)
+		defer tools.GetLoadedToolsStore().Clear(tools.Scope(chatID, "0"))
 
 		mockExecutor := newMockToolExecutor()
 		activity := NewExecuteToolsActivity(h.Repo(), mockExecutor)
@@ -123,8 +123,8 @@ func TestExecuteToolsActivity_PermissionEnforcement(t *testing.T) {
 		h.CreateTestProject(ctx, projectID, userID)
 		h.CreateTestChat(ctx, chatID, projectID, userID)
 
-		tools.GetLoadedToolsStore().SetPermission(chatID, tools.PermissionMutating)
-		defer tools.GetLoadedToolsStore().Clear(chatID)
+		tools.GetLoadedToolsStore().SetPermission(tools.Scope(chatID, "0"), tools.PermissionMutating)
+		defer tools.GetLoadedToolsStore().Clear(tools.Scope(chatID, "0"))
 
 		mockExecutor := newMockToolExecutor()
 		activity := NewExecuteToolsActivity(h.Repo(), mockExecutor)
@@ -150,7 +150,11 @@ func TestExecuteToolsActivity_PermissionEnforcement(t *testing.T) {
 		assert.Equal(t, 1, mockExecutor.GetExecutionCount("call_bash"))
 	})
 
-	t.Run("Default permission is orchestrator (allows everything)", func(t *testing.T) {
+	// An unset scope is the worker-restart case: the in-memory store was emptied
+	// while the run was in flight. It must fail CLOSED — a readonly-tier tool
+	// still runs, a mutating one does not — rather than granting orchestrator
+	// precisely because the grant was lost.
+	t.Run("Unset permission falls back to readonly and still allows a readonly tool", func(t *testing.T) {
 		h := NewIdempotencyTestHelper(t)
 		defer h.Cleanup()
 
@@ -163,8 +167,8 @@ func TestExecuteToolsActivity_PermissionEnforcement(t *testing.T) {
 		h.CreateTestProject(ctx, projectID, userID)
 		h.CreateTestChat(ctx, chatID, projectID, userID)
 
-		// Don't set permission — should default to orchestrator
-		defer tools.GetLoadedToolsStore().Clear(chatID)
+		// Deliberately set no permission for this scope.
+		defer tools.GetLoadedToolsStore().Clear(tools.Scope(chatID, "0"))
 
 		mockExecutor := newMockToolExecutor()
 		activity := NewExecuteToolsActivity(h.Repo(), mockExecutor)
@@ -189,6 +193,50 @@ func TestExecuteToolsActivity_PermissionEnforcement(t *testing.T) {
 		assert.False(t, output.ToolResults[0].IsError)
 		assert.Equal(t, 1, mockExecutor.GetExecutionCount("call_any"))
 	})
+
+	// The other half of the same case, and the one the old orchestrator default
+	// got wrong: losing the grant must not widen it.
+	t.Run("Unset permission denies a mutating tool", func(t *testing.T) {
+		h := NewIdempotencyTestHelper(t)
+		defer h.Cleanup()
+
+		ctx := context.Background()
+
+		userID := uuid.New().String()
+		projectID := uuid.New().String()
+		chatID := uuid.New().String()
+
+		h.CreateTestProject(ctx, projectID, userID)
+		h.CreateTestChat(ctx, chatID, projectID, userID)
+
+		// Deliberately set no permission for this scope.
+		defer tools.GetLoadedToolsStore().Clear(tools.Scope(chatID, "0"))
+
+		mockExecutor := newMockToolExecutor()
+		activity := NewExecuteToolsActivity(h.Repo(), mockExecutor)
+
+		input := ExecuteToolsInput{
+			ChatID: chatID,
+			Thread: "0",
+			ToolCalls: []ToolCall{
+				{
+					ID:    "call_write",
+					Name:  "write",
+					Input: `{"file_path": "/tmp/x", "content": "y"}`,
+				},
+			},
+		}
+
+		var output ExecuteToolsOutput
+		err := h.ExecuteActivity(activity.Execute, input, &output)
+
+		require.NoError(t, err)
+		require.Len(t, output.ToolResults, 1)
+		assert.True(t, output.ToolResults[0].IsError,
+			"a mutating tool must be denied when the scope carries no granted permission")
+		assert.Equal(t, 0, mockExecutor.GetExecutionCount("call_write"),
+			"a denied tool must never reach the executor")
+	})
 }
 
 // TestExecuteToolsActivity_SpawnPresetValidation tests that spawn tool calls
@@ -208,8 +256,8 @@ func TestExecuteToolsActivity_SpawnPresetValidation(t *testing.T) {
 		h.CreateTestChat(ctx, chatID, projectID, userID)
 
 		// Orchestrator permission so spawn itself is allowed
-		tools.GetLoadedToolsStore().SetPermission(chatID, tools.PermissionOrchestrator)
-		defer tools.GetLoadedToolsStore().Clear(chatID)
+		tools.GetLoadedToolsStore().SetPermission(tools.Scope(chatID, "0"), tools.PermissionOrchestrator)
+		defer tools.GetLoadedToolsStore().Clear(tools.Scope(chatID, "0"))
 
 		mockExecutor := newMockToolExecutor()
 		activity := NewExecuteToolsActivity(h.Repo(), mockExecutor)
@@ -252,8 +300,8 @@ func TestExecuteToolsActivity_SpawnPresetValidation(t *testing.T) {
 		h.CreateTestProject(ctx, projectID, userID)
 		h.CreateTestChat(ctx, chatID, projectID, userID)
 
-		tools.GetLoadedToolsStore().SetPermission(chatID, tools.PermissionOrchestrator)
-		defer tools.GetLoadedToolsStore().Clear(chatID)
+		tools.GetLoadedToolsStore().SetPermission(tools.Scope(chatID, "0"), tools.PermissionOrchestrator)
+		defer tools.GetLoadedToolsStore().Clear(tools.Scope(chatID, "0"))
 
 		mockExecutor := newMockToolExecutor()
 		activity := NewExecuteToolsActivity(h.Repo(), mockExecutor)
@@ -292,8 +340,8 @@ func TestExecuteToolsActivity_SpawnPresetValidation(t *testing.T) {
 		h.CreateTestProject(ctx, projectID, userID)
 		h.CreateTestChat(ctx, chatID, projectID, userID)
 
-		tools.GetLoadedToolsStore().SetPermission(chatID, tools.PermissionOrchestrator)
-		defer tools.GetLoadedToolsStore().Clear(chatID)
+		tools.GetLoadedToolsStore().SetPermission(tools.Scope(chatID, "0"), tools.PermissionOrchestrator)
+		defer tools.GetLoadedToolsStore().Clear(tools.Scope(chatID, "0"))
 
 		mockExecutor := newMockToolExecutor()
 		activity := NewExecuteToolsActivity(h.Repo(), mockExecutor)
@@ -332,8 +380,8 @@ func TestExecuteToolsActivity_SpawnPresetValidation(t *testing.T) {
 		h.CreateTestProject(ctx, projectID, userID)
 		h.CreateTestChat(ctx, chatID, projectID, userID)
 
-		tools.GetLoadedToolsStore().SetPermission(chatID, tools.PermissionOrchestrator)
-		defer tools.GetLoadedToolsStore().Clear(chatID)
+		tools.GetLoadedToolsStore().SetPermission(tools.Scope(chatID, "0"), tools.PermissionOrchestrator)
+		defer tools.GetLoadedToolsStore().Clear(tools.Scope(chatID, "0"))
 
 		mockExecutor := newMockToolExecutor()
 		activity := NewExecuteToolsActivity(h.Repo(), mockExecutor)
@@ -383,8 +431,8 @@ func TestExecuteToolsActivity_MixedPermissions(t *testing.T) {
 		// gating it at mutating would leave a readonly agent unable to look
 		// around. It can still redirect into a file, which is why a hard
 		// boundary has to live below the tool layer.
-		tools.GetLoadedToolsStore().SetPermission(chatID, tools.PermissionReadOnly)
-		defer tools.GetLoadedToolsStore().Clear(chatID)
+		tools.GetLoadedToolsStore().SetPermission(tools.Scope(chatID, "0"), tools.PermissionReadOnly)
+		defer tools.GetLoadedToolsStore().Clear(tools.Scope(chatID, "0"))
 
 		mockExecutor := newMockToolExecutor()
 		activity := NewExecuteToolsActivity(h.Repo(), mockExecutor)

--- a/internal/workflow/runtime/preflight_network_tools_test.go
+++ b/internal/workflow/runtime/preflight_network_tools_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 Reliant Labs
+package runtime
+
+import (
+	"testing"
+
+	reliantv1 "github.com/reliant-labs/reliant/gen/reliant/v1"
+)
+
+// networkOnlyPreflightConfig mirrors the real registry after fetch and websearch
+// stopped being daemon-located. Unlike testPreflightConfig, which hardcodes the
+// old marking, this one encodes the corrected fact so the assertion below is
+// about RequiresDaemon's behaviour rather than about the fixture.
+func networkOnlyPreflightConfig() *PreflightConfig {
+	daemonTools := map[string]bool{
+		"shell":        true,
+		"shell_list":   true,
+		"shell_output": true,
+		"shell_kill":   true,
+		"code_context": true,
+	}
+	return &PreflightConfig{
+		IsDaemonTool: func(name string) bool { return daemonTools[name] },
+		ExpandToolFilter: func(filter []string) []string {
+			var result []string
+			for _, spec := range filter {
+				switch spec {
+				case "tag:web":
+					result = append(result, "fetch", "websearch")
+				case "tag:readonly":
+					result = append(result, "view", "fetch", "websearch")
+				default:
+					result = append(result, spec)
+				}
+			}
+			return result
+		},
+	}
+}
+
+// TestRequiresDaemon_NetworkOnlyAgentNeedsNoDaemon is the workflow-level point of
+// the location change: an agent that can read the web and nothing else must be
+// able to start with no daemon connected.
+//
+// Before fetch/websearch moved off the daemon this returned true, so the
+// preflight gate refused the run — the failure the daemon-less work exists to
+// remove.
+func TestRequiresDaemon_NetworkOnlyAgentNeedsNoDaemon(t *testing.T) {
+	t.Parallel()
+
+	wf := &reliantv1.Workflow{
+		Nodes: []*reliantv1.Node{
+			{
+				Id:   "research",
+				Type: "call_llm",
+				Args: &reliantv1.Node_CallLlm{
+					CallLlm: &reliantv1.CallLLMArgs{
+						ToolsConfig: &reliantv1.ToolsConfig{
+							Filter: &reliantv1.CelStringList{
+								Value: &reliantv1.CelStringList_Literal{
+									Literal: &reliantv1.StringList{
+										Values: []string{"tag:web"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if RequiresDaemon(wf, networkOnlyPreflightConfig()) {
+		t.Error("a workflow whose only tools are fetch/websearch must not require a daemon")
+	}
+}
+
+// TestRequiresDaemon_ShellStillRequiresDaemon guards the other half: relaxing the
+// network tools must not relax the gate for tools that genuinely need a machine.
+func TestRequiresDaemon_ShellStillRequiresDaemon(t *testing.T) {
+	t.Parallel()
+
+	wf := &reliantv1.Workflow{
+		Nodes: []*reliantv1.Node{
+			{
+				Id:   "build",
+				Type: "call_llm",
+				Args: &reliantv1.Node_CallLlm{
+					CallLlm: &reliantv1.CallLLMArgs{
+						ToolsConfig: &reliantv1.ToolsConfig{
+							Filter: &reliantv1.CelStringList{
+								Value: &reliantv1.CelStringList_Literal{
+									Literal: &reliantv1.StringList{
+										Values: []string{"shell"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if !RequiresDaemon(wf, networkOnlyPreflightConfig()) {
+		t.Error("a workflow using the shell must still require a daemon")
+	}
+}


### PR DESCRIPTION
> Stacked on #250. Review that one first; this PR targets `fix/network-tools-not-daemon-bound` and will retarget to `main` once #250 merges.

## What

`LoadedToolsStore` is now keyed by `(chatID, thread)` via a new `tools.Scope` helper, instead of by `chatID` alone, and its permission lookup fails closed.

## Why the key was wrong

One key was doing three jobs. `chatID` identifies a chat, but the store is really tracking what a *single agent in a single run* has been granted. Thread is what distinguishes them:

- A new run sets `targetThread = workflowID` (`chat_send.go:1005`), so it is unique per run.
- A spawned child runs on the **same chat** under a new thread.

Three bugs fall out of that, all fixed here.

**1. Tools leaked across runs.** `Clear` had no production caller — every caller in the tree was a test. A `plan`-mode run following an `auto` run inherited `write`/`edit` in its offered tool list.

**2. Tools leaked across the spawn boundary, in both directions.** A child's `load_tool` grant outlived the child and persisted to the parent; the parent's grants silently widened the child. Permission was last-writer-wins per chat, so the parent cap computed correctly at `call_llm.go:809` was written into a slot the parent and child shared, and concurrent background spawns overwrote each other.

**3. `GetPermission` failed open.** It defaulted to `PermissionOrchestrator` when unset. The store is in-memory, so a worker restart empties it mid-run — and any `execute_tools` landing between the restart and the next `call_llm` was granted **maximum privilege precisely because the grant had been lost**. It now defaults to `PermissionReadOnly`.

`Clear` is now wired into `CleanupActivity`, which runs at a terminal state, so a finished run releases its grants rather than waiting for process exit. `CleanupInput` already carried both `ChatID` and `Thread`.

Store method parameters are renamed `chatID` -> `scopeKey` so the signatures stop lying about what they take.

## Tests

New, in `loaded_tools_store_scope_test.go`: `DoesNotLeakAcrossRuns`, `DoesNotLeakAcrossSpawn`, `PermissionIsPerScope`, `UnknownScopeFailsClosed`.

**Two existing tests asserted the bug** as intended behavior (`GetPermission_DefaultOrchestrator`, `ClearRemovesPermission`, both commented "backward compat") and are rewritten to the fail-closed contract.

**Worth a reviewer's attention:** the permission-enforcement tests in `execute_tools_validation_test.go` were setting permission by bare `chatID` while the activity reads by scope. They were passing for the *wrong reason* — the new readonly default happened to match what they asserted. Fixed to use `Scope`, and added `Unset permission denies a mutating tool`, which I verified **fails** when `GetPermission` is temporarily reverted to the orchestrator default, so it has real teeth.

Note these are DB-backed and silently SKIP without Postgres on `:5433` (`make postgres-up`) — a package-level `ok` does not mean they ran.

Full repo suite green: 118 packages, 0 failures.

## Context

Prerequisite for making the workflow `tools:` filter authoritative — today it is a hint that `load_tool` can walk straight past. Research in `research/TOOL_GATING.md`; plan in `research/ENGINE_SPLIT_PLAN.md`.
