### PR TITLE
fix(tools): make the workflow tools: filter an actual boundary

### DIFF
--- a/internal/llm/tools/load_tool.go
+++ b/internal/llm/tools/load_tool.go
@@ -101,6 +101,19 @@ func (t *loadToolTool) loadTool(rctx *rctx.ToolContext, name string, permission 
 			"Tool '%s' not found in the registry. Use load_tool with query to search for available tools.", name))
 	}
 
+	scopeKey := Scope(GetChatID(rctx), rctx.Thread)
+	store := GetLoadedToolsStore()
+
+	// The workflow's declared tool set is checked FIRST, and independently of
+	// the permission ladder. A tool must pass both: the ladder says what this
+	// agent's tier may ever hold, the filter says what this workflow said its
+	// agent should have. Checking only the ladder is what let an agent load
+	// `write` past a `tools: [view]` declaration.
+	if !store.IsToolAllowed(scopeKey, name) {
+		return NewTextErrorResponse(fmt.Sprintf(
+			"Tool '%s' is not in this workflow's declared tool set.", name))
+	}
+
 	// Check permission
 	minPerm := MinimumPermissionForTool(name)
 	if !PermissionAtLeast(permission, minPerm) {
@@ -110,8 +123,6 @@ func (t *loadToolTool) loadTool(rctx *rctx.ToolContext, name string, permission 
 	}
 
 	// Check if already loaded
-	scopeKey := Scope(GetChatID(rctx), rctx.Thread)
-	store := GetLoadedToolsStore()
 	if store.Has(scopeKey, name) {
 		return NewTextResponse(fmt.Sprintf("Tool '%s' is already loaded.", name))
 	}
@@ -136,6 +147,17 @@ func (t *loadToolTool) loadMCPTool(rctx *rctx.ToolContext, name string) ToolResp
 
 	if store.Has(scopeKey, name) {
 		return NewTextResponse(fmt.Sprintf("Tool '%s' is already loaded.", name))
+	}
+
+	// A workflow's declared tool set covers MCP too. The ladder exemption below
+	// is deliberate and stays, but it previously left an author with a
+	// restrictive `tools:` filter no way to refuse a connected MCP tool —
+	// availability was the only check, so MCP was the widest hole in the filter.
+	// `tag:mcp` expands to the connected names, so an author who wants them can
+	// still say so in one line.
+	if !store.IsToolAllowed(scopeKey, name) {
+		return NewTextErrorResponse(fmt.Sprintf(
+			"MCP tool '%s' is not in this workflow's declared tool set.", name))
 	}
 
 	// Verify the MCP tool is actually connected in this environment before
@@ -171,8 +193,22 @@ func mcpToolAvailable(available []MCPToolInfo, name string) bool {
 }
 
 func (t *loadToolTool) searchTools(scopeKey, query string, permission string) ToolResponse {
-	mcpTools := GetLoadedToolsStore().GetAvailableMCPTools(scopeKey)
+	store := GetLoadedToolsStore()
+	mcpTools := store.GetAvailableMCPTools(scopeKey)
 	results := SearchTools(query, permission, mcpTools)
+
+	// Discovery must agree with enforcement. Advertising a tool that loadTool
+	// will then refuse teaches the model to keep retrying something that cannot
+	// work, and burns a turn each time.
+	if store.HasAllowedTools(scopeKey) {
+		filtered := results[:0]
+		for _, r := range results {
+			if store.IsToolAllowed(scopeKey, r.Name) {
+				filtered = append(filtered, r)
+			}
+		}
+		results = filtered
+	}
 
 	if len(results) == 0 {
 		return NewTextResponse(fmt.Sprintf("No tools found matching '%s'.", query))

--- a/internal/llm/tools/load_tool_filter_test.go
+++ b/internal/llm/tools/load_tool_filter_test.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2025 Reliant Labs
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reliant-labs/reliant/internal/rctx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newFilteredTestCtx builds a tool context whose scope carries BOTH a permission
+// level and a declared allow-set, which is the combination a workflow with a
+// `tools:` filter produces.
+func newFilteredTestCtx(t *testing.T, permission string, allowed []string) *rctx.ToolContext {
+	t.Helper()
+	chatID := "filter-test-" + t.Name()
+	const thread = "0"
+	scopeKey := Scope(chatID, thread)
+
+	store := GetLoadedToolsStore()
+	store.Clear(scopeKey)
+	store.SetPermission(scopeKey, permission)
+	store.SetAllowedTools(scopeKey, allowed)
+
+	t.Cleanup(func() { store.Clear(scopeKey) })
+
+	worktree := &rctx.WorktreeInfo{ID: "test", Path: t.TempDir()}
+	return rctx.NewToolContext(context.Background(), chatID, thread, nil, worktree)
+}
+
+// TestLoadTool_CannotEscapeDeclaredFilter is the point of the whole change.
+//
+// A workflow that declares `tools: [view]` is making a statement about what its
+// agent should have. Before this, load_tool consulted only the permission
+// ladder — which defaults to `mutating` — so the agent could simply ask for
+// `write` and get it, and the loaded tool was appended AFTER filter expansion,
+// so even an explicit exclusion was overridden.
+func TestLoadTool_CannotEscapeDeclaredFilter(t *testing.T) {
+	t.Parallel()
+	tool := &loadToolTool{}
+	ctx := newFilteredTestCtx(t, PermissionMutating, []string{ToolView, ToolLoadTool})
+
+	resp, err := tool.Execute(ctx, LoadToolParams{Name: ToolWrite})
+	require.NoError(t, err)
+
+	assert.True(t, resp.IsError,
+		"loading a tool outside the declared filter must fail, got: %s", resp.Content)
+	assert.False(t, GetLoadedToolsStore().Has(Scope(ctx.ChatID, ctx.Thread), ToolWrite),
+		"a refused tool must not be recorded as loaded")
+}
+
+// TestLoadTool_AllowedByFilterStillHonoursLadder pins that the two checks are
+// AND, not OR. Naming a tool in `tools:` must not promote an agent past its
+// permission level — otherwise the filter becomes a privilege escalation path.
+func TestLoadTool_AllowedByFilterStillHonoursLadder(t *testing.T) {
+	t.Parallel()
+	tool := &loadToolTool{}
+	ctx := newFilteredTestCtx(t, PermissionReadOnly, []string{ToolView, ToolWrite, ToolLoadTool})
+
+	resp, err := tool.Execute(ctx, LoadToolParams{Name: ToolWrite})
+	require.NoError(t, err)
+
+	assert.True(t, resp.IsError,
+		"the ladder must still apply to a tool the filter allows, got: %s", resp.Content)
+}
+
+// TestLoadTool_AllowedByBothSucceeds — the positive case, so the guard cannot be
+// satisfied by refusing everything.
+func TestLoadTool_AllowedByBothSucceeds(t *testing.T) {
+	t.Parallel()
+	tool := &loadToolTool{}
+	ctx := newFilteredTestCtx(t, PermissionMutating, []string{ToolView, ToolWrite, ToolLoadTool})
+
+	resp, err := tool.Execute(ctx, LoadToolParams{Name: ToolWrite})
+	require.NoError(t, err)
+
+	assert.False(t, resp.IsError,
+		"a tool allowed by both filter and ladder must load: %s", resp.Content)
+	assert.True(t, GetLoadedToolsStore().Has(Scope(ctx.ChatID, ctx.Thread), ToolWrite))
+}
+
+// TestLoadTool_UndeclaredFilterAllowsAnything guards the compatibility case. A
+// workflow with no `tools:` filter places no restriction; reading "no
+// declaration" as "deny all" would break every such workflow, and would also
+// strand a live run whose scope was lost to a worker restart.
+func TestLoadTool_UndeclaredFilterAllowsAnything(t *testing.T) {
+	t.Parallel()
+	tool := &loadToolTool{}
+	ctx := newFilteredTestCtx(t, PermissionMutating, nil)
+
+	resp, err := tool.Execute(ctx, LoadToolParams{Name: ToolWrite})
+	require.NoError(t, err)
+
+	assert.False(t, resp.IsError,
+		"an undeclared filter must not restrict anything: %s", resp.Content)
+}
+
+// TestLoadTool_MCPToolRespectsFilter closes the documented MCP bypass.
+// loadMCPTool deliberately skips the permission ladder ("MCP tools are gated by
+// MCP configuration, not the agent permission ladder"), which left a workflow
+// with a restrictive `tools:` filter no way to refuse a connected MCP tool.
+// The ladder exemption stays; the authorial declaration now applies.
+func TestLoadTool_MCPToolRespectsFilter(t *testing.T) {
+	t.Parallel()
+	tool := &loadToolTool{}
+	const mcpName = "mcp__chrome-devtools__take_screenshot"
+
+	ctx := newFilteredTestCtx(t, PermissionMutating, []string{ToolView, ToolLoadTool})
+	GetLoadedToolsStore().SetAvailableMCPTools(Scope(ctx.ChatID, ctx.Thread), []MCPToolInfo{
+		{Name: mcpName, Description: "Capture a screenshot"},
+	})
+
+	resp, err := tool.Execute(ctx, LoadToolParams{Name: mcpName})
+	require.NoError(t, err)
+
+	assert.True(t, resp.IsError,
+		"a connected MCP tool outside the declared filter must be refused, got: %s", resp.Content)
+}
+
+// TestLoadTool_MCPToolAllowedByTagLoads — an author who wants MCP tools can say
+// so, and `tag:mcp` expands to the connected names.
+func TestLoadTool_MCPToolAllowedByTagLoads(t *testing.T) {
+	t.Parallel()
+	tool := &loadToolTool{}
+	const mcpName = "mcp__chrome-devtools__take_screenshot"
+
+	ctx := newFilteredTestCtx(t, PermissionMutating, []string{ToolView, ToolLoadTool, mcpName})
+	GetLoadedToolsStore().SetAvailableMCPTools(Scope(ctx.ChatID, ctx.Thread), []MCPToolInfo{
+		{Name: mcpName, Description: "Capture a screenshot"},
+	})
+
+	resp, err := tool.Execute(ctx, LoadToolParams{Name: mcpName})
+	require.NoError(t, err)
+
+	assert.False(t, resp.IsError,
+		"an MCP tool named in the filter must load: %s", resp.Content)
+}
+
+// TestLoadTool_PlanModeCannotLoadWrite is the live consumer of the filter, and
+// the case that matters most once the readonly tier is removed.
+//
+// Plan mode declares `tools: ['tag:plan', 'tag:shell']`. Its `readonly`
+// permission is going away — it never prevented writes anyway, because the
+// shell is granted at every tier — so the declared set becomes the only thing
+// expressing "a planning agent is not handed write". This pins that it holds
+// even at mutating permission.
+func TestLoadTool_PlanModeCannotLoadWrite(t *testing.T) {
+	t.Parallel()
+	tool := &loadToolTool{}
+
+	planTools := ExpandToolFilter([]string{"tag:plan", "tag:shell"}, nil)
+	ctx := newFilteredTestCtx(t, PermissionMutating, append(planTools, ToolLoadTool))
+
+	resp, err := tool.Execute(ctx, LoadToolParams{Name: ToolWrite})
+	require.NoError(t, err)
+	assert.True(t, resp.IsError,
+		"a plan-mode agent must not be able to load write: %s", resp.Content)
+
+	// ...while its actual working set still resolves, so the guard is not just
+	// refusing everything. Search is the shell in plan mode.
+	shellResp, err := tool.Execute(ctx, LoadToolParams{Name: ShellToolName})
+	require.NoError(t, err)
+	assert.False(t, shellResp.IsError,
+		"plan mode must keep the shell — it is the only search path: %s", shellResp.Content)
+}
+
+// TestSearchTools_DoesNotAdvertiseFilteredOutTools — discovery must agree with
+// enforcement. Advertising a tool that load_tool will then refuse teaches the
+// model to keep retrying something that cannot work.
+func TestLoadTool_SearchOmitsFilteredOutTools(t *testing.T) {
+	t.Parallel()
+	tool := &loadToolTool{}
+	ctx := newFilteredTestCtx(t, PermissionMutating, []string{ToolView, ToolLoadTool})
+
+	resp, err := tool.Execute(ctx, LoadToolParams{Query: "write"})
+	require.NoError(t, err)
+
+	assert.NotContains(t, resp.Content, "**"+ToolWrite+"**",
+		"search must not advertise a tool the filter excludes: %s", resp.Content)
+}

--- a/internal/llm/tools/loaded_tools_store.go
+++ b/internal/llm/tools/loaded_tools_store.go
@@ -24,6 +24,7 @@ type LoadedToolsStore struct {
 	mu           sync.RWMutex
 	tools        map[string]map[string]bool      // scope -> set of tool names
 	permissions  map[string]string               // scope -> permission level
+	allowed      map[string]map[string]bool      // scope -> workflow-declared allow-set
 	skills       map[string][]config.StoredSkill // scope -> skills
 	availableMCP map[string][]MCPToolInfo        // scope -> connected/available MCP tools
 }
@@ -57,6 +58,7 @@ type MCPToolInfo struct {
 var globalLoadedToolsStore = &LoadedToolsStore{
 	tools:        make(map[string]map[string]bool),
 	permissions:  make(map[string]string),
+	allowed:      make(map[string]map[string]bool),
 	skills:       make(map[string][]config.StoredSkill),
 	availableMCP: make(map[string][]MCPToolInfo),
 }
@@ -118,6 +120,7 @@ func (s *LoadedToolsStore) Clear(scopeKey string) {
 
 	delete(s.tools, scopeKey)
 	delete(s.permissions, scopeKey)
+	delete(s.allowed, scopeKey)
 	delete(s.skills, scopeKey)
 	delete(s.availableMCP, scopeKey)
 }
@@ -170,6 +173,59 @@ func (s *LoadedToolsStore) SetPermission(scopeKey, permission string) {
 	defer s.mu.Unlock()
 
 	s.permissions[scopeKey] = permission
+}
+
+// SetAllowedTools records the workflow's declared tool set for a scope, already
+// expanded from `tools:` (tags, globs and exclusions resolved to concrete
+// names). It is what makes the declaration a boundary rather than a hint: the
+// expansion used to be computed to build one request's tool array and then
+// thrown away, so load_tool could hand back anything the permission ladder
+// happened to allow — including a tool the author had explicitly excluded.
+//
+// An EMPTY set means "no declaration", not "nothing allowed". A workflow with
+// no `tools:` filter places no restriction, and must not be silently reduced to
+// zero tools.
+func (s *LoadedToolsStore) SetAllowedTools(scopeKey string, names []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(names) == 0 {
+		delete(s.allowed, scopeKey)
+		return
+	}
+	set := make(map[string]bool, len(names))
+	for _, name := range names {
+		set[name] = true
+	}
+	s.allowed[scopeKey] = set
+}
+
+// IsToolAllowed reports whether a tool passes the scope's declared allow-set.
+// Scopes with no declaration allow everything, so an undeclared workflow keeps
+// working and a lost scope (worker restart) does not strand a live run.
+//
+// This is deliberately NOT the security boundary — a declared set still hands
+// the agent a shell. It enforces authorial intent: what this workflow said its
+// agent should have.
+func (s *LoadedToolsStore) IsToolAllowed(scopeKey, toolName string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	set, ok := s.allowed[scopeKey]
+	if !ok {
+		return true
+	}
+	return set[toolName]
+}
+
+// HasAllowedTools reports whether a scope carries a declaration at all, so
+// callers can tell "allowed because declared" from "allowed because undeclared".
+func (s *LoadedToolsStore) HasAllowedTools(scopeKey string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	_, ok := s.allowed[scopeKey]
+	return ok
 }
 
 // GetPermission returns the permission level for a scope.

--- a/internal/workflow/runtime/activities/handlers/call_llm.go
+++ b/internal/workflow/runtime/activities/handlers/call_llm.go
@@ -1852,14 +1852,42 @@ func (a *CallLLMActivity) getAvailableToolsWithSpawn(ctx context.Context, chat *
 	// Expand tool filter with spawn support
 	filterResult := tools.ExpandToolFilterWithSpawn(toolFilter, mcpToolNames)
 
-	// Include dynamically loaded tools (via load_tool)
+	// Record the expansion as this scope's allow-set BEFORE anything is added to
+	// it, so the declaration is what the author wrote rather than what the agent
+	// has since accumulated. Previously this expansion was used to build one
+	// request's tool array and then discarded, which is why `tools:` could not
+	// refuse anything load_tool chose to add.
+	//
+	// The two universally-granted tools are admitted explicitly. Both are handed
+	// to every tool-enabled agent AFTER this expansion (see below), so a filter
+	// that never named them would otherwise make the agent unable to use the very
+	// tool it discovers with — load_tool would refuse its own name.
+	if chat != nil && len(filterResult.ToolNames) > 0 {
+		allowed := make([]string, 0, len(filterResult.ToolNames)+2)
+		allowed = append(allowed, filterResult.ToolNames...)
+		allowed = append(allowed, tools.ToolLoadTool, tools.ToolSpawnSend)
+		tools.GetLoadedToolsStore().SetAllowedTools(tools.Scope(chat.ID, thread), allowed)
+	}
+
+	// Include dynamically loaded tools (via load_tool). These are intersected
+	// against the declared set rather than appended past it: appending is what
+	// let a loaded tool override even an explicit `!write` exclusion. load_tool
+	// already refuses out-of-set tools, so this is the second half of the same
+	// rule — a grant recorded before the filter narrowed cannot outlive it.
 	if chat != nil {
-		loadedTools := tools.GetLoadedToolsStore().Get(tools.Scope(chat.ID, thread))
-		if len(loadedTools) > 0 {
-			filterResult.ToolNames = append(filterResult.ToolNames, loadedTools...)
+		scopeKey := tools.Scope(chat.ID, thread)
+		store := tools.GetLoadedToolsStore()
+		var admitted []string
+		for _, name := range store.Get(scopeKey) {
+			if store.IsToolAllowed(scopeKey, name) {
+				admitted = append(admitted, name)
+			}
+		}
+		if len(admitted) > 0 {
+			filterResult.ToolNames = append(filterResult.ToolNames, admitted...)
 			logDebug("[CallLLM] Including dynamically loaded tools",
 				"chatID", chat.ID,
-				"loadedTools", loadedTools)
+				"loadedTools", admitted)
 		}
 	}
 

--- a/internal/workflow/runtime/activities/handlers/execute_tools.go
+++ b/internal/workflow/runtime/activities/handlers/execute_tools.go
@@ -213,9 +213,11 @@ func (a *ExecuteToolsActivity) Execute(ctx context.Context, input ActivityInput)
 	expectedResponseTools := protoArgs.GetExpectedResponseTools()
 	responseToolSchemas := protoStructMapToGoMap(protoArgs.GetResponseToolSchemas())
 
-	// Resolve the permission level for tool execution enforcement.
-	// This was set by call_llm when it resolved tools for the LLM request.
-	grantedPermission := tools.GetLoadedToolsStore().GetPermission(tools.Scope(rtx.ChatID, rtx.Thread))
+	// Resolve the permission level and the declared tool set for execution-time
+	// enforcement. Both were set by call_llm when it resolved tools for the LLM
+	// request; a tool must pass both to run.
+	scopeKey := tools.Scope(rtx.ChatID, rtx.Thread)
+	grantedPermission := tools.GetLoadedToolsStore().GetPermission(scopeKey)
 
 	// Build set for O(1) response tool lookups in worker goroutines
 	responseToolSet := make(map[string]bool, len(expectedResponseTools))
@@ -301,6 +303,24 @@ func (a *ExecuteToolsActivity) Execute(ctx context.Context, input ActivityInput)
 							result: message.ToolResult{
 								ToolCallID: toolCallID,
 								Content:    "incomplete tool call: missing name or id",
+								IsError:    true,
+							},
+						}
+						return
+					}
+
+					// Enforce the workflow's declared tool set at EXECUTION, not
+					// only when the request was built. The model can name a tool
+					// that was never offered — a stale name from earlier history,
+					// or an outright hallucination — and without this the call
+					// would run purely because the ladder allowed its tier.
+					if !tools.GetLoadedToolsStore().IsToolAllowed(scopeKey, toolName) {
+						resultsChan <- toolCallResult{
+							index: job.index,
+							result: message.ToolResult{
+								ToolCallID: toolCallID,
+								Name:       toolName,
+								Content:    fmt.Sprintf("Tool '%s' is not in this workflow's declared tool set.", toolName),
 								IsError:    true,
 							},
 						}

--- a/internal/workflow/runtime/workflow.go
+++ b/internal/workflow/runtime/workflow.go
@@ -2594,6 +2594,23 @@ func buildSpawnChildInputs(workflowInputs map[string]interface{}) map[string]int
 		childInputs["parent_permission"] = parentPerm
 	}
 
+	// The parent's DECLARED TOOL SET is deliberately not propagated, unlike its
+	// permission. The two constrain different things and only one of them
+	// composes.
+	//
+	// A permission cap composes because it is a tier: a child at or below its
+	// parent's tier is always meaningful. A tool set does not — an orchestrator's
+	// filter describes the orchestrator's own job, not its children's. The
+	// builtin `code_reviewer` preset is the worked example: it holds a narrow
+	// filter (view, code_context, shell, web) and spawns `researcher`, whose work
+	// needs a different set entirely. Intersecting parent into child would leave
+	// every spawned unit with the orchestrator's tools, which is precisely what
+	// presets exist to avoid.
+	//
+	// A child's set comes from its own preset, and is enforced against that set
+	// by the same rules as any other agent. The permission cap remains the
+	// constraint that crosses the boundary.
+
 	return childInputs
 }
 


### PR DESCRIPTION
> Stacked on #250 and #251 — those two commits appear in this diff. Review them first; the third commit is this PR's. CI here only runs against `main`, so stacking has to be expressed this way.

## The bug

A workflow declaring `tools: [view]` could not stop its agent from calling `load_tool(name="write")` and getting it.

The filter was expanded once to build a request's tool array and then thrown away. `load_tool` consulted only the permission ladder — which **defaults to `mutating`** — and the loaded tool was appended *after* filter expansion, so even an explicit `!write` exclusion was overridden on the next turn.

Net effect: `tools:` was a prompt-surface hint, not a boundary.

## The fix

The expansion is recorded as the scope's allow-set and enforced in four places:

| Where | Was | Now |
|---|---|---|
| `load_tool` | ladder only | allow-set **first**, then ladder — must pass both |
| `loadMCPTool` | availability only | allow-set too (ladder exemption kept) |
| `execute_tools` | ladder only | allow-set checked at execution |
| `call_llm` | loaded tools appended past filter | intersected against it |

Two deliberate choices worth reviewing:

**An empty set means "no declaration", not "nothing allowed."** A workflow without a `tools:` filter is unrestricted, and a scope lost to a worker restart does not strand a live run. Reading absence as deny-all would break every undeclared workflow.

**Enforcement at execute, not just at request build.** The model can name a tool that was never offered — a stale name from earlier history, or a hallucination — and the ladder alone would have run it.

## MCP

`loadMCPTool` explicitly bypasses the permission ladder ("MCP tools are gated by MCP configuration, not the agent permission ladder"). That exemption is deliberate and **stays**. But availability was previously the *only* check, which made MCP the widest hole in the filter — a `tools: [view]` agent could load any connected MCP tool, including mutating ones. The authorial declaration now applies. `tag:mcp` expands to the connected names, so an author who wants them says so in one line.

## Spawn: tool sets deliberately do NOT propagate

Unlike the permission cap, which does. The reasoning is in a comment at the call site, and it is the part I'd most like a second opinion on:

A permission cap composes because it is a **tier** — a child at or below its parent's tier is always meaningful. A tool set does not. An orchestrator's filter describes the orchestrator's own job, not its children's.

The builtin `code_reviewer` preset is the worked example: a narrow filter (`view`, `code_context`, `tag:shell`, `tag:web`) that spawns `researcher`, whose work needs a different set entirely. Intersecting parent into child would leave every spawned unit holding the orchestrator's tools — which is precisely what presets exist to avoid. A child's set comes from its own preset and is enforced against that.

## Why now: this unblocks removing the `readonly` tier

Per the permission-model discussion (`research/PERMISSIONS_REDESIGN.md`), `readonly` is going away — it never prevented writes, because the shell is granted at every tier.

**Plan mode is the live consumer** (`agent.yaml:214` sets `permission: readonly` when `mode == 'plan'`). Once the tier is gone, its declared set `['tag:plan', 'tag:shell']` is the only thing expressing "a planning agent is not handed write". So this had to land first, or removing the tier would silently promote plan mode to `mutating` **with `write`/`edit` handed to it**.

`TestLoadTool_PlanModeCannotLoadWrite` pins that it now holds on the filter alone, at mutating permission, while the shell still resolves — plan mode's only search path.

## Scope note

This is **authorial intent, not a security boundary**, and the code says so in place. A declared set still hands the agent a shell that can `> file`. Real containment is a separate axis and a separate piece of work.

## Tests

`load_tool_filter_test.go` — the escape hatch, both AND directions (filter-allowed still honours the ladder; ladder-allowed still honours the filter), the undeclared-workflow compatibility case, MCP refused and MCP allowed-by-name, search agreeing with enforcement, and plan mode.

Full repo suite green: 118 packages, 0 failures.
