### PR TITLE
refactor(tools): remove the readonly permission tier

### DIFF
--- a/internal/llm/tools/file_concurrency_test.go
+++ b/internal/llm/tools/file_concurrency_test.go
@@ -64,11 +64,11 @@ func TestPathLockNotHeldAcrossPermissionGate(t *testing.T) {
 
 	mustReturnWithin(t, 5*time.Second, "permission tier gate", func() {
 		required := MinimumPermissionForTool(EditToolName)
-		assert.Equal(t, PermissionMutating, required, "edit is a mutating tool")
+		assert.Equal(t, PermissionMutating, required, "edit sits at the base tier")
 		assert.True(t, PermissionAtLeast(PermissionMutating, required),
 			"a mutating agent must clear edit's gate")
-		assert.False(t, PermissionAtLeast(PermissionReadOnly, required),
-			"a readonly agent must not clear edit's gate")
+		assert.False(t, PermissionAtLeast("bogus", required),
+			"an unrecognized level must not clear edit's gate")
 	})
 
 	wrapped := NewEditTool()

--- a/internal/llm/tools/load_tool.go
+++ b/internal/llm/tools/load_tool.go
@@ -101,6 +101,19 @@ func (t *loadToolTool) loadTool(rctx *rctx.ToolContext, name string, permission 
 			"Tool '%s' not found in the registry. Use load_tool with query to search for available tools.", name))
 	}
 
