### PR TITLE
fix(agent): stop skill suggestions from editing the user's message

### DIFF
--- a/internal/workflow/runtime/activities/handlers/call_llm.go
+++ b/internal/workflow/runtime/activities/handlers/call_llm.go
@@ -1266,7 +1266,7 @@ func (a *CallLLMActivity) streamLLMResponse(ctx context.Context, chat *db.Chat, 
 	// Inject skill suggestions into the latest user message based on token matching.
 	// Skills come from the synced project config — no filesystem access.
 	if projectCfg != nil {
-		if n := injectSkillSuggestions(history, projectCfg.Skills, preloadedSkillNames); n > 0 {
+		if n := injectSkillSuggestions(&history, projectCfg.Skills, preloadedSkillNames); n > 0 {
 			activity.GetLogger(ctx).Debug("[CallLLM] Injected skill suggestions",
 				"chatID", chat.ID,
 				"count", n)
@@ -2791,11 +2791,22 @@ func getLatestUserMessageText(history []message.Message) string {
 // offset so the prompt cache reuses it; a catalog-dependent suffix appended to
 // it breaks that prefix on every turn, and does so hardest while the catalog is
 // still filling — which is exactly when the seed matters most.
-func injectSkillSuggestions(history []message.Message, catalog []cfgpkg.StoredSkill, preloaded []string) int {
-	if len(catalog) == 0 || len(preloaded) > 0 {
+// injectSkillSuggestions appends a reminder naming skills that match the latest
+// user request. It returns the number suggested, and 0 when it added nothing.
+//
+// The reminder is its OWN message and never edits the user's turn. Appending it
+// to the user's text made the user's words not be the user's words: the
+// transcript stopped matching what was sent, and the model saw the user asking
+// for skills they never mentioned. An engine may add to a request; it does not
+// get to rewrite the part the caller wrote.
+//
+// It takes history by pointer because it now appends rather than mutating in
+// place — a slice passed by value cannot grow for its caller.
+func injectSkillSuggestions(history *[]message.Message, catalog []cfgpkg.StoredSkill, preloaded []string) int {
+	if history == nil || len(catalog) == 0 || len(preloaded) > 0 {
 		return 0
 	}
-	latestUserText := getLatestUserMessageText(history)
+	latestUserText := getLatestUserMessageText(*history)
 	if latestUserText == "" {
 		return 0
 	}
@@ -2803,14 +2814,20 @@ func injectSkillSuggestions(history []message.Message, catalog []cfgpkg.StoredSk
 	if len(suggestions) == 0 {
 		return 0
 	}
-	injectReminderIntoLastUserMessage(history, buildSkillSuggestionReminder(suggestions))
+
+	// Positioned after the request it is about, so the model reads the guidance
+	// with the request already in view.
+	*history = append(*history, message.Message{
+		Role:  message.User,
+		Parts: []message.ContentPart{message.TextContent{Text: buildSkillSuggestionReminder(suggestions)}},
+	})
 	return len(suggestions)
 }
 
 // buildSkillSuggestionReminder formats suggested skills as a system-reminder block.
 func buildSkillSuggestionReminder(suggestions []suggest.Suggested) string {
 	var sb strings.Builder
-	sb.WriteString("\n\n<system-reminder>\nPotentially relevant skills (use the skill tool to load if needed):\n")
+	sb.WriteString("<system-reminder>\nPotentially relevant skills (use the skill tool to load if needed):\n")
 	for _, s := range suggestions {
 		desc := s.Skill.Description
 		if len(desc) > 80 {
@@ -2820,24 +2837,6 @@ func buildSkillSuggestionReminder(suggestions []suggest.Suggested) string {
 	}
 	sb.WriteString("</system-reminder>")
 	return sb.String()
-}
-
-// injectReminderIntoLastUserMessage appends a reminder string to the last user message's text content.
-func injectReminderIntoLastUserMessage(history []message.Message, reminder string) {
-	for i := len(history) - 1; i >= 0; i-- {
-		if history[i].Role != message.User {
-			continue
-		}
-		for j, part := range history[i].Parts {
-			if tc, ok := part.(message.TextContent); ok {
-				history[i].Parts[j] = message.TextContent{Text: tc.Text + reminder}
-				return
-			}
-		}
-		// No text part found, append one
-		history[i].Parts = append(history[i].Parts, message.TextContent{Text: reminder})
-		return
-	}
 }
 
 func formatStoredMemories(projectCfg *cfgpkg.Config) string {

--- a/internal/workflow/runtime/activities/handlers/call_llm_preload_skills_test.go
+++ b/internal/workflow/runtime/activities/handlers/call_llm_preload_skills_test.go
@@ -439,11 +439,13 @@ func TestSkillSuggestionsNeverContradictThePreload(t *testing.T) {
 	// The stimulus is real: with no preload signal, the suggester fires on the
 	// seed and endorses the very skills the seed says are already loaded.
 	control := forkedThread()
-	require.Positive(t, injectSkillSuggestions(control, catalog, nil),
+	require.Positive(t, injectSkillSuggestions(&control, catalog, nil),
 		"the suggester no longer fires on a preload seed, so this guard is testing nothing")
+	// The reminder is its own message now (it no longer edits the seed), so the
+	// contradiction shows up in the appended turn rather than inside the seed.
 	contradicted := 0
 	for _, name := range injected {
-		if strings.Contains(control[1].Content().Text, "- "+name+":") {
+		if strings.Contains(control[len(control)-1].Content().Text, "- "+name+":") {
 			contradicted++
 		}
 	}
@@ -455,7 +457,7 @@ func TestSkillSuggestionsNeverContradictThePreload(t *testing.T) {
 	// The fix: a call that preloaded skills makes no suggestion, and the seed is
 	// returned untouched.
 	guarded := forkedThread()
-	require.Zero(t, injectSkillSuggestions(guarded, catalog, injected),
+	require.Zero(t, injectSkillSuggestions(&guarded, catalog, injected),
 		"the harness suggested skills into a turn whose seed already told the model not to "+
 			"load them")
 	require.Equal(t, seed[0].Content().Text, guarded[1].Content().Text,
@@ -473,9 +475,9 @@ func TestSkillSuggestionsStillFireWithoutAPreload(t *testing.T) {
 		{Role: message.User, Parts: []message.ContentPart{message.TextContent{Text: "PROTO body — regenerate the proto surface"}}},
 	}
 
-	require.Positive(t, injectSkillSuggestions(history, catalog, nil),
+	require.Positive(t, injectSkillSuggestions(&history, catalog, nil),
 		"a call with no preloaded skills must still get suggestions; the guard above is a "+
 			"condition on the preload, not a removal of the feature")
-	require.Contains(t, history[0].Content().Text, "Potentially relevant skills",
-		"the reminder must land on the user message the suggester scored")
+	require.Contains(t, history[len(history)-1].Content().Text, "Potentially relevant skills",
+		"the reminder must be delivered as its own message after the scored request")
 }

--- a/internal/workflow/runtime/activities/handlers/call_llm_skill_suggestion_message_test.go
+++ b/internal/workflow/runtime/activities/handlers/call_llm_skill_suggestion_message_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2025 Reliant Labs
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/reliant-labs/reliant/internal/models/message"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSkillSuggestionsDoNotEditTheUserMessage pins the boundary this engine
+// must not cross: whatever the engine adds to a request, the user's own turn is
+// theirs.
+//
+// The suggester used to append its <system-reminder> onto the last user
+// message's text. That made the user's words not be the user's words — which is
+// a correctness problem in the IDE (the transcript no longer matches what was
+// sent) and a trust problem for an API caller, whose one certainty is what they
+// put in the request. It also meant the model saw the user asking for skills
+// they never mentioned.
+//
+// The suggestion is still delivered; it arrives as its own message.
+func TestSkillSuggestionsDoNotEditTheUserMessage(t *testing.T) {
+	catalog := preloadTestCatalog()
+
+	const userText = "PROTO body — regenerate the proto surface"
+	history := []message.Message{
+		{Role: message.User, Parts: []message.ContentPart{message.TextContent{Text: userText}}},
+	}
+
+	n := injectSkillSuggestions(&history, catalog, nil)
+	require.Positive(t, n, "precondition: this input must produce suggestions")
+
+	// Find the user's turn wherever it now sits.
+	var userTurns []message.Message
+	for _, m := range history {
+		if m.Role == message.User {
+			userTurns = append(userTurns, m)
+		}
+	}
+	require.NotEmpty(t, userTurns, "the user's turn must survive")
+
+	require.Equal(t, userText, userTurns[0].Content().Text,
+		"the user's message was modified; suggestions must be their own message")
+
+	// ...and the suggestion still reaches the model.
+	var combined strings.Builder
+	for _, m := range history {
+		combined.WriteString(m.Content().Text)
+		combined.WriteString("\n")
+	}
+	require.Contains(t, combined.String(), "Potentially relevant skills",
+		"the suggestion must still be delivered, just not inside the user's turn")
+}
+
+// TestSkillSuggestionsArriveAfterTheUserTurn keeps the reminder positioned where
+// it is useful. A suggestion about the current request has to follow it, or the
+// model reads guidance about a request it has not seen yet.
+func TestSkillSuggestionsArriveAfterTheUserTurn(t *testing.T) {
+	catalog := preloadTestCatalog()
+
+	history := []message.Message{
+		{Role: message.User, Parts: []message.ContentPart{message.TextContent{Text: "PROTO body — regenerate the proto surface"}}},
+	}
+
+	require.Positive(t, injectSkillSuggestions(&history, catalog, nil))
+
+	lastUser, reminder := -1, -1
+	for i, m := range history {
+		if m.Role == message.User && !strings.Contains(m.Content().Text, "Potentially relevant skills") {
+			lastUser = i
+		}
+		if strings.Contains(m.Content().Text, "Potentially relevant skills") {
+			reminder = i
+		}
+	}
+	require.GreaterOrEqual(t, lastUser, 0, "expected a user turn")
+	require.GreaterOrEqual(t, reminder, 0, "expected a reminder message")
+	require.Greater(t, reminder, lastUser,
+		"the reminder must follow the request it is about")
+}


### PR DESCRIPTION
## What

Skill suggestions no longer append into the user's own message. They arrive as their own message, positioned after the request they scored.

## Why

`injectSkillSuggestions` appended its `<system-reminder>` block onto the **last user message's text**. Two problems, and the first one applies today:

1. **The transcript stopped matching what was sent.** The user's words in the request were not the words the user wrote.
2. **The model saw the user asking for skills they never mentioned** — the suggestion was indistinguishable from the request, because it was inside it.

An engine may add to a request. It does not get to rewrite the caller's half of it. That is true in the IDE and it is load-bearing for an API caller, whose one certainty about a request is the part they supplied.

## Behavior change

The suggestion is still delivered and still positioned to be useful — the model reads it with the request already in view, which is what the in-message append was really buying. The only difference is that it is a separate turn.

`injectSkillSuggestions` now takes `history` by pointer, because it appends rather than mutating in place and a slice passed by value cannot grow for its caller.

`injectReminderIntoLastUserMessage` had no other caller and is removed with it, along with the reminder's leading `\n\n` — those existed only to separate it from text it was being glued onto.

## Tests

New, in `call_llm_skill_suggestion_message_test.go` — both verified failing before the change:

- `TestSkillSuggestionsDoNotEditTheUserMessage` — the user's text is byte-identical afterward, **and** the suggestion still reaches the model, so the guard cannot be satisfied by dropping the feature.
- `TestSkillSuggestionsArriveAfterTheUserTurn` — the reminder follows the request it is about.

Two existing tests are updated for the new delivery shape rather than weakened. `TestSkillSuggestionsNeverContradictThePreload` still pins that a preload seed is returned untouched; it now finds the contradiction in the appended turn instead of inside the seed.

## Verification

`go build ./...` clean. All four skill-suggestion tests pass.

**One pre-existing failure, not from this change:** `TestCallLLM_StalledProgressFailsForRetry` fails in this package. I verified it fails identically on a clean `main` clone, in isolation, three runs out of three — so it is broken on `main` today, independent of this PR. Worth its own look; flagging rather than folding a fix into an unrelated change.

## Context

This is the first step from `research/ENGINE_MODE.md`, which proposes making the engine's ~29 injection points opt-in via a `context:` declaration so an API user can get exactly what their workflow declares. **This particular fix is not gated on that design** — editing the caller's message is wrong in every mode, so it needs no flag and no decision.
