### PR TITLE
fix(terminal,daemon): close the real PTY, and stop calling a 3.5-minute provision a failure

### DIFF
--- a/internal/grpc/services/terminal_ws.go
+++ b/internal/grpc/services/terminal_ws.go
@@ -28,10 +28,17 @@ var wsUpgrader = websocket.Upgrader{
 }
 
 // wsMessage is the JSON envelope sent from server to browser.
+//
+// SessionID is the DAEMON's session id, and the browser needs it to close the
+// session later. The browser mints its own local id first (it needs a React key
+// before the socket exists), so without this field it had no way to learn the
+// real one — and CloseSession was called with the local id, which the daemon
+// has never heard of. That failed every close and leaked the PTY.
 type wsMessage struct {
-	Type string `json:"type"`
-	Data string `json:"data,omitempty"`
-	PID  int32  `json:"pid,omitempty"`
+	Type      string `json:"type"`
+	Data      string `json:"data,omitempty"`
+	PID       int32  `json:"pid,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
 }
 
 // wsResizeMessage is the JSON message the browser sends for resize events.
@@ -122,8 +129,9 @@ func TerminalWSHandler(router toolexec.DaemonRouter, validator auth.TokenValidat
 			"working_dir", workingDir,
 		)
 
-		// Send init message to browser.
-		writeWSJSON(conn, wsMessage{Type: "init", PID: createResp.PID})
+		// Send init message to browser, carrying the daemon's session id so the
+		// browser can address this session on close. See wsMessage.SessionID.
+		writeWSJSON(conn, wsMessage{Type: "init", PID: createResp.PID, SessionID: sessionID})
 
 		// --- Subscribe to terminal output ---
 		outputCh, unsub, err := router.SubscribeTerminalOutput(ctx, userID, sessionID)

--- a/internal/toolexec/daemon_router_nats.go
+++ b/internal/toolexec/daemon_router_nats.go
@@ -306,6 +306,20 @@ func (r *NATSDaemonRouter) resolveViaControlPlane(ctx context.Context, userID st
 		if resp.Msg.Daemon != nil && resp.Msg.Daemon.DaemonId != "" {
 			return "", true, fmt.Errorf("control plane found a daemon record but it is not yet routable")
 		}
+		// Found=false with a nil Daemon is ambiguous, and resolving it the wrong
+		// way is what told a user mid-provision "no machine is connected to your
+		// account yet". A machine that is still coming up is not yet routable, so
+		// ResolveDaemon reports Found=false and returns no daemon — identical on
+		// the wire to a user who has never provisioned one.
+		//
+		// The DB fallback (step 3) is what can actually tell these apart: it
+		// lists the user's daemon rows directly and sets sawDaemonRecord from
+		// them. So do NOT claim "no record" here — claiming it is a positive
+		// assertion this call cannot support, and it would be believed even
+		// though the caller ORs our answer with the DB's. Returning false is
+		// safe only because the OR lets a later step correct it; saying so
+		// explicitly keeps the next reader from "simplifying" this into an
+		// early return.
 		return "", false, fmt.Errorf("control plane found no matching daemon")
 	}
 

--- a/web/src/components/OnboardingFlow/DaemonConnectingGate.tsx
+++ b/web/src/components/OnboardingFlow/DaemonConnectingGate.tsx
@@ -41,13 +41,32 @@ import {
 } from "@/services/controlPlane/daemon";
 
 /**
- * 60 seconds at 2-second intervals is enough to catch the median provisioning
- * window for a cloud daemon (image pull + NATS handshake) without keeping the
- * user staring at a spinner indefinitely. After the window we fail fast and
- * give the user real CTAs (Retry / View logs / Skip).
+ * How long to keep waiting before offering the failure CTAs.
+ *
+ * This was 60s, chosen as "the median provisioning window". Measured against
+ * prod it is not: a cold start on the kata daemon cluster is ~3.5 minutes, and
+ * the breakdown is mostly not ours to shorten.
+ *
+ *   ~2m00s  GCE boots an n2-standard-8, because the kata node pools scale to
+ *           zero, so the common case pays a full VM boot
+ *     ~50s  scheduler binds the pod once the node registers
+ *     ~20s  kata-deploy has not yet written the containerd handler, so the
+ *           first sandbox create on a fresh node fails and is retried
+ *      ~7s  image pull (1.46 GB, served from the preloaded secondary boot disk)
+ *
+ * At 60s we declared failure roughly a third of the way through a provision
+ * that was working, and the user read "no machine is connected to your account
+ * yet" while their machine was still two minutes from ready.
+ *
+ * 5 minutes covers the measured cold start with headroom. This is deliberately
+ * NOT the point at which we go quiet: classifyDaemonWait escalates the copy at
+ * DAEMON_WAIT_SLOW_MS (20s) and again at DAEMON_WAIT_STUCK_MS (60s), where it
+ * surfaces Retry and "check on it" while still telling the truth — that the
+ * machine is expected to connect on its own. The timeout is only the point
+ * where we stop claiming it will.
  */
 export const POLL_INTERVAL_MS = 2_000;
-export const POLL_TIMEOUT_MS = 60_000;
+export const POLL_TIMEOUT_MS = 300_000;
 
 const FAILED_FALLBACK_MESSAGE =
   "We couldn't reach your machine. This is usually a network or configuration problem.";

--- a/web/src/components/Terminal/Terminal.tsx
+++ b/web/src/components/Terminal/Terminal.tsx
@@ -61,6 +61,7 @@ export function Terminal({ sessionId, workingDir, worktreeId, className }: Termi
   const daemonUnavailableRef = useRef(false);
   const connectWebSocketRef = useRef<(() => Promise<(() => void) | undefined>) | null>(null);
   const updateSessionPID = useTerminalStore((state) => state.updateSessionPID);
+  const setDaemonSessionId = useTerminalStore((state) => state.setDaemonSessionId);
   const activeSessionId = useTerminalStore((state) => state.activeSessionId);
 
   const updateConnectionState = useCallback((next: TerminalConnectionState) => {
@@ -347,6 +348,11 @@ export function Terminal({ sessionId, workingDir, worktreeId, className }: Termi
                 updateSessionPID(sessionId, data.pid);
                 logger.info("[Terminal] Received PID", { sessionId, pid: data.pid });
               }
+              // Bind the daemon's session id. Until this lands the store only
+              // knows the local id, which cannot close the PTY.
+              if (typeof data.session_id === "string" && data.session_id) {
+                setDaemonSessionId(sessionId, data.session_id);
+              }
             } else if (data.type === "output") {
               term.write(data.data);
             } else if (data.type === "error") {
@@ -505,7 +511,7 @@ export function Terminal({ sessionId, workingDir, worktreeId, className }: Termi
 
       term.dispose();
     };
-  }, [sessionId, workingDir, worktreeId, updateSessionPID, updateConnectionState]); // updateConnectionState is a stable setter
+  }, [sessionId, workingDir, worktreeId, updateSessionPID, setDaemonSessionId, updateConnectionState]); // updateConnectionState is a stable setter
 
   // Listen for theme changes and update terminal colors
   useEffect(() => {

--- a/web/src/store/__tests__/terminalStore.daemonSessionId.test.ts
+++ b/web/src/store/__tests__/terminalStore.daemonSessionId.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Closing a terminal must address the DAEMON's session id, not the local one.
+ *
+ * The store mints `terminal-<ts>-<rand>` when a tab is created, because React
+ * needs a key before any socket exists. The daemon mints its own UUID when it
+ * actually forks the PTY. Those are different namespaces, and only the second
+ * one can close anything.
+ *
+ * Sending the local id — which is what this code used to do — produced
+ * `CloseSession ... session not found: terminal-1789117900104-d1qzvmsih` in
+ * prod on every single terminal close. The failure was swallowed as a
+ * `logger.warn`, so the UI looked correct while the shell process kept running
+ * inside the user's workspace until the pod died. That is the leak these tests
+ * exist to prevent, and it is invisible from the frontend alone — which is why
+ * the assertion is on the ARGUMENT, not on the call count.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const closeSession = vi.fn(() => Promise.resolve({ success: true, message: "" }));
+
+vi.mock("../../api/terminal-grpc", () => ({
+  terminalApi: {
+    closeSession: (id: string) => closeSession(id),
+  },
+}));
+
+vi.mock("../../lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../workspaceStateStore", () => ({
+  useWorkspaceStateStore: { getState: () => ({}) },
+}));
+
+import { useTerminalStore } from "../terminalStore";
+
+function reset() {
+  useTerminalStore.setState({
+    sessions: [],
+    activeSessionId: null,
+    activeSessionPerWorktree: {},
+  });
+  closeSession.mockClear();
+}
+
+describe("terminal close uses the daemon session id", () => {
+  beforeEach(reset);
+
+  it("sends the daemon id, never the local id", () => {
+    const localId = useTerminalStore.getState().createSession("/home/workspace");
+    const daemonId = "83328599-641e-4a39-aec5-9a5822ff72fa";
+
+    useTerminalStore.getState().setDaemonSessionId(localId, daemonId);
+    useTerminalStore.getState().killSession(localId);
+
+    expect(closeSession).toHaveBeenCalledWith(daemonId);
+    // The precise regression: the local id must never reach the wire.
+    expect(closeSession).not.toHaveBeenCalledWith(localId);
+  });
+
+  it("does not call the server when no daemon session was ever created", () => {
+    // "init" never arrived — the socket failed, or the daemon was offline. No
+    // PTY exists, so there is nothing to close. Calling CloseSession here with
+    // the local id is exactly what generated the prod error noise.
+    const localId = useTerminalStore.getState().createSession("/home/workspace");
+
+    useTerminalStore.getState().killSession(localId);
+
+    expect(closeSession).not.toHaveBeenCalled();
+  });
+
+  it("still removes the tab locally when the server close fails", () => {
+    // The close is fire-and-forget on purpose: a session can legitimately be
+    // gone already (user typed `exit`, daemon restarted). A rejected close must
+    // not strand the tab in the UI.
+    closeSession.mockImplementationOnce(() => Promise.reject(new Error("boom")));
+
+    const localId = useTerminalStore.getState().createSession("/home/workspace");
+    useTerminalStore.getState().setDaemonSessionId(localId, "some-uuid");
+    useTerminalStore.getState().killSession(localId);
+
+    expect(
+      useTerminalStore.getState().sessions.find((s) => s.id === localId),
+    ).toBeUndefined();
+  });
+
+  it("keeps the local id as the store key", () => {
+    // The daemon id is for addressing the PTY; the local id remains the
+    // identity the React tree and activeSessionId use. Conflating them would
+    // break every consumer that holds a session id across the socket lifecycle.
+    const localId = useTerminalStore.getState().createSession("/home/workspace");
+    useTerminalStore.getState().setDaemonSessionId(localId, "a-uuid");
+
+    const session = useTerminalStore.getState().sessions.find((s) => s.id === localId);
+    expect(session?.id).toBe(localId);
+    expect(session?.daemonSessionId).toBe("a-uuid");
+    expect(useTerminalStore.getState().activeSessionId).toBe(localId);
+  });
+});

--- a/web/src/store/terminalStore.ts
+++ b/web/src/store/terminalStore.ts
@@ -13,6 +13,19 @@ export interface TerminalSession {
   createdAt: Date;
   isActive: boolean;
   pid?: number;
+  /**
+   * The DAEMON's session id, learned from the server's "init" message.
+   *
+   * `id` above is minted locally before any socket exists, because the React
+   * tree needs a stable key immediately. It is meaningless to the daemon. Only
+   * this id can address the real PTY, so it is what CloseSession must send —
+   * passing `id` made every close fail with "session not found" and left the
+   * shell process running in the workspace.
+   *
+   * Undefined until "init" arrives, and undefined forever for a session whose
+   * socket never connected. Closing one of those is correctly a no-op.
+   */
+  daemonSessionId?: string;
 }
 
 interface TerminalState {
@@ -32,6 +45,8 @@ interface TerminalState {
   getWorktreeSessions: (worktreeId?: string) => TerminalSession[];
   updateSessionTitle: (id: string, title: string) => void;
   updateSessionPID: (id: string, pid: number) => void;
+  /** Bind the daemon's session id once "init" arrives. See TerminalSession.daemonSessionId. */
+  setDaemonSessionId: (id: string, daemonSessionId: string) => void;
   toggleTerminal: () => void; // Show/hide the terminal panel
   showTerminal: () => void; // Expand/show the terminal panel
   hideTerminal: () => void; // Collapse/hide the terminal panel
@@ -82,12 +97,23 @@ export const useTerminalStore = create(
   },
 
   killSession: (id: string) => {
-    // Phase 12: Close the session on the server via gRPC
-    // Fire-and-forget - we update UI immediately for responsiveness
-    terminalApi.closeSession(id).catch((error) => {
-      // Log but don't block - session might have already been closed server-side
-      logger.warn("[TerminalStore] Failed to close session on server (may already be closed)", { id, error });
-    });
+    // Close on the server with the DAEMON's id, not `id` — `id` is local and
+    // the daemon has never seen it. Sending it failed every close with
+    // "session not found" and left the PTY running in the workspace until the
+    // pod died. Fire-and-forget: the UI drops the tab immediately.
+    const daemonSessionId = get().sessions.find((s) => s.id === id)?.daemonSessionId;
+    if (daemonSessionId) {
+      terminalApi.closeSession(daemonSessionId).catch((error) => {
+        // Still best-effort: the session may have exited on its own (the shell
+        // was exited, or the daemon restarted) and is genuinely gone already.
+        logger.warn("[TerminalStore] Failed to close session on server (may already be closed)", { id, daemonSessionId, error });
+      });
+    } else {
+      // No daemon id means "init" never arrived, so no PTY was ever created
+      // for this tab. There is nothing to close, and calling CloseSession with
+      // the local id is what produced the errors this replaces.
+      logger.debug("[TerminalStore] No daemon session to close", { id });
+    }
 
     set((state) => {
       const sessions = state.sessions.filter((s) => s.id !== id);
@@ -164,6 +190,15 @@ export const useTerminalStore = create(
         s.id === id ? { ...s, title } : s
       ),
     }));
+  },
+
+  setDaemonSessionId: (id: string, daemonSessionId: string) => {
+    set((state) => ({
+      sessions: state.sessions.map((s) =>
+        s.id === id ? { ...s, daemonSessionId } : s
+      ),
+    }));
+    logger.debug("[TerminalStore] Bound daemon session id", { id, daemonSessionId });
   },
 
   updateSessionPID: (id: string, pid: number) => {


### PR DESCRIPTION
Two prod defects found while tracing a workspace cold start end to end in `prod-daemon-v2`.

## 1. Terminal closes never reached the daemon, leaking a PTY every time

Observed in prod on **every** terminal close:

```
CloseSession code=internal error="daemon command \"terminal.close\" failed:
  close session: session not found: terminal-1789117900104-d1qzvmsih"
```

There are two session-id namespaces. `terminalStore` mints `terminal-<ts>-<rand>` when a tab is created, because the React tree needs a key before any socket exists. The daemon mints its own UUID when it actually forks the PTY. Only the second one can close anything — and the browser had no way to learn it, because the server's `init` message carried `type` and `pid` and nothing else.

So `killSession` posted the local id, the daemon had never heard of it, and the close failed every time. The frontend swallowed the rejection as a `logger.warn` ("may already be closed"), which is why this looked completely fine from the UI **while shell processes accumulated inside the user's workspace** until the pod died.

The fix: `wsMessage` carries `session_id`, `init` populates it, the store binds it onto the session, and `killSession` sends that instead. A tab whose `init` never arrived has no PTY at all, so it now correctly closes nothing rather than generating the error above.

## 2. A provisioning machine was reported as no machine at all

`POLL_TIMEOUT_MS = 60_000` in `DaemonConnectingGate` was chosen as "the median provisioning window". Measured against prod it is not close — a cold start on the kata daemon cluster is **~3.5 minutes**, and almost none of it is ours to shorten:

| Phase | Cost |
|---|---|
| GCE boots an n2-standard-8 (kata pools scale to zero) | ~2m 00s |
| Scheduler binds the pod once the node registers | ~50s |
| kata-deploy has not written the containerd handler yet, so the first sandbox create fails and is retried | ~20s |
| Image pull — 1.46 GB, served from the preloaded secondary boot disk | ~7s |

At 60s we declared failure roughly a third of the way into a provision that was working correctly, and the user read **"no machine is connected to your account yet"** while their machine was two minutes from ready.

Raised to 5 minutes. This is deliberately not the point where we go quiet: `classifyDaemonWait` already escalates at `DAEMON_WAIT_SLOW_MS` (20s) and again at `DAEMON_WAIT_STUCK_MS` (60s), where it surfaces Retry and "you can keep working elsewhere". The timeout is only where we stop claiming it will connect on its own.

## A comment, not a behavior change

`resolveViaControlPlane` returns `sawRecord=false` on a `Found=false` / nil-`Daemon` response, and that is load-bearing but non-obvious. A still-provisioning machine is not routable, so `ResolveDaemon` reports exactly the same thing as for a user who never provisioned one. Only the DB fallback can distinguish them, and it does — the caller ORs the two answers. The comment exists so the next reader does not "simplify" that into an early return and resurrect the misleading message.

## Verification

- `go build ./...` clean
- `internal/toolexec/...` and `internal/grpc/services/...` tests pass
- `tsc -b` clean
- **2869/2869** web tests pass (375 files)
- `npm run lint` — 0 errors
- The two behavioral terminal guards were confirmed to **fail** against the old close path and **pass** with the fix

## Not included

The remaining items from the same investigation are infrastructure rather than code, and are being handled separately: swapping the kata node pools onto the already-built `workspace-base-sbd-2629e84ce3fc` disk image, and gating pod scheduling on the kata handler actually existing so the first pod on a fresh node stops failing its sandbox.