+	scopeKey := Scope(GetChatID(rctx), rctx.Thread)
+	store := GetLoadedToolsStore()
+
+	// The workflow's declared tool set is checked FIRST, and independently of
+	// the permission ladder. A tool must pass both: the ladder says what this
+	// agent's tier may ever hold, the filter says what this workflow said its
+	// agent should have. Checking only the ladder is what let an agent load
+	// `write` past a `tools: [view]` declaration.
+	if !store.IsToolAllowed(scopeKey, name) {
+		return NewTextErrorResponse(fmt.Sprintf(
+			"Tool '%s' is not in this workflow's declared tool set.", name))
+	}
+
 	// Check permission
 	minPerm := MinimumPermissionForTool(name)
 	if !PermissionAtLeast(permission, minPerm) {
@@ -110,8 +123,6 @@ func (t *loadToolTool) loadTool(rctx *rctx.ToolContext, name string, permission 
 	}
 
 	// Check if already loaded
-	scopeKey := Scope(GetChatID(rctx), rctx.Thread)
-	store := GetLoadedToolsStore()
 	if store.Has(scopeKey, name) {
 		return NewTextResponse(fmt.Sprintf("Tool '%s' is already loaded.", name))
 	}
@@ -136,6 +147,17 @@ func (t *loadToolTool) loadMCPTool(rctx *rctx.ToolContext, name string) ToolResp
 
 	if store.Has(scopeKey, name) {
 		return NewTextResponse(fmt.Sprintf("Tool '%s' is already loaded.", name))
+	}
+
+	// A workflow's declared tool set covers MCP too. The ladder exemption below
+	// is deliberate and stays, but it previously left an author with a
+	// restrictive `tools:` filter no way to refuse a connected MCP tool —
+	// availability was the only check, so MCP was the widest hole in the filter.
+	// `tag:mcp` expands to the connected names, so an author who wants them can
+	// still say so in one line.
+	if !store.IsToolAllowed(scopeKey, name) {
+		return NewTextErrorResponse(fmt.Sprintf(
+			"MCP tool '%s' is not in this workflow's declared tool set.", name))
 	}
 
 	// Verify the MCP tool is actually connected in this environment before
@@ -171,8 +193,22 @@ func mcpToolAvailable(available []MCPToolInfo, name string) bool {
 }
 
 func (t *loadToolTool) searchTools(scopeKey, query string, permission string) ToolResponse {
-	mcpTools := GetLoadedToolsStore().GetAvailableMCPTools(scopeKey)
+	store := GetLoadedToolsStore()
+	mcpTools := store.GetAvailableMCPTools(scopeKey)
 	results := SearchTools(query, permission, mcpTools)
+
+	// Discovery must agree with enforcement. Advertising a tool that loadTool
+	// will then refuse teaches the model to keep retrying something that cannot
+	// work, and burns a turn each time.
+	if store.HasAllowedTools(scopeKey) {
+		filtered := results[:0]
+		for _, r := range results {
+			if store.IsToolAllowed(scopeKey, r.Name) {
+				filtered = append(filtered, r)
+			}
+		}
+		results = filtered
+	}
 
 	if len(results) == 0 {
 		return NewTextResponse(fmt.Sprintf("No tools found matching '%s'.", query))

--- a/internal/llm/tools/load_tool_filter_test.go
+++ b/internal/llm/tools/load_tool_filter_test.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2025 Reliant Labs
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reliant-labs/reliant/internal/rctx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newFilteredTestCtx builds a tool context whose scope carries BOTH a permission
+// level and a declared allow-set, which is the combination a workflow with a
+// `tools:` filter produces.
+func newFilteredTestCtx(t *testing.T, permission string, allowed []string) *rctx.ToolContext {
+	t.Helper()
+	chatID := "filter-test-" + t.Name()
+	const thread = "0"
+	scopeKey := Scope(chatID, thread)
+
+	store := GetLoadedToolsStore()
+	store.Clear(scopeKey)
+	store.SetPermission(scopeKey, permission)
+	store.SetAllowedTools(scopeKey, allowed)
+
+	t.Cleanup(func() { store.Clear(scopeKey) })
+
+	worktree := &rctx.WorktreeInfo{ID: "test", Path: t.TempDir()}
+	return rctx.NewToolContext(context.Background(), chatID, thread, nil, worktree)
+}
+
+// TestLoadTool_CannotEscapeDeclaredFilter is the point of the whole change.
+//
+// A workflow that declares `tools: [view]` is making a statement about what its
+// agent should have. Before this, load_tool consulted only the permission
+// ladder — which defaults to `mutating` — so the agent could simply ask for
+// `write` and get it, and the loaded tool was appended AFTER filter expansion,
+// so even an explicit exclusion was overridden.
+func TestLoadTool_CannotEscapeDeclaredFilter(t *testing.T) {
+	t.Parallel()
+	tool := &loadToolTool{}
+	ctx := newFilteredTestCtx(t, PermissionMutating, []string{ToolView, ToolLoadTool})
+
+	resp, err := tool.Execute(ctx, LoadToolParams{Name: ToolWrite})
+	require.NoError(t, err)
+
+	assert.True(t, resp.IsError,
+		"loading a tool outside the declared filter must fail, got: %s", resp.Content)
+	assert.False(t, GetLoadedToolsStore().Has(Scope(ctx.ChatID, ctx.Thread), ToolWrite),
+		"a refused tool must not be recorded as loaded")
+}
+
+// TestLoadTool_AllowedByFilterStillHonoursLadder pins that the two checks are
+// AND, not OR. Naming a tool in `tools:` must not promote an agent past its
+// permission level — otherwise the filter becomes a privilege escalation path.
+func TestLoadTool_AllowedByFilterStillHonoursLadder(t *testing.T) {
+	t.Parallel()
+	tool := &loadToolTool{}
+	ctx := newFilteredTestCtx(t, PermissionReadOnly, []string{ToolView, ToolWrite, ToolLoadTool})
+
+	resp, err := tool.Execute(ctx, LoadToolParams{Name: ToolWrite})
+	require.NoError(t, err)
+
+	assert.True(t, resp.IsError,
+		"the ladder must still apply to a tool the filter allows, got: %s", resp.Content)
+}
+
+// TestLoadTool_AllowedByBothSucceeds — the positive case, so the guard cannot be
+// satisfied by refusing everything.
+func TestLoadTool_AllowedByBothSucceeds(t *testing.T) {
+	t.Parallel()
+	tool := &loadToolTool{}
+	ctx := newFilteredTestCtx(t, PermissionMutating, []string{ToolView, ToolWrite, ToolLoadTool})
+
+	resp, err := tool.Execute(ctx, LoadToolParams{Name: ToolWrite})
+	require.NoError(t, err)
+
+	assert.False(t, resp.IsError,
+		"a tool allowed by both filter and ladder must load: %s", resp.Content)
+	assert.True(t, GetLoadedToolsStore().Has(Scope(ctx.ChatID, ctx.Thread), ToolWrite))
+}
+
+// TestLoadTool_UndeclaredFilterAllowsAnything guards the compatibility case. A
+// workflow with no `tools:` filter places no restriction; reading "no
+// declaration" as "deny all" would break every such workflow, and would also
+// strand a live run whose scope was lost to a worker restart.
+func TestLoadTool_UndeclaredFilterAllowsAnything(t *testing.T) {
+	t.Parallel()
+	tool := &loadToolTool{}
+	ctx := newFilteredTestCtx(t, PermissionMutating, nil)
+
+	resp, err := tool.Execute(ctx, LoadToolParams{Name: ToolWrite})
+	require.NoError(t, err)
+
+	assert.False(t, resp.IsError,
+		"an undeclared filter must not restrict anything: %s", resp.Content)
+}
+
+// TestLoadTool_MCPToolRespectsFilter closes the documented MCP bypass.
+// loadMCPTool deliberately skips the permission ladder ("MCP tools are gated by
+// MCP configuration, not the agent permission ladder"), which left a workflow
+// with a restrictive `tools:` filter no way to refuse a connected MCP tool.
+// The ladder exemption stays; the authorial declaration now applies.
+func TestLoadTool_MCPToolRespectsFilter(t *testing.T) {
+	t.Parallel()
+	tool := &loadToolTool{}
+	const mcpName = "mcp__chrome-devtools__take_screenshot"
+
+	ctx := newFilteredTestCtx(t, PermissionMutating, []string{ToolView, ToolLoadTool})
+	GetLoadedToolsStore().SetAvailableMCPTools(Scope(ctx.ChatID, ctx.Thread), []MCPToolInfo{
+		{Name: mcpName, Description: "Capture a screenshot"},
+	})
+
+	resp, err := tool.Execute(ctx, LoadToolParams{Name: mcpName})
+	require.NoError(t, err)
+
+	assert.True(t, resp.IsError,
+		"a connected MCP tool outside the declared filter must be refused, got: %s", resp.Content)
+}
+
+// TestLoadTool_MCPToolAllowedByTagLoads — an author who wants MCP tools can say
+// so, and `tag:mcp` expands to the connected names.
+func TestLoadTool_MCPToolAllowedByTagLoads(t *testing.T) {
+	t.Parallel()
+	tool := &loadToolTool{}
+	const mcpName = "mcp__chrome-devtools__take_screenshot"
+
+	ctx := newFilteredTestCtx(t, PermissionMutating, []string{ToolView, ToolLoadTool, mcpName})
+	GetLoadedToolsStore().SetAvailableMCPTools(Scope(ctx.ChatID, ctx.Thread), []MCPToolInfo{
+		{Name: mcpName, Description: "Capture a screenshot"},
+	})
+
+	resp, err := tool.Execute(ctx, LoadToolParams{Name: mcpName})
+	require.NoError(t, err)
+
+	assert.False(t, resp.IsError,
+		"an MCP tool named in the filter must load: %s", resp.Content)
+}
+
+// TestLoadTool_PlanModeCannotLoadWrite is the live consumer of the filter, and
+// the case that matters most once the readonly tier is removed.
+//
+// Plan mode declares `tools: ['tag:plan', 'tag:shell']`. Its `readonly`
+// permission is going away — it never prevented writes anyway, because the
+// shell is granted at every tier — so the declared set becomes the only thing
+// expressing "a planning agent is not handed write". This pins that it holds
+// even at mutating permission.
+func TestLoadTool_PlanModeCannotLoadWrite(t *testing.T) {
+	t.Parallel()
+	tool := &loadToolTool{}
+
+	planTools := ExpandToolFilter([]string{"tag:plan", "tag:shell"}, nil)
+	ctx := newFilteredTestCtx(t, PermissionMutating, append(planTools, ToolLoadTool))
+
+	resp, err := tool.Execute(ctx, LoadToolParams{Name: ToolWrite})
+	require.NoError(t, err)
+	assert.True(t, resp.IsError,
+		"a plan-mode agent must not be able to load write: %s", resp.Content)
+
+	// ...while its actual working set still resolves, so the guard is not just
+	// refusing everything. Search is the shell in plan mode.
+	shellResp, err := tool.Execute(ctx, LoadToolParams{Name: ShellToolName})
+	require.NoError(t, err)
+	assert.False(t, shellResp.IsError,
+		"plan mode must keep the shell — it is the only search path: %s", shellResp.Content)
+}
+
+// TestSearchTools_DoesNotAdvertiseFilteredOutTools — discovery must agree with
+// enforcement. Advertising a tool that load_tool will then refuse teaches the
+// model to keep retrying something that cannot work.
+func TestLoadTool_SearchOmitsFilteredOutTools(t *testing.T) {
+	t.Parallel()
+	tool := &loadToolTool{}
+	ctx := newFilteredTestCtx(t, PermissionMutating, []string{ToolView, ToolLoadTool})
+
+	resp, err := tool.Execute(ctx, LoadToolParams{Query: "write"})
+	require.NoError(t, err)
+
+	assert.NotContains(t, resp.Content, "**"+ToolWrite+"**",
+		"search must not advertise a tool the filter excludes: %s", resp.Content)
+}

--- a/internal/llm/tools/load_tool_filter_test.go
+++ b/internal/llm/tools/load_tool_filter_test.go
@@ -54,12 +54,14 @@ func TestLoadTool_CannotEscapeDeclaredFilter(t *testing.T) {
 // TestLoadTool_AllowedByFilterStillHonoursLadder pins that the two checks are
 // AND, not OR. Naming a tool in `tools:` must not promote an agent past its
 // permission level — otherwise the filter becomes a privilege escalation path.
+// spawn is the capability the ladder still gates, so it is the one that can
+// demonstrate this.
 func TestLoadTool_AllowedByFilterStillHonoursLadder(t *testing.T) {
 	t.Parallel()
 	tool := &loadToolTool{}
-	ctx := newFilteredTestCtx(t, PermissionReadOnly, []string{ToolView, ToolWrite, ToolLoadTool})
+	ctx := newFilteredTestCtx(t, PermissionMutating, []string{ToolView, "spawn", ToolLoadTool})
 
-	resp, err := tool.Execute(ctx, LoadToolParams{Name: ToolWrite})
+	resp, err := tool.Execute(ctx, LoadToolParams{Name: "spawn"})
 	require.NoError(t, err)
 
 	assert.True(t, resp.IsError,

--- a/internal/llm/tools/load_tool_test.go
+++ b/internal/llm/tools/load_tool_test.go
@@ -206,28 +206,12 @@ func TestLoadTool_LoadMCPTool_NoneConnectedErrors(t *testing.T) {
 
 // ----- Permission gating -----
 
-func TestLoadTool_PermissionGating_ReadOnlyCannotLoadMutatingTool(t *testing.T) {
-	t.Parallel()
-	tool := &loadToolTool{}
-	ctx := newLoadToolTestCtx(t, PermissionReadOnly)
-
-	resp, err := tool.Execute(ctx, LoadToolParams{Name: ToolWrite})
-	require.NoError(t, err)
-	assert.True(t, resp.IsError, "readonly agent must be denied write tool")
-	assert.Contains(t, resp.Content, "permission")
-	assert.Contains(t, resp.Content, PermissionMutating)
-}
-
-func TestLoadTool_PermissionGating_ReadOnlyCanLoadReadOnlyTool(t *testing.T) {
-	t.Parallel()
-	tool := &loadToolTool{}
-	ctx := newLoadToolTestCtx(t, PermissionReadOnly)
-
-	resp, err := tool.Execute(ctx, LoadToolParams{Name: ToolFetch})
-	require.NoError(t, err)
-	assert.False(t, resp.IsError, "readonly agent should be allowed to load fetch: %s", resp.Content)
-	assert.Contains(t, resp.Content, ToolFetch)
-}
+// The readonly tier's gating tests are gone with the tier. What they were
+// really asserting — that an agent scoped to reading cannot acquire `write` —
+// is now enforced by the declared tool set and tested in load_tool_filter_test.go
+// (TestLoadTool_CannotEscapeDeclaredFilter, TestLoadTool_PlanModeCannotLoadWrite).
+// That is a stronger test than the old one, which passed while the same agent
+// held a shell that could `> file`.
 
 func TestLoadTool_PermissionGating_MutatingCanLoadMutatingTool(t *testing.T) {
 	t.Parallel()
@@ -302,16 +286,19 @@ func TestLoadTool_LoadAlreadyLoadedTool_Idempotent(t *testing.T) {
 func TestLoadTool_DeniedLoadNotStored(t *testing.T) {
 	t.Parallel()
 	tool := &loadToolTool{}
-	ctx := newLoadToolTestCtx(t, PermissionReadOnly)
+	// spawn is the one capability the ladder still gates, so it is what a denial
+	// is tested with now that readonly is gone.
+	ctx := newLoadToolTestCtx(t, PermissionMutating)
 
-	resp, err := tool.Execute(ctx, LoadToolParams{Name: ToolWrite})
+	resp, err := tool.Execute(ctx, LoadToolParams{Name: "spawn"})
 	require.NoError(t, err)
-	require.True(t, resp.IsError, "readonly must be denied write")
+	require.True(t, resp.IsError, "a mutating agent must be denied spawn")
 
+	scopeKey := Scope(ctx.ChatID, ctx.Thread)
 	store := GetLoadedToolsStore()
-	assert.False(t, store.Has(ctx.ChatID, ToolWrite),
+	assert.False(t, store.Has(scopeKey, "spawn"),
 		"permission-denied load must NOT be recorded in the store")
-	assert.Nil(t, store.Get(ctx.ChatID),
+	assert.Nil(t, store.Get(scopeKey),
 		"store should have no loaded tools after a denied load")
 }
 

--- a/internal/llm/tools/loaded_tools_store.go
+++ b/internal/llm/tools/loaded_tools_store.go
@@ -230,19 +230,24 @@ func (s *LoadedToolsStore) HasAllowedTools(scopeKey string) bool {
 
 // GetPermission returns the permission level for a scope.
 //
-// An unknown scope FAILS CLOSED at PermissionReadOnly. This store is in-memory,
-// so a worker restart empties it while runs are in flight; the previous default
-// of PermissionOrchestrator meant that any execute_tools landing between the
-// restart and the next call_llm — which is what re-populates the scope — was
-// granted maximum privilege precisely because the state had been lost.
+// An unknown scope FAILS CLOSED at the LOWEST live tier. This store is
+// in-memory, so a worker restart empties it while runs are in flight; defaulting
+// to PermissionOrchestrator would grant maximum privilege — including spawn —
+// to any execute_tools landing between the restart and the next call_llm, which
+// is what re-populates the scope, precisely because the state had been lost.
+//
+// With the readonly tier removed, the lowest tier is PermissionMutating, so this
+// default now withholds only spawn. That is a real reduction in what the
+// fail-closed path protects, and it is the honest one: the readonly tier never
+// withheld write in the first place, since the shell was granted at every level.
 func (s *LoadedToolsStore) GetPermission(scopeKey string) string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	if perm, ok := s.permissions[scopeKey]; ok {
-		return perm
+		return NormalizePermission(perm)
 	}
-	return PermissionReadOnly
+	return PermissionMutating
 }
 
 // DeferredToolNames returns tool names from the registry (and available MCP tools)
@@ -319,7 +324,7 @@ func SearchTools(query string, permission string, mcpTools []MCPToolInfo) []Tool
 		results = append(results, ToolSearchResult{
 			Name:              m.Name,
 			Tags:              []ToolTag{TagMCP},
-			MinPermission:     PermissionReadOnly,
+			MinPermission:     PermissionMutating,
 			PermissionAllowed: true,
 		})
 	}

--- a/internal/llm/tools/loaded_tools_store.go
+++ b/internal/llm/tools/loaded_tools_store.go
@@ -24,6 +24,7 @@ type LoadedToolsStore struct {
 	mu           sync.RWMutex
 	tools        map[string]map[string]bool      // scope -> set of tool names
 	permissions  map[string]string               // scope -> permission level
+	allowed      map[string]map[string]bool      // scope -> workflow-declared allow-set
 	skills       map[string][]config.StoredSkill // scope -> skills
 	availableMCP map[string][]MCPToolInfo        // scope -> connected/available MCP tools
 }
@@ -57,6 +58,7 @@ type MCPToolInfo struct {
 var globalLoadedToolsStore = &LoadedToolsStore{
 	tools:        make(map[string]map[string]bool),
 	permissions:  make(map[string]string),
+	allowed:      make(map[string]map[string]bool),
 	skills:       make(map[string][]config.StoredSkill),
 	availableMCP: make(map[string][]MCPToolInfo),
 }
@@ -118,6 +120,7 @@ func (s *LoadedToolsStore) Clear(scopeKey string) {
 
 	delete(s.tools, scopeKey)
 	delete(s.permissions, scopeKey)
+	delete(s.allowed, scopeKey)
 	delete(s.skills, scopeKey)
 	delete(s.availableMCP, scopeKey)
 }
@@ -170,6 +173,59 @@ func (s *LoadedToolsStore) SetPermission(scopeKey, permission string) {
 	defer s.mu.Unlock()
 
 	s.permissions[scopeKey] = permission
+}
+
+// SetAllowedTools records the workflow's declared tool set for a scope, already
+// expanded from `tools:` (tags, globs and exclusions resolved to concrete
+// names). It is what makes the declaration a boundary rather than a hint: the
+// expansion used to be computed to build one request's tool array and then
+// thrown away, so load_tool could hand back anything the permission ladder
+// happened to allow — including a tool the author had explicitly excluded.
+//
+// An EMPTY set means "no declaration", not "nothing allowed". A workflow with
+// no `tools:` filter places no restriction, and must not be silently reduced to
+// zero tools.
+func (s *LoadedToolsStore) SetAllowedTools(scopeKey string, names []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(names) == 0 {
+		delete(s.allowed, scopeKey)
+		return
+	}
+	set := make(map[string]bool, len(names))
+	for _, name := range names {
+		set[name] = true
+	}
+	s.allowed[scopeKey] = set
+}
+
+// IsToolAllowed reports whether a tool passes the scope's declared allow-set.
+// Scopes with no declaration allow everything, so an undeclared workflow keeps
+// working and a lost scope (worker restart) does not strand a live run.
+//
+// This is deliberately NOT the security boundary — a declared set still hands
+// the agent a shell. It enforces authorial intent: what this workflow said its
+// agent should have.
+func (s *LoadedToolsStore) IsToolAllowed(scopeKey, toolName string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	set, ok := s.allowed[scopeKey]
+	if !ok {
+		return true
+	}
+	return set[toolName]
+}
+
+// HasAllowedTools reports whether a scope carries a declaration at all, so
+// callers can tell "allowed because declared" from "allowed because undeclared".
+func (s *LoadedToolsStore) HasAllowedTools(scopeKey string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	_, ok := s.allowed[scopeKey]
+	return ok
 }
 
 // GetPermission returns the permission level for a scope.

--- a/internal/llm/tools/loaded_tools_store_scope_test.go
+++ b/internal/llm/tools/loaded_tools_store_scope_test.go
@@ -62,11 +62,11 @@ func TestLoadedToolsStore_PermissionIsPerScope(t *testing.T) {
 	child := scope(chatID, "thread:child-1")
 
 	s.SetPermission(parent, PermissionOrchestrator)
-	s.SetPermission(child, PermissionReadOnly)
+	s.SetPermission(child, PermissionMutating)
 
 	assert.Equal(t, PermissionOrchestrator, s.GetPermission(parent),
 		"a child's lower permission must not overwrite the parent's")
-	assert.Equal(t, PermissionReadOnly, s.GetPermission(child),
+	assert.Equal(t, PermissionMutating, s.GetPermission(child),
 		"the child must keep the capped permission it was given")
 }
 
@@ -78,6 +78,6 @@ func TestLoadedToolsStore_UnknownScopeFailsClosed(t *testing.T) {
 	t.Parallel()
 	s := newTestStore()
 
-	assert.Equal(t, PermissionReadOnly, s.GetPermission(scope("chat-never-seen", "thread:root")),
-		"an unknown scope must fail closed, not grant orchestrator")
+	assert.Equal(t, PermissionMutating, s.GetPermission(scope("chat-never-seen", "thread:root")),
+		"an unknown scope must fail closed at the lowest live tier, not grant orchestrator")
 }

--- a/internal/llm/tools/loaded_tools_store_test.go
+++ b/internal/llm/tools/loaded_tools_store_test.go
@@ -113,8 +113,21 @@ func TestLoadedToolsStore_SetAndGetPermission(t *testing.T) {
 	assert.Equal(t, PermissionMutating, s.GetPermission(chatID))
 
 	// Overwrite
-	s.SetPermission(chatID, PermissionReadOnly)
-	assert.Equal(t, PermissionReadOnly, s.GetPermission(chatID))
+	s.SetPermission(chatID, PermissionOrchestrator)
+	assert.Equal(t, PermissionOrchestrator, s.GetPermission(chatID))
+}
+
+// A scope written before the readonly tier was removed — an in-flight run, or a
+// stored value — must read back as a live tier rather than as an unknown level
+// that fails every comparison.
+func TestLoadedToolsStore_GetPermission_NormalizesRetiredTier(t *testing.T) {
+	t.Parallel()
+	s := newTestStore()
+	chatID := "chat-legacy-perm"
+
+	s.SetPermission(chatID, "readonly")
+	assert.Equal(t, PermissionMutating, s.GetPermission(chatID),
+		"a stored readonly must normalize forward, not strand the run")
 }
 
 func TestLoadedToolsStore_GetPermission_DefaultFailsClosed(t *testing.T) {
@@ -123,11 +136,11 @@ func TestLoadedToolsStore_GetPermission_DefaultFailsClosed(t *testing.T) {
 
 	// An unset scope means "we do not know what this agent was granted", which
 	// happens after a worker restart empties this in-memory store mid-run. The
-	// answer must be the LEAST privilege, not the most: the previous
-	// orchestrator default handed maximum privilege to any execute_tools that
-	// landed before the next call_llm repopulated the scope.
-	assert.Equal(t, PermissionReadOnly, s.GetPermission("unknown-scope"),
-		"unset permission must fail closed at readonly")
+	// answer must be the LEAST privilege, not the most: an orchestrator default
+	// would hand spawn to any execute_tools that landed before the next call_llm
+	// repopulated the scope.
+	assert.Equal(t, PermissionMutating, s.GetPermission("unknown-scope"),
+		"unset permission must fail closed at the lowest live tier")
 }
 
 func TestLoadedToolsStore_ClearRemovesPermission(t *testing.T) {
@@ -135,14 +148,14 @@ func TestLoadedToolsStore_ClearRemovesPermission(t *testing.T) {
 	s := newTestStore()
 	chatID := "chat-clear-perm"
 
-	s.SetPermission(chatID, PermissionReadOnly)
+	s.SetPermission(chatID, PermissionOrchestrator)
 	s.Add(chatID, "view")
-	assert.Equal(t, PermissionReadOnly, s.GetPermission(chatID))
+	assert.Equal(t, PermissionOrchestrator, s.GetPermission(chatID))
 
 	s.Clear(chatID)
 
 	// Back to the fail-closed default.
-	assert.Equal(t, PermissionReadOnly, s.GetPermission(chatID),
+	assert.Equal(t, PermissionMutating, s.GetPermission(chatID),
 		"Clear must remove stored permission, falling back to the least-privilege default")
 	assert.Nil(t, s.Get(chatID))
 }
@@ -180,7 +193,7 @@ func TestSearchTools_SurfacesConnectedMCPTool(t *testing.T) {
 	}
 
 	// Keyword present in the MCP tool NAME.
-	results := SearchTools("screenshot", PermissionReadOnly, mcpTools)
+	results := SearchTools("screenshot", PermissionMutating, mcpTools)
 	require.True(t, containsToolResult(results, "mcp__chrome-devtools__take_screenshot"),
 		"expected screenshot MCP tool surfaced by name keyword")
 	for _, r := range results {
@@ -191,12 +204,12 @@ func TestSearchTools_SurfacesConnectedMCPTool(t *testing.T) {
 	}
 
 	// Keyword present only in the DESCRIPTION ("browser").
-	results = SearchTools("browser", PermissionReadOnly, mcpTools)
+	results = SearchTools("browser", PermissionMutating, mcpTools)
 	assert.True(t, containsToolResult(results, "mcp__chrome-devtools__navigate_page"),
 		"expected MCP tool surfaced via description keyword")
 
 	// Non-matching keyword surfaces no MCP tools.
-	results = SearchTools("zzz_no_match_zzz", PermissionReadOnly, mcpTools)
+	results = SearchTools("zzz_no_match_zzz", PermissionMutating, mcpTools)
 	for _, r := range results {
 		assert.NotContains(t, r.Name, "mcp__", "no MCP tool should match a non-matching keyword")
 	}

--- a/internal/llm/tools/permissions.go
+++ b/internal/llm/tools/permissions.go
@@ -1,29 +1,48 @@
 // Copyright (c) 2025 Reliant Labs
 package tools
 
-// Permission levels control which tools an agent can load via load_tool.
+// Permission levels control which tools an agent is OFFERED, and which it can
+// load via load_tool.
+//
+// THIS IS NOT A SECURITY BOUNDARY, and must not be described as one. Every tier
+// holds the shell family, because search goes through the shell — so an agent
+// at any level can read, write and execute whatever the daemon user can. What
+// the ladder decides is which convenience tools the model is handed, which is
+// steering: an agent not given `write` is far less likely to write, and that is
+// genuinely useful for shaping behavior. It is not a guarantee, and code that
+// needs a guarantee must get it below the tool layer.
+//
+// A third tier, "readonly", was removed. It sat below mutating and differed
+// only in withholding write/edit/find_replace/move_code — each a one-line shell
+// equivalent (`cat > f`, `sed -i`, `mv`) — while still handing over the shell.
+// The name promised something the mechanism never delivered, which is worse
+// than not offering it: callers reasonably read "readonly" as "cannot write".
+// What that tier was really expressing — "this agent should not be handed write
+// tools" — is now said directly by a workflow's `tools:` filter, which is
+// enforced (see LoadedToolsStore.IsToolAllowed). A real read-only mode needs OS
+// containment and will be reintroduced on that footing.
 const (
-	// PermissionReadOnly allows read-only tools: view, fetch, websearch, skill,
-	// load_tool — plus the shell, which is the ONLY search path now that the
-	// scoped grep/glob tools are gone. See minimumPermissionFromTags for why
-	// that makes "readonly" a weaker guarantee than its name implies.
-	PermissionReadOnly = "readonly"
-
-	// PermissionMutating allows read-only + mutating tools: write, edit, bash, find_replace, move_code, etc.
+	// PermissionMutating is the default: every tool except those reserved for
+	// orchestrators.
 	PermissionMutating = "mutating"
 
-	// PermissionOrchestrator allows all tools including spawn
+	// PermissionOrchestrator additionally allows spawning sub-agents.
 	PermissionOrchestrator = "orchestrator"
 )
 
 // permissionOrder defines the hierarchy for comparison.
 var permissionOrder = map[string]int{
-	PermissionReadOnly:     0,
-	PermissionMutating:     1,
-	PermissionOrchestrator: 2,
+	PermissionMutating:     0,
+	PermissionOrchestrator: 1,
 }
 
 // PermissionAtLeast returns true if `have` is at least as permissive as `need`.
+//
+// An unrecognized level is NOT at least anything — including the retired
+// "readonly", which a stored workflow or an in-flight run may still carry. That
+// is deliberate: such a run is denied rather than silently promoted to
+// mutating. See NormalizePermission for the resolution callers should apply
+// when reading a level that may predate this change.
 func PermissionAtLeast(have, need string) bool {
 	h, ok1 := permissionOrder[have]
 	n, ok2 := permissionOrder[need]
@@ -33,15 +52,43 @@ func PermissionAtLeast(have, need string) bool {
 	return h >= n
 }
 
+// legacyReadOnlyPermission is the retired tier. Workflow YAML, presets and
+// in-flight Temporal histories may still carry it, so it is recognized at the
+// boundary and mapped forward rather than treated as a typo.
+const legacyReadOnlyPermission = "readonly"
+
+// NormalizePermission maps a declared permission onto a live tier.
+//
+// The retired "readonly" becomes "mutating", which is an honest description of
+// what it always was: the shell rode along at that tier, so the agent could
+// already do anything mutating could. Workflows that relied on the name to
+// withhold write tools should express that in `tools:`, which enforces it —
+// the builtin agent's plan mode does exactly this, and its filter is what
+// actually keeps write out of a planning agent's hands.
+//
+// An empty or unrecognized value resolves to the default tier.
+func NormalizePermission(permission string) string {
+	switch permission {
+	case PermissionOrchestrator:
+		return PermissionOrchestrator
+	case PermissionMutating:
+		return PermissionMutating
+	case legacyReadOnlyPermission:
+		return PermissionMutating
+	default:
+		return PermissionMutating
+	}
+}
+
 // InitialToolsForPermission returns the tool names that are always loaded
 // (with full schemas) for a given permission level.
 func InitialToolsForPermission(permission string) []string {
-	// All levels get these. The shell family rides along at EVERY level because
-	// searching the codebase now goes through the shell — a level without it
-	// cannot search at all, which is the regression that followed the first
-	// removal of grep/glob. `tag:shell` is kept whole (the shell's own
-	// description tells the model to reach for shell_output/shell_kill/shell_list,
-	// so handing over the shell without them documents tools that do not exist).
+	// The shell family rides along at EVERY level because searching the codebase
+	// goes through the shell — a level without it cannot search at all, which is
+	// the regression that followed the removal of grep/glob. `tag:shell` is kept
+	// whole (the shell's own description tells the model to reach for
+	// shell_output/shell_kill/shell_list, so handing over the shell without them
+	// documents tools that do not exist).
 	base := []string{
 		ToolSkill,
 		ToolLoadTool,
@@ -51,29 +98,26 @@ func InitialToolsForPermission(permission string) []string {
 		ToolShellOutput,
 		ToolShellWait,
 		ToolShellKill,
+		ToolFetch,
+		ToolWebSearch,
+		ToolWrite,
+		ToolEdit,
+		ToolFindReplace,
+		ToolMoveCode,
 	}
 
-	switch permission {
-	case PermissionReadOnly:
-		return append(base, ToolFetch, ToolWebSearch)
-	case PermissionMutating:
-		return append(base,
-			ToolFetch, ToolWebSearch,
-			ToolWrite, ToolEdit, ToolFindReplace, ToolMoveCode,
-		)
-	case PermissionOrchestrator:
-		// Orchestrator gets everything mutating gets, plus spawn is added separately
-		return append(base,
-			ToolFetch, ToolWebSearch,
-			ToolWrite, ToolEdit, ToolFindReplace, ToolMoveCode,
-		)
+	// Orchestrator adds spawn, which is granted separately — so both live tiers
+	// start from the same set. The switch is kept rather than collapsed because
+	// an unrecognized level must still resolve to something sane.
+	switch NormalizePermission(permission) {
+	case PermissionMutating, PermissionOrchestrator:
+		return base
 	default:
 		return base
 	}
 }
 
 // MinimumPermissionForTool returns the minimum permission level required to load a tool.
-// Uses tool tags from the registry to determine the level.
 func MinimumPermissionForTool(toolName string) string {
 	// Explicit orchestrator-only tools.
 	//
@@ -86,42 +130,9 @@ func MinimumPermissionForTool(toolName string) string {
 		return PermissionOrchestrator
 	}
 
-	// Check the registry for tag-based classification
-	registry := GetToolRegistry()
-	for _, def := range registry {
-		if def.Name == toolName {
-			return minimumPermissionFromTags(def.Tags)
-		}
-	}
-
-	// MCP tools and unknown tools default to readonly (safe default)
-	return PermissionReadOnly
-}
-
-// minimumPermissionFromTags determines permission level from tool tags.
-//
-// The shell family is readonly-tier. That is a deliberate weakening, not an
-// oversight: with the scoped grep/glob tools removed, the shell is the only way
-// to search a codebase, so gating it at mutating would leave readonly and
-// plan-mode agents unable to search — the exact regression the earlier removal
-// produced. The tradeoff is that "readonly" no longer means the agent cannot
-// write; it means the agent is not HANDED write tools, while retaining a shell
-// that can still `>` a file. Callers needing a hard read-only boundary must
-// enforce it below the tool layer (sandbox/filesystem), not via this gate.
-func minimumPermissionFromTags(tags []ToolTag) string {
-	for _, tag := range tags {
-		switch tag {
-		case TagShell, TagExecution:
-			return PermissionReadOnly
-		case TagFile:
-			// File tools that are also read-only stay readonly
-			for _, t := range tags {
-				if t == TagReadOnly {
-					return PermissionReadOnly
-				}
-			}
-			return PermissionMutating
-		}
-	}
-	return PermissionReadOnly
+	// Everything else — including MCP and unknown tools — sits at the base tier.
+	// Tag-based classification existed only to separate mutating from readonly;
+	// with readonly gone there is nothing left for it to decide, and a tag table
+	// that always returns the same answer reads as a gate while gating nothing.
+	return PermissionMutating
 }

--- a/internal/llm/tools/permissions_test.go
+++ b/internal/llm/tools/permissions_test.go
@@ -7,48 +7,71 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// ----- PermissionAtLeast -----
+// The ladder has two live tiers. Everything that used to distinguish a third,
+// "readonly", is now said by a workflow's `tools:` filter — see
+// load_tool_filter_test.go, which is where the enforceable half of this story
+// is tested.
 
-func TestPermissionAtLeast_ReadOnlyNotSufficientForMutating(t *testing.T) {
-	t.Parallel()
-	assert.False(t, PermissionAtLeast(PermissionReadOnly, PermissionMutating),
-		"readonly must not satisfy mutating requirement")
-	assert.False(t, PermissionAtLeast(PermissionReadOnly, PermissionOrchestrator),
-		"readonly must not satisfy orchestrator requirement")
-}
+// ----- PermissionAtLeast -----
 
 func TestPermissionAtLeast_MutatingNotSufficientForOrchestrator(t *testing.T) {
 	t.Parallel()
 	assert.False(t, PermissionAtLeast(PermissionMutating, PermissionOrchestrator),
 		"mutating must not satisfy orchestrator requirement")
-	// But mutating >= readonly
-	assert.True(t, PermissionAtLeast(PermissionMutating, PermissionReadOnly),
-		"mutating must satisfy readonly requirement")
 }
 
 func TestPermissionAtLeast_OrchestratorIsSufficientForAll(t *testing.T) {
 	t.Parallel()
-	assert.True(t, PermissionAtLeast(PermissionOrchestrator, PermissionReadOnly))
 	assert.True(t, PermissionAtLeast(PermissionOrchestrator, PermissionMutating))
 	assert.True(t, PermissionAtLeast(PermissionOrchestrator, PermissionOrchestrator))
 }
 
 func TestPermissionAtLeast_SamePermission(t *testing.T) {
 	t.Parallel()
-	assert.True(t, PermissionAtLeast(PermissionReadOnly, PermissionReadOnly))
 	assert.True(t, PermissionAtLeast(PermissionMutating, PermissionMutating))
 	assert.True(t, PermissionAtLeast(PermissionOrchestrator, PermissionOrchestrator))
 }
 
 func TestPermissionAtLeast_InvalidPermission(t *testing.T) {
 	t.Parallel()
-	// Unknown permissions must not satisfy any real permission requirement.
-	assert.False(t, PermissionAtLeast("bogus", PermissionReadOnly),
+	assert.False(t, PermissionAtLeast("bogus", PermissionMutating),
 		"unknown 'have' permission must be treated as insufficient")
 	assert.False(t, PermissionAtLeast(PermissionOrchestrator, "bogus"),
 		"unknown 'need' permission must return false (safe default)")
 	assert.False(t, PermissionAtLeast("", ""),
 		"empty permissions must be treated as insufficient")
+}
+
+// The retired tier is not silently promoted by the comparison itself — a stored
+// "readonly" is an unknown level here and fails closed. Callers that may read a
+// pre-change value run it through NormalizePermission first.
+func TestPermissionAtLeast_RetiredReadOnlyIsNotRecognized(t *testing.T) {
+	t.Parallel()
+	assert.False(t, PermissionAtLeast("readonly", PermissionMutating),
+		"the retired tier must not satisfy a real requirement without normalization")
+}
+
+// ----- NormalizePermission -----
+
+// A workflow, preset, or in-flight Temporal history written before the tier was
+// removed still carries "readonly". It resolves to mutating, which is an honest
+// description of what that tier always was: the shell rode along at it, so the
+// agent could already do anything mutating could.
+func TestNormalizePermission_RetiredReadOnlyBecomesMutating(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, PermissionMutating, NormalizePermission("readonly"))
+}
+
+func TestNormalizePermission_LiveTiersUnchanged(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, PermissionMutating, NormalizePermission(PermissionMutating))
+	assert.Equal(t, PermissionOrchestrator, NormalizePermission(PermissionOrchestrator))
+}
+
+func TestNormalizePermission_UnknownFallsBackToBaseTier(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, PermissionMutating, NormalizePermission(""))
+	assert.Equal(t, PermissionMutating, NormalizePermission("bogus"))
 }
 
 // ----- InitialToolsForPermission -----
@@ -67,126 +90,95 @@ func containsAll(haystack []string, needles ...string) bool {
 	return true
 }
 
-// containsNone returns true if none of the needles appear in haystack.
-func containsNone(haystack []string, needles ...string) bool {
-	set := make(map[string]bool, len(haystack))
-	for _, h := range haystack {
-		set[h] = true
-	}
-	for _, n := range needles {
-		if set[n] {
-			return false
-		}
-	}
-	return true
-}
-
-func TestInitialToolsForPermission_ReadOnly(t *testing.T) {
-	t.Parallel()
-	got := InitialToolsForPermission(PermissionReadOnly)
-
-	// Read-only agents must get the core discovery/read tools.
-	assert.True(t, containsAll(got,
-		ToolSkill, ToolLoadTool, ToolView, ToolFetch, ToolWebSearch,
-	), "readonly initial set missing expected read-only tools: %v", got)
-
-	// The shell family rides along even at readonly, because it is the only way
-	// to search a codebase now that the scoped grep/glob tools are gone. A
-	// readonly agent without it cannot search at all.
-	assert.True(t, containsAll(got,
-		ShellToolName, ToolShellList, ToolShellOutput, ToolShellKill,
-	), "readonly initial set missing the shell search path: %v", got)
-
-	// But must NOT get the file-mutating tools.
-	assert.True(t, containsNone(got,
-		ToolWrite, ToolEdit, ToolFindReplace, ToolMoveCode,
-	), "readonly initial set unexpectedly contains mutating tools: %v", got)
-}
-
 func TestInitialToolsForPermission_Mutating(t *testing.T) {
 	t.Parallel()
 	got := InitialToolsForPermission(PermissionMutating)
 
-	// Mutating agents get everything readonly gets...
 	assert.True(t, containsAll(got,
 		ToolSkill, ToolLoadTool, ToolView, ToolFetch, ToolWebSearch,
-	), "mutating initial set missing read-only tools: %v", got)
+	), "mutating initial set missing read tools: %v", got)
 
-	// ...plus all the mutating tools.
 	assert.True(t, containsAll(got,
-		ToolWrite, ToolEdit, ShellToolName, ToolFindReplace, ToolMoveCode,
-		ToolShellList, ToolShellOutput, ToolShellKill,
+		ToolWrite, ToolEdit, ToolFindReplace, ToolMoveCode,
 	), "mutating initial set missing mutating tools: %v", got)
+
+	// The shell family is kept whole — the shell's own description tells the
+	// model to reach for shell_output/shell_list/shell_kill, so handing over the
+	// shell without them documents tools that do not exist.
+	assert.True(t, containsAll(got,
+		ShellToolName, ToolShellList, ToolShellOutput, ToolShellWait, ToolShellKill,
+	), "mutating initial set missing the shell family: %v", got)
 }
 
 func TestInitialToolsForPermission_Orchestrator(t *testing.T) {
 	t.Parallel()
-	got := InitialToolsForPermission(PermissionOrchestrator)
+	// Both live tiers start from the same set; orchestrator's extra capability
+	// is spawn, which is granted separately rather than through this list.
+	assert.Equal(t,
+		InitialToolsForPermission(PermissionMutating),
+		InitialToolsForPermission(PermissionOrchestrator),
+		"orchestrator differs from mutating only by spawn, which is granted separately")
+}
 
-	// Orchestrator at minimum contains everything the mutating level has.
-	assert.True(t, containsAll(got,
-		ToolSkill, ToolLoadTool, ToolView, ToolFetch, ToolWebSearch,
-		ToolWrite, ToolEdit, ShellToolName, ToolFindReplace, ToolMoveCode,
-		ToolShellList, ToolShellOutput, ToolShellKill,
-	), "orchestrator initial set missing expected tools: %v", got)
+func TestInitialToolsForPermission_RetiredTierStillResolves(t *testing.T) {
+	t.Parallel()
+	// A stored "readonly" must not produce an empty or degraded tool set.
+	assert.Equal(t,
+		InitialToolsForPermission(PermissionMutating),
+		InitialToolsForPermission("readonly"),
+		"the retired tier must resolve to the base set, not to nothing")
+}
 
-	// NOTE: The current implementation comment says "spawn is added separately",
-	// so we do not assert spawn is in the initial set here — this test
-	// documents that expectation. If that behavior changes, update this test.
+// A stored workflow declaring the retired tier must still run, and must resolve
+// to a tier that actually clears the gates its tools sit behind. This is the
+// upgrade path: a `permission: readonly` workflow keeps working, it just stops
+// implying a guarantee it never provided.
+func TestRetiredReadOnlyWorkflowStillClearsItsGates(t *testing.T) {
+	t.Parallel()
+
+	resolved := NormalizePermission("readonly")
+
+	for _, name := range []string{ToolView, ShellToolName, ToolWrite, ToolEdit} {
+		assert.True(t, PermissionAtLeast(resolved, MinimumPermissionForTool(name)),
+			"a normalized legacy workflow must still be able to run %q", name)
+	}
+
+	// ...but it does not silently gain the one capability the ladder still gates.
+	assert.False(t, PermissionAtLeast(resolved, MinimumPermissionForTool("spawn")),
+		"normalizing the retired tier must not grant spawn")
 }
 
 // ----- MinimumPermissionForTool -----
 
-func TestMinimumPermissionForTool_ReadOnlyTools(t *testing.T) {
-	t.Parallel()
-	readOnlyTools := []string{ToolView, ToolFetch, ToolWebSearch}
-	for _, name := range readOnlyTools {
-		assert.Equal(t, PermissionReadOnly, MinimumPermissionForTool(name),
-			"tool %q should require readonly permission", name)
-	}
-}
-
-func TestMinimumPermissionForTool_MutatingTools(t *testing.T) {
-	t.Parallel()
-	mutatingTools := []string{ToolWrite, ToolEdit, ToolFindReplace, ToolMoveCode}
-	for _, name := range mutatingTools {
-		assert.Equal(t, PermissionMutating, MinimumPermissionForTool(name),
-			"tool %q should require mutating permission", name)
-	}
-}
-
-// The shell gates at READONLY, not mutating. This is the deliberate tradeoff
-// taken when the scoped grep/glob tools were removed: the shell became the only
-// search path, so gating it at mutating would leave readonly and plan-mode
-// agents unable to search — the regression that followed the first removal.
-// "readonly" therefore means "not handed write tools", not "cannot write": the
-// shell can still redirect into a file. A hard read-only boundary has to be
-// enforced below the tool layer.
-func TestMinimumPermissionForTool_ShellIsReadOnlyTier(t *testing.T) {
-	t.Parallel()
-	for _, name := range []string{ShellToolName, ToolShellList, ToolShellOutput, ToolShellKill} {
-		assert.Equal(t, PermissionReadOnly, MinimumPermissionForTool(name),
-			"tool %q must be loadable by a readonly agent so search still works", name)
-	}
-}
-
 func TestMinimumPermissionForTool_OrchestratorTools(t *testing.T) {
 	t.Parallel()
-	// The implementation explicitly lists "spawn" and ToolAgent as orchestrator-only.
 	assert.Equal(t, PermissionOrchestrator, MinimumPermissionForTool("spawn"))
 	assert.Equal(t, PermissionOrchestrator, MinimumPermissionForTool(ToolAgent))
 }
 
-func TestMinimumPermissionForTool_UnknownTool(t *testing.T) {
+// Everything that is not spawn sits at the base tier. With readonly gone there
+// is nothing for tag-based classification to decide, so the answer is uniform —
+// which is the point: the ladder no longer pretends to separate reading from
+// writing, because it never could once the shell was granted at every level.
+func TestMinimumPermissionForTool_EverythingElseIsBaseTier(t *testing.T) {
 	t.Parallel()
-	// Unknown tools default to readonly (safe default per implementation comment).
-	assert.Equal(t, PermissionReadOnly, MinimumPermissionForTool("nonexistent_tool_xyz"),
-		"unknown tools must default to the safest permission level")
+	for _, name := range []string{
+		ToolView, ToolFetch, ToolWebSearch,
+		ToolWrite, ToolEdit, ToolFindReplace, ToolMoveCode,
+		ShellToolName, ToolShellList, ToolShellOutput, ToolShellKill,
+		"nonexistent_tool_xyz",
+		"mcp__proxyman__get_flow_detail",
+	} {
+		assert.Equal(t, PermissionMutating, MinimumPermissionForTool(name),
+			"tool %q should sit at the base tier", name)
+	}
 }
 
-func TestMinimumPermissionForTool_MCPTools(t *testing.T) {
+// spawn_status and spawn_send stay reachable below orchestrator: an agent
+// holding a handle to a sub-agent it spawned needs no extra privilege to look at
+// it or talk to it, and a sub-agent itself does not run at orchestrator tier.
+func TestMinimumPermissionForTool_SpawnObservabilityNotGated(t *testing.T) {
 	t.Parallel()
-	// MCP tools (prefix mcp__) aren't in the registry and should get the safe default.
-	assert.Equal(t, PermissionReadOnly, MinimumPermissionForTool("mcp__proxyman__get_flow_detail"))
-	assert.Equal(t, PermissionReadOnly, MinimumPermissionForTool("mcp__serena__find_symbol"))
+	assert.Equal(t, PermissionMutating, MinimumPermissionForTool(ToolSpawnStatus))
+	assert.Equal(t, PermissionMutating, MinimumPermissionForTool(ToolSpawnSend))
 }

--- a/internal/workflow/builtin/agent.yaml
+++ b/internal/workflow/builtin/agent.yaml
@@ -203,15 +203,20 @@ nodes:
             # through the shell, since there are no dedicated grep/glob tools;
             # spawn available in all modes (child inherits preset config).
             #
-            # Plan mode gates at 'readonly', which is now sufficient: the shell is
-            # readonly-tier precisely so plan-mode agents can still search. The
-            # earlier blanket 'mutating' existed only because the shell used to
-            # gate at mutating and plan mode would otherwise have had no way to
-            # search at all; that workaround is no longer needed.
+            # The FILTER is what makes this a planning agent. It is enforced:
+            # load_tool and execute_tools both check it, so a plan-mode agent
+            # cannot acquire `write` by asking for it.
+            #
+            # `permission` is no longer varied by mode. It used to read
+            # 'readonly' for plan, which promised more than it delivered — the
+            # shell was granted at that tier too, so a plan-mode agent could
+            # always redirect into a file. The tier was removed rather than left
+            # to imply a guarantee it never made; a real read-only mode needs OS
+            # containment and will return on that footing.
             tools_config:
               filter: "{{inputs.mode == 'plan' ? ['tag:plan', 'tag:shell'] : inputs.tools}}"
               spawn: "{{[spawn(workflow.name, inputs.spawn_presets)]}}"
-              permission: "{{inputs.mode == 'plan' ? 'readonly' : 'mutating'}}"
+              permission: mutating
 
         - id: approval
           type: approval

--- a/internal/workflow/runtime/activities/handlers/call_llm.go
+++ b/internal/workflow/runtime/activities/handlers/call_llm.go
@@ -1852,14 +1852,42 @@ func (a *CallLLMActivity) getAvailableToolsWithSpawn(ctx context.Context, chat *
 	// Expand tool filter with spawn support
 	filterResult := tools.ExpandToolFilterWithSpawn(toolFilter, mcpToolNames)
 
-	// Include dynamically loaded tools (via load_tool)
+	// Record the expansion as this scope's allow-set BEFORE anything is added to
+	// it, so the declaration is what the author wrote rather than what the agent
+	// has since accumulated. Previously this expansion was used to build one
+	// request's tool array and then discarded, which is why `tools:` could not
+	// refuse anything load_tool chose to add.
+	//
+	// The two universally-granted tools are admitted explicitly. Both are handed
+	// to every tool-enabled agent AFTER this expansion (see below), so a filter
+	// that never named them would otherwise make the agent unable to use the very
+	// tool it discovers with — load_tool would refuse its own name.
+	if chat != nil && len(filterResult.ToolNames) > 0 {
+		allowed := make([]string, 0, len(filterResult.ToolNames)+2)
+		allowed = append(allowed, filterResult.ToolNames...)
+		allowed = append(allowed, tools.ToolLoadTool, tools.ToolSpawnSend)
+		tools.GetLoadedToolsStore().SetAllowedTools(tools.Scope(chat.ID, thread), allowed)
+	}
+
+	// Include dynamically loaded tools (via load_tool). These are intersected
+	// against the declared set rather than appended past it: appending is what
+	// let a loaded tool override even an explicit `!write` exclusion. load_tool
+	// already refuses out-of-set tools, so this is the second half of the same
+	// rule — a grant recorded before the filter narrowed cannot outlive it.
 	if chat != nil {
-		loadedTools := tools.GetLoadedToolsStore().Get(tools.Scope(chat.ID, thread))
-		if len(loadedTools) > 0 {
-			filterResult.ToolNames = append(filterResult.ToolNames, loadedTools...)
+		scopeKey := tools.Scope(chat.ID, thread)
+		store := tools.GetLoadedToolsStore()
+		var admitted []string
+		for _, name := range store.Get(scopeKey) {
+			if store.IsToolAllowed(scopeKey, name) {
+				admitted = append(admitted, name)
+			}
+		}
+		if len(admitted) > 0 {
+			filterResult.ToolNames = append(filterResult.ToolNames, admitted...)
 			logDebug("[CallLLM] Including dynamically loaded tools",
 				"chatID", chat.ID,
-				"loadedTools", loadedTools)
+				"loadedTools", admitted)
 		}
 	}
 

--- a/internal/workflow/runtime/activities/handlers/execute_tools.go
+++ b/internal/workflow/runtime/activities/handlers/execute_tools.go
@@ -213,9 +213,11 @@ func (a *ExecuteToolsActivity) Execute(ctx context.Context, input ActivityInput)
 	expectedResponseTools := protoArgs.GetExpectedResponseTools()
 	responseToolSchemas := protoStructMapToGoMap(protoArgs.GetResponseToolSchemas())
 
-	// Resolve the permission level for tool execution enforcement.
-	// This was set by call_llm when it resolved tools for the LLM request.
-	grantedPermission := tools.GetLoadedToolsStore().GetPermission(tools.Scope(rtx.ChatID, rtx.Thread))
+	// Resolve the permission level and the declared tool set for execution-time
+	// enforcement. Both were set by call_llm when it resolved tools for the LLM
+	// request; a tool must pass both to run.
+	scopeKey := tools.Scope(rtx.ChatID, rtx.Thread)
+	grantedPermission := tools.GetLoadedToolsStore().GetPermission(scopeKey)
 
 	// Build set for O(1) response tool lookups in worker goroutines
 	responseToolSet := make(map[string]bool, len(expectedResponseTools))
@@ -301,6 +303,24 @@ func (a *ExecuteToolsActivity) Execute(ctx context.Context, input ActivityInput)
 							result: message.ToolResult{
 								ToolCallID: toolCallID,
 								Content:    "incomplete tool call: missing name or id",
+								IsError:    true,
+							},
+						}
+						return
+					}
+
+					// Enforce the workflow's declared tool set at EXECUTION, not
+					// only when the request was built. The model can name a tool
+					// that was never offered — a stale name from earlier history,
+					// or an outright hallucination — and without this the call
+					// would run purely because the ladder allowed its tier.
+					if !tools.GetLoadedToolsStore().IsToolAllowed(scopeKey, toolName) {
+						resultsChan <- toolCallResult{
+							index: job.index,
+							result: message.ToolResult{
+								ToolCallID: toolCallID,
+								Name:       toolName,
+								Content:    fmt.Sprintf("Tool '%s' is not in this workflow's declared tool set.", toolName),
 								IsError:    true,
 							},
 						}

--- a/internal/workflow/runtime/activities/handlers/execute_tools_validation_test.go
+++ b/internal/workflow/runtime/activities/handlers/execute_tools_validation_test.go
@@ -16,10 +16,11 @@ import (
 // TOOL PERMISSION ENFORCEMENT TESTS
 // ============================================================================
 
-// TestExecuteToolsActivity_PermissionEnforcement tests that tool calls are validated
-// against the permission level set by call_llm via LoadedToolsStore.
+// TestExecuteToolsActivity_PermissionEnforcement tests that tool calls are
+// validated at execution against BOTH the declared tool set and the permission
+// level set by call_llm via LoadedToolsStore.
 func TestExecuteToolsActivity_PermissionEnforcement(t *testing.T) {
-	t.Run("Mutating tool denied with readonly permission", func(t *testing.T) {
+	t.Run("Tool outside the declared set is denied", func(t *testing.T) {
 		h := NewIdempotencyTestHelper(t)
 		defer h.Cleanup()
 
@@ -32,17 +33,18 @@ func TestExecuteToolsActivity_PermissionEnforcement(t *testing.T) {
 		h.CreateTestProject(ctx, projectID, userID)
 		h.CreateTestChat(ctx, chatID, projectID, userID)
 
-		// Set readonly permission (simulates plan mode)
-		tools.GetLoadedToolsStore().SetPermission(tools.Scope(chatID, "0"), tools.PermissionReadOnly)
+		// Plan mode is expressed as a DECLARED TOOL SET, not a permission tier.
+		// The readonly tier used to carry this and never actually prevented a
+		// write — the shell was granted at that tier too. The filter does, and
+		// is enforced here at execution.
+		tools.GetLoadedToolsStore().SetPermission(tools.Scope(chatID, "0"), tools.PermissionMutating)
+		tools.GetLoadedToolsStore().SetAllowedTools(tools.Scope(chatID, "0"),
+			[]string{tools.ToolView, tools.ShellToolName})
 		defer tools.GetLoadedToolsStore().Clear(tools.Scope(chatID, "0"))
 
 		mockExecutor := newMockToolExecutor()
 		activity := NewExecuteToolsActivity(h.Repo(), mockExecutor)
 
-		// write requires mutating permission. The shell family does NOT: it
-		// is readonly-tier by decision (internal/llm/tools/permissions.go),
-		// since the shell is the only way to search once the scoped search
-		// tools were removed.
 		input := ExecuteToolsInput{
 			ChatID: chatID,
 			Thread: "0",
@@ -61,14 +63,13 @@ func TestExecuteToolsActivity_PermissionEnforcement(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, output.ToolResults, 1)
 		assert.True(t, output.ToolResults[0].IsError)
-		assert.Contains(t, output.ToolResults[0].Content, "permission")
-		assert.Contains(t, output.ToolResults[0].Content, "readonly")
+		assert.Contains(t, output.ToolResults[0].Content, "declared tool set")
 
 		// Tool should NOT have been executed
 		assert.Equal(t, 0, mockExecutor.GetExecutionCount("call_write"))
 	})
 
-	t.Run("Read-only tool allowed with readonly permission", func(t *testing.T) {
+	t.Run("Tool inside the declared set runs", func(t *testing.T) {
 		h := NewIdempotencyTestHelper(t)
 		defer h.Cleanup()
 
@@ -81,14 +82,17 @@ func TestExecuteToolsActivity_PermissionEnforcement(t *testing.T) {
 		h.CreateTestProject(ctx, projectID, userID)
 		h.CreateTestChat(ctx, chatID, projectID, userID)
 
-		// Set readonly permission
-		tools.GetLoadedToolsStore().SetPermission(tools.Scope(chatID, "0"), tools.PermissionReadOnly)
+		// A tool inside the declared set runs normally, so the guard above is
+		// not just refusing everything.
+		tools.GetLoadedToolsStore().SetPermission(tools.Scope(chatID, "0"), tools.PermissionMutating)
+		tools.GetLoadedToolsStore().SetAllowedTools(tools.Scope(chatID, "0"),
+			[]string{tools.ToolView, tools.ShellToolName})
 		defer tools.GetLoadedToolsStore().Clear(tools.Scope(chatID, "0"))
 
 		mockExecutor := newMockToolExecutor()
 		activity := NewExecuteToolsActivity(h.Repo(), mockExecutor)
 
-		// view is a read-only tool
+		// view is inside the declared set
 		input := ExecuteToolsInput{
 			ChatID: chatID,
 			Thread: "0",
@@ -151,10 +155,11 @@ func TestExecuteToolsActivity_PermissionEnforcement(t *testing.T) {
 	})
 
 	// An unset scope is the worker-restart case: the in-memory store was emptied
-	// while the run was in flight. It must fail CLOSED — a readonly-tier tool
-	// still runs, a mutating one does not — rather than granting orchestrator
-	// precisely because the grant was lost.
-	t.Run("Unset permission falls back to readonly and still allows a readonly tool", func(t *testing.T) {
+	// while the run was in flight. It must fail CLOSED — falling back to the
+	// lowest live tier rather than granting orchestrator precisely because the
+	// grant was lost. An undeclared scope still allows ordinary tools, so a live
+	// run is not stranded.
+	t.Run("Unset permission falls back to the base tier and still runs ordinary tools", func(t *testing.T) {
 		h := NewIdempotencyTestHelper(t)
 		defer h.Cleanup()
 
@@ -196,7 +201,12 @@ func TestExecuteToolsActivity_PermissionEnforcement(t *testing.T) {
 
 	// The other half of the same case, and the one the old orchestrator default
 	// got wrong: losing the grant must not widen it.
-	t.Run("Unset permission denies a mutating tool", func(t *testing.T) {
+	//
+	// spawn is what this can be shown with now. With the readonly tier removed,
+	// the base tier IS mutating, so there is no longer a "mutating tool" an
+	// ungranted scope can be denied — the fail-closed default withholds exactly
+	// one capability, and that is the one worth pinning.
+	t.Run("Unset permission denies spawn", func(t *testing.T) {
 		h := NewIdempotencyTestHelper(t)
 		defer h.Cleanup()
 
@@ -220,9 +230,9 @@ func TestExecuteToolsActivity_PermissionEnforcement(t *testing.T) {
 			Thread: "0",
 			ToolCalls: []ToolCall{
 				{
-					ID:    "call_write",
-					Name:  "write",
-					Input: `{"file_path": "/tmp/x", "content": "y"}`,
+					ID:    "call_spawn",
+					Name:  "spawn",
+					Input: `{"preset": "general", "prompt": "x"}`,
 				},
 			},
 		}
@@ -233,8 +243,8 @@ func TestExecuteToolsActivity_PermissionEnforcement(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, output.ToolResults, 1)
 		assert.True(t, output.ToolResults[0].IsError,
-			"a mutating tool must be denied when the scope carries no granted permission")
-		assert.Equal(t, 0, mockExecutor.GetExecutionCount("call_write"),
+			"spawn must be denied when the scope carries no granted permission")
+		assert.Equal(t, 0, mockExecutor.GetExecutionCount("call_spawn"),
 			"a denied tool must never reach the executor")
 	})
 }
@@ -425,13 +435,15 @@ func TestExecuteToolsActivity_MixedPermissions(t *testing.T) {
 		h.CreateTestProject(ctx, projectID, userID)
 		h.CreateTestChat(ctx, chatID, projectID, userID)
 
-		// Set readonly — view and bash are allowed, write is denied. bash is
-		// readonly-tier by decision (internal/llm/tools/permissions.go): with
-		// the scoped search tools gone the shell is the only way to search, so
-		// gating it at mutating would leave a readonly agent unable to look
-		// around. It can still redirect into a file, which is why a hard
-		// boundary has to live below the tool layer.
-		tools.GetLoadedToolsStore().SetPermission(tools.Scope(chatID, "0"), tools.PermissionReadOnly)
+		// A declared set of view + bash: both run, write is refused. bash is in
+		// the set because with the scoped search tools gone the shell is the
+		// only way to search, so a planning agent needs it. It can still
+		// redirect into a file — which is exactly why this is authorial intent
+		// and not a security boundary; a hard boundary lives below the tool
+		// layer.
+		tools.GetLoadedToolsStore().SetPermission(tools.Scope(chatID, "0"), tools.PermissionMutating)
+		tools.GetLoadedToolsStore().SetAllowedTools(tools.Scope(chatID, "0"),
+			[]string{tools.ToolView, "bash"})
 		defer tools.GetLoadedToolsStore().Clear(tools.Scope(chatID, "0"))
 
 		mockExecutor := newMockToolExecutor()
@@ -476,7 +488,7 @@ func TestExecuteToolsActivity_MixedPermissions(t *testing.T) {
 
 		// Mutating tool should be denied
 		assert.True(t, resultMap["call_write"].IsError)
-		assert.Contains(t, resultMap["call_write"].Content, "permission")
+		assert.Contains(t, resultMap["call_write"].Content, "declared tool set")
 
 		// Verify execution counts
 		assert.Equal(t, 1, mockExecutor.GetExecutionCount("call_view"))

--- a/internal/workflow/runtime/workflow.go
+++ b/internal/workflow/runtime/workflow.go
@@ -2627,13 +2627,22 @@ func resolveParentPermission(workflowInputs map[string]interface{}) string {
 		return pp
 	}
 
-	// Derive from mode: plan mode = readonly, otherwise mutating
-	// These match the permission constants in internal/llm/tools/permissions.go
+	// Every live mode maps to the same tier. Plan mode used to derive "readonly",
+	// which promised more than it delivered — the shell was granted at that tier
+	// too, so a plan-mode agent could always write. What keeps write out of a
+	// planning agent's hands is its `tools:` filter (['tag:plan', 'tag:shell']),
+	// which is enforced; see LoadedToolsStore.IsToolAllowed.
+	//
+	// The mode switch is kept rather than collapsed to a constant because an
+	// unrecognized mode must still return "" — "don't constrain" is a different
+	// answer from "constrain to the base tier", and a spawned child of an unknown
+	// mode should inherit no cap rather than a guessed one.
+	// The literal matches tools.PermissionMutating, spelled out because
+	// internal/llm/tools imports this package (workflow_discovery.go) and the
+	// dependency cannot run the other way.
 	mode := getModeFromInputs(workflowInputs)
 	switch mode {
-	case "plan":
-		return "readonly"
-	case "manual", "auto":
+	case "plan", "manual", "auto":
 		return "mutating"
 	default:
 		return "" // Unknown mode, don't constrain

--- a/internal/workflow/runtime/workflow.go
+++ b/internal/workflow/runtime/workflow.go
@@ -2594,6 +2594,23 @@ func buildSpawnChildInputs(workflowInputs map[string]interface{}) map[string]int
 		childInputs["parent_permission"] = parentPerm
 	}
 
+	// The parent's DECLARED TOOL SET is deliberately not propagated, unlike its
+	// permission. The two constrain different things and only one of them
+	// composes.
+	//
+	// A permission cap composes because it is a tier: a child at or below its
+	// parent's tier is always meaningful. A tool set does not — an orchestrator's
+	// filter describes the orchestrator's own job, not its children's. The
+	// builtin `code_reviewer` preset is the worked example: it holds a narrow
+	// filter (view, code_context, shell, web) and spawns `researcher`, whose work
+	// needs a different set entirely. Intersecting parent into child would leave
+	// every spawned unit with the orchestrator's tools, which is precisely what
+	// presets exist to avoid.
+	//
+	// A child's set comes from its own preset, and is enforced against that set
+	// by the same rules as any other agent. The permission cap remains the
+	// constraint that crosses the boundary.
+
 	return childInputs
 }
 

--- a/internal/workflow/yaml/parser_test.go
+++ b/internal/workflow/yaml/parser_test.go
@@ -406,6 +406,9 @@ nodes:
         filter: [view, edit]
         permission: readonly
 `
+	// `readonly` is the RETIRED permission tier, deliberately left in this
+	// fixture: stored workflows still carry it, so parsing must keep accepting
+	// it. tools.NormalizePermission maps it onto a live tier at use.
 	wf, err := ParseWorkflow([]byte(yaml))
 	if err != nil {
 		t.Fatalf("parse: %v", err)


### PR DESCRIPTION
> Stacked on #250, #251 and #252 — those commits appear in this diff. **#252 is a hard prerequisite**, not just ordering: it makes `tools:` enforceable, and this PR removes the tier that was nominally doing that job. Landing this without it would silently promote plan mode to `mutating` **with `write`/`edit` handed to it**.

## What

Removes the `readonly` permission tier. Two tiers remain: `mutating` (default) and `orchestrator`.

## Why

`readonly` promised something the mechanism never delivered. It sat below `mutating` and differed by withholding exactly four tools — `write`, `edit`, `find_replace`, `move_code` — each with a one-line shell equivalent (`cat > f`, `sed -i`, `mv`), **while still handing over the full shell family**. It had to: the shell is the only search path since the scoped grep/glob tools were removed, so a tier without it cannot search at all.

The source already admitted this, in `permissions.go`:

> readonly "no longer means the agent cannot write; it means the agent is not HANDED write tools, while retaining a shell that can still `>` a file."

A name that reads as a guarantee and isn't one is worse than no tier, because callers reasonably plan around it. Background and prior art in `research/PERMISSIONS_REDESIGN.md` — notably that **nobody in the industry achieves read-only through tool selection**; Codex's read-only sandbox still hands over a full shell and writes fail at the syscall.

## What replaces it

Nothing, deliberately — the intent moves to a mechanism that enforces it. "This agent should not be handed write tools" is now said by the workflow's `tools:` filter, which #252 made authoritative at both load and execute.

Tag-based classification in `MinimumPermissionForTool` goes too: it existed only to separate `mutating` from `readonly`, and a table that always returns the same answer reads as a gate while gating nothing. The surviving distinction is **spawn**.

## Plan mode: the one real consumer

`agent.yaml` derived `permission: readonly` from `mode == 'plan'`. It now declares `permission: mutating` and relies on its filter `['tag:plan', 'tag:shell']`, which genuinely prevents acquiring `write`. `TestLoadTool_PlanModeCannotLoadWrite` pins that it holds at mutating permission, while the shell still resolves — plan mode's only search path.

This is strictly stronger than before: the old tier let a plan-mode agent write via bash *and* told you it couldn't.

## Backward compatibility

Stored workflows, presets and in-flight Temporal histories still carry `readonly`.

- `NormalizePermission` maps it forward to `mutating` — an honest description of what that tier always was.
- `PermissionAtLeast` deliberately does **not** recognize it, so an unnormalized legacy value fails closed rather than being silently promoted.
- The YAML parser fixture declaring `permission: readonly` is kept on purpose, with a comment, to prove legacy workflows still parse.
- `TestRetiredReadOnlyWorkflowStillClearsItsGates` asserts a normalized legacy workflow can still run `view`/`shell`/`write`/`edit`, and still cannot spawn.

## One honest regression

The fail-closed default for an unknown scope (the worker-restart case from #251) moves from `readonly` to `mutating`, so it now withholds only `spawn`. That is a real reduction in what it protects — and the accurate framing is that **the old default never withheld `write` either**, since the shell was granted at that tier.

## Tests

`permissions_test.go` is rewritten around the two-tier contract plus normalization. Three tests that existed only to verify readonly gating are deleted rather than rewritten — the filter tests in #252 cover that ground more strongly. Tests using `readonly` as a generic "low tier" are retargeted to `spawn`, the capability the ladder still gates.

Every package I touched passes: `internal/llm/tools`, all of `internal/workflow/runtime/...`, `internal/toolexec/...`, `internal/workflow/builtin`, `internal/workflow/yaml`.

**Note on the full suite.** `go test ./...` intermittently fails one test under parallel load against the shared Postgres. I verified this is pre-existing and not from this change: a clean `main` clone failed twice in a row the same way (on a *different* test, `TestCallLLM_StalledProgressFailsForRetry`), while this branch failed on `TestConcurrentUserUpdatesDoNotSerializationConflict`. Both pass consistently in isolation and at package scope. There were 8 concurrent `go test` processes from other agents on this box at the time. Worth a separate look; not a blocker here.
