### PR TITLE
sweep: atomic message ordering, fork seq seeding, and the heartbeat ladder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/invopop/jsonschema v0.14.0
 	github.com/jackc/pgx/v5 v5.10.0
+	github.com/lib/pq v1.12.3
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/nats-io/nats-server/v2 v2.14.1
 	github.com/nats-io/nats.go v1.53.1
@@ -185,7 +186,6 @@ require (
 	github.com/klauspost/cpuid/v2 v2.4.0 // indirect
 	github.com/kubescape/go-git-url v0.0.33 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
-	github.com/lib/pq v1.12.3 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/mattn/go-runewidth v0.0.29 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect

--- a/internal/db/message_order_counters.go
+++ b/internal/db/message_order_counters.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 Reliant Labs
+package db
+
+import (
+	"context"
+	"fmt"
+)
+
+// seedSeqCounterFromForkChainSQL raises a chat's seq counter to cover the
+// history it INHERITS through a context-window fork chain.
+//
+// A branched chat displays its parent's messages but does not own those rows —
+// they keep the parent's chat_id and are resolved on read by walking the
+// window chain. So a fresh branch's own rows are empty and its counter would
+// start at 0, placing every message the user sends numerically BENEATH the
+// hundreds of inherited messages rendered above it. The reply saves and
+// streams correctly but renders at the top of the transcript, which reads as
+// "my message never arrived".
+//
+// This is the defect GetNextSeqByChat's per-save recursive walk existed to
+// prevent. Seeding at fork time buys the same guarantee for the cost of ONE
+// walk per fork instead of one per message saved forever after.
+//
+// GREATEST, never a bare assignment: the counter may already be ahead (a
+// re-fork, or a branch that has since saved its own messages), and lowering it
+// would hand out a number already in use.
+const seedSeqCounterFromForkChainSQL = `
+WITH RECURSIVE chain AS (
+    SELECT cw.id, cw.parent_context_window_id
+    FROM context_windows cw
+    WHERE cw.id = $2
+    UNION
+    SELECT parent.id, parent.parent_context_window_id
+    FROM context_windows parent
+    JOIN chain ON chain.parent_context_window_id = parent.id
+),
+high AS (
+    SELECT COALESCE(MAX(m.seq), -1) AS max_seq
+    FROM messages m
+    WHERE m.context_window_id = ANY(ARRAY(SELECT id FROM chain))
+)
+INSERT INTO message_order_counters (counter_kind, scope_id, last_assigned)
+SELECT 'seq', $1, high.max_seq
+FROM high
+WHERE high.max_seq >= 0
+ON CONFLICT (counter_kind, scope_id) DO UPDATE
+SET last_assigned = GREATEST(
+        message_order_counters.last_assigned,
+        EXCLUDED.last_assigned
+    )
+`
+
+// SeedSeqCounterForFork raises chatID's seq allocator to cover everything
+// reachable through forkAtContextWindowID's chain.
+//
+// Called when a thread is forked. Safe to call repeatedly: the GREATEST keeps
+// it monotonic, so a retry or a duplicate fork cannot move the counter
+// backwards.
+func (r *Repo) SeedSeqCounterForFork(ctx context.Context, chatID, forkAtContextWindowID string) error {
+	if chatID == "" {
+		return fmt.Errorf("chat ID is required")
+	}
+	if forkAtContextWindowID == "" {
+		return fmt.Errorf("fork context window ID is required")
+	}
+
+	if _, err := r.DB.DB(ctx).ExecContext(ctx, seedSeqCounterFromForkChainSQL, chatID, forkAtContextWindowID); err != nil {
+		return fmt.Errorf("failed to seed seq counter for fork: %w", err)
+	}
+	return nil
+}

--- a/internal/db/migrations/postgres/20260901000000_message_order_counters.sql
+++ b/internal/db/migrations/postgres/20260901000000_message_order_counters.sql
@@ -1,0 +1,108 @@
+-- +goose Up
+-- Allocate messages.ordinal and messages.seq from transactional counters
+-- instead of scanning MAX() at write time.
+--
+-- What this replaces, and why the scans had to go:
+--
+--   GetNextOrdinalByThread:  SELECT MAX(ordinal)+1 FROM messages WHERE thread_id = ?
+--   GetNextSeqByChat:        a WITH RECURSIVE walk of the whole context-window
+--                            fork chain, plus two MAX(seq) lookups.
+--
+-- Both ran inside SaveMessage's SERIALIZABLE transaction, on EVERY message
+-- save. Two problems, one fatal:
+--
+--  1. A MAX() read followed by an INSERT into the range just read is the
+--     textbook SSI anti-pattern. The read takes a predicate lock over a range
+--     another writer is about to insert into, so concurrent savers of the same
+--     chat abort each other with 40001 "could not serialize access due to
+--     read/write dependencies among transactions". Observed in production logs
+--     44 times in a single session; 8 of those exhausted all 7 attempts and
+--     surfaced to the user as a red error in the transcript.
+--
+--  2. The recursive CTE re-derived the fork chain on every save, even though a
+--     fork chain changes exactly ONCE — when the fork is created. That is the
+--     most expensive statement in the transaction, and it was paid per message
+--     while holding serializable locks, widening the window in which any other
+--     writer could collide.
+--
+-- A counter row turns both into an O(1) upsert. The row lock still serializes
+-- allocation (that is the point: it is what keeps the numbering gap-free and
+-- keeps sequence order consistent with commit order), but it is now held for
+-- microseconds inside a single statement rather than across five-plus network
+-- round trips.
+--
+-- SCOPES. These mirror the allocators they replace, and the difference matters:
+--   ordinal is per-THREAD  (GetNextOrdinalByThread keyed on thread_id)
+--   seq     is per-CHAT    (chat-global total order; see
+--                           20260802000000_add_message_seq.sql)
+-- Using one table with a kind discriminator keeps the allocator generic and
+-- matches update_stream_counters, which already works this way.
+CREATE TABLE message_order_counters (
+    counter_kind text NOT NULL,
+    scope_id text NOT NULL,
+    last_assigned bigint NOT NULL,
+    CONSTRAINT message_order_counters_pkey
+        PRIMARY KEY (counter_kind, scope_id),
+    CONSTRAINT message_order_counters_kind_check
+        CHECK (counter_kind IN ('ordinal', 'seq'))
+);
+
+-- Seed ordinal counters from each thread's current high-water mark.
+INSERT INTO message_order_counters (counter_kind, scope_id, last_assigned)
+SELECT 'ordinal', thread_id, MAX(ordinal)
+FROM messages
+GROUP BY thread_id;
+
+-- Seed seq counters from each chat's own rows.
+--
+-- This half is straightforward: a chat's seq high-water mark is the max over
+-- the rows carrying its chat_id.
+INSERT INTO message_order_counters (counter_kind, scope_id, last_assigned)
+SELECT 'seq', chat_id, MAX(seq)
+FROM messages
+GROUP BY chat_id;
+
+-- Now raise each chat's seq counter to cover INHERITED history.
+--
+-- This is the subtle half, and getting it wrong is a visible product bug.
+--
+-- A branched chat DISPLAYS its parent's messages but does not OWN those rows —
+-- they keep the parent's chat_id and are resolved on read by walking the
+-- context-window chain. So the seed above, which only sees a chat's own rows,
+-- restarts a fresh branch at 0. Every message the user then sends lands
+-- numerically BENEATH the hundreds of inherited messages rendered above it:
+-- the reply is saved and streamed correctly but appears at the top of the
+-- transcript, which reads to the user as "my message never arrived".
+--
+-- That is precisely the defect GetNextSeqByChat's recursive walk existed to
+-- prevent, so the counter has to inherit the same high-water mark the walk
+-- computed. We do that walk ONCE, here, instead of on every future save.
+WITH RECURSIVE chain AS (
+    -- Each thread's own context windows, tagged with the thread's chat.
+    SELECT cw.id, cw.parent_context_window_id, t.chat_id
+    FROM context_windows cw
+    JOIN threads t ON t.id = cw.thread_id
+    UNION
+    -- Walk to parent windows, carrying the ORIGINATING chat_id down so the
+    -- inherited max is attributed to the chat that displays it.
+    SELECT parent.id, parent.parent_context_window_id, chain.chat_id
+    FROM context_windows parent
+    JOIN chain ON chain.parent_context_window_id = parent.id
+),
+inherited AS (
+    SELECT chain.chat_id, MAX(m.seq) AS max_seq
+    FROM chain
+    JOIN messages m ON m.context_window_id = chain.id
+    GROUP BY chain.chat_id
+)
+INSERT INTO message_order_counters (counter_kind, scope_id, last_assigned)
+SELECT 'seq', inherited.chat_id, inherited.max_seq
+FROM inherited
+ON CONFLICT (counter_kind, scope_id) DO UPDATE
+SET last_assigned = GREATEST(
+        message_order_counters.last_assigned,
+        EXCLUDED.last_assigned
+    );
+
+-- +goose Down
+DROP TABLE message_order_counters;

--- a/internal/db/postgres/generated/models.go
+++ b/internal/db/postgres/generated/models.go
@@ -348,6 +348,12 @@ type MessageContentBlock struct {
 	UpdatedAt        time.Time      `json:"updated_at"`
 }
 
+type MessageOrderCounter struct {
+	CounterKind  string `json:"counter_kind"`
+	ScopeID      string `json:"scope_id"`
+	LastAssigned int64  `json:"last_assigned"`
+}
+
 type Plan struct {
 	ID          string         `json:"id"`
 	Title       string         `json:"title"`

--- a/internal/db/postgres/schema.sql
+++ b/internal/db/postgres/schema.sql
@@ -553,6 +553,17 @@ CREATE TABLE public.message_content_blocks (
 );
 
 --
+-- Name: message_order_counters; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.message_order_counters (
+    counter_kind text NOT NULL,
+    scope_id text NOT NULL,
+    last_assigned bigint NOT NULL,
+    CONSTRAINT message_order_counters_kind_check CHECK ((counter_kind = ANY (ARRAY['ordinal'::text, 'seq'::text])))
+);
+
+--
 -- Name: plans; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1149,6 +1160,13 @@ ALTER TABLE ONLY public.item_defaults
 
 ALTER TABLE ONLY public.message_content_blocks
     ADD CONSTRAINT message_content_blocks_pkey PRIMARY KEY (id);
+
+--
+-- Name: message_order_counters message_order_counters_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.message_order_counters
+    ADD CONSTRAINT message_order_counters_pkey PRIMARY KEY (counter_kind, scope_id);
 
 --
 -- Name: messages messages_chat_seq_key; Type: CONSTRAINT; Schema: public; Owner: -
@@ -1839,6 +1857,12 @@ CREATE INDEX project_daemons_daemon_idx ON public.project_daemons USING btree (d
 --
 
 CREATE UNIQUE INDEX projects_user_remote_url_uniq ON public.projects USING btree (user_id, remote_url) WHERE (remote_url IS NOT NULL);
+
+--
+-- Name: settings_user_key_unique; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX settings_user_key_unique ON public.settings USING btree (user_id, key) WHERE (project_id IS NULL);
 
 --
 -- Name: agent_messages agent_messages_chat_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -

--- a/internal/db/repo.go
+++ b/internal/db/repo.go
@@ -585,6 +585,36 @@ func (r *Repo) runTxWithRetries(ctx context.Context, opts TxOptions, f func(ctx 
 	return errors.New("transaction failed after retries")
 }
 
+// RunTxNoRetry runs f in one transaction attempt and returns its error
+// verbatim, with no retry ladder.
+//
+// This exists to MEASURE contention rather than to survive it. RunTx's retries
+// convert a serialization conflict into either eventual success or a
+// "transaction failed after retries" string, both of which hide the raw
+// conflict rate — and the raw rate is the only honest way to compare two write
+// designs. A benchmark or control test that wants to know "does this shape
+// conflict at all" must not have the answer absorbed before it sees it.
+//
+// Not for production paths: a real writer wants the retries.
+func (r *Repo) RunTxNoRetry(ctx context.Context, f func(ctx context.Context) error) error {
+	if r.DB == nil {
+		return errors.New("database connection not initialized")
+	}
+	if _, ok := ctx.Value(txKey).(pgdb.DBTX); ok {
+		return f(ctx)
+	}
+
+	metrics := &txMetrics{txStartTime: time.Now()}
+	result, err := r.attemptTransaction(ctx, TxOptions{}, f, metrics)
+	if err != nil {
+		return err
+	}
+	if result.committed {
+		return nil
+	}
+	return result.err
+}
+
 // attemptTransaction tries to begin and execute a single transaction
 // Returns (result, nil) if transaction was started, (nil, err) if begin failed
 func (r *Repo) attemptTransaction(ctx context.Context, opts TxOptions, f func(ctx context.Context) error, metrics *txMetrics) (*txResult, error) {

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -396,6 +396,19 @@ type Repository interface {
 	GetLatestNonMessageUpdatesPerEntity(ctx context.Context, chatID string) ([]ChatUpdate, error)
 	CreateChatUpdate(ctx context.Context, chatID string, updateType reliantv1.ChatUpdateType, entityID string, data string) error
 
+	// SaveMessageAtomic writes a message, its content blocks and its
+	// chat_update in a single statement, allocating ordinal, seq and the
+	// update sequence from counter rows rather than MAX() scans.
+	SaveMessageAtomic(ctx context.Context, w AtomicMessageWrite) (*AtomicMessageResult, error)
+
+	// SeedSeqCounterForFork raises a chat's seq allocator to cover the
+	// history reachable through a fork's context-window chain.
+	SeedSeqCounterForFork(ctx context.Context, chatID, forkAtContextWindowID string) error
+
+	// RunTxNoRetry runs one transaction attempt with no retry ladder, so a
+	// serialization conflict surfaces verbatim instead of being absorbed.
+	RunTxNoRetry(ctx context.Context, f func(ctx context.Context) error) error
+
 	// Question methods
 	CreateQuestion(ctx context.Context, question *Question) error
 	GetQuestionByID(ctx context.Context, id string) (*Question, error)

--- a/internal/db/save_message_atomic.go
+++ b/internal/db/save_message_atomic.go
@@ -1,0 +1,388 @@
+// Copyright (c) 2025 Reliant Labs
+package db
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/lib/pq"
+	reliantv1 "github.com/reliant-labs/reliant/gen/reliant/v1"
+)
+
+// AtomicMessageWrite is everything one SaveMessage persists: the message row,
+// its content blocks, and the chat_update that announces it.
+//
+// Ordinal and Seq are deliberately ABSENT — they are allocated by the database
+// as part of the write and returned. A caller cannot supply them, which is what
+// makes the read-then-insert race structurally impossible rather than merely
+// avoided by convention.
+type AtomicMessageWrite struct {
+	MessageID       string
+	ChatID          string
+	ThreadID        string
+	ContextWindowID string
+	Role            reliantv1.MessageRole
+	DisplayStyle    *reliantv1.DisplayStyle
+	Model           *string
+	Agent           *string
+	TokenCount      *int
+	Cost            *float64
+	WorkflowID      *string
+	RunID           *string
+	NodeID          *string
+	NodePath        *string
+	ActivityID      *string
+	CreatedAt       time.Time
+
+	Blocks []MessageContentBlock
+
+	// ChatUpdateData is the chat_update payload. It is built by the caller
+	// EXCEPT for ordinal and seq, which do not exist until this statement
+	// runs; BuildChatUpdateData patches them in from the RETURNING values.
+	ChatUpdateData   func(ordinal, seq, updateSeq int64) (string, error)
+	ChatUpdateType   reliantv1.ChatUpdateType
+	ChatUpdateEntity string
+}
+
+// AtomicMessageResult reports the numbers the database assigned.
+type AtomicMessageResult struct {
+	Ordinal         int64
+	Seq             int64
+	UpdateSeq       int64
+	ChatUpdate      ChatUpdate
+	ChatUpdateBytes string
+}
+
+// saveMessageAtomicSQL writes a message, its content blocks and its
+// chat_update in ONE statement.
+//
+// # Why one statement
+//
+// This replaces a SERIALIZABLE transaction that made 5+N network round trips:
+// MAX(ordinal) scan, a WITH RECURSIVE fork-chain walk for seq, the message
+// insert, one insert PER content block in a Go loop, then the counter upsert
+// and ledger insert. Locks were held across every one of those round trips, so
+// a transaction doing microseconds of real work stayed open for seconds — and
+// the longer it was open, the wider the window for another writer on the same
+// chat to collide. Measured on one dev session: 881 SQLSTATE 40001 conflicts,
+// 35 of which exhausted all 7 retry attempts and surfaced to users as errors.
+//
+// Collapsing to a single statement means the locks are held for the duration of
+// one statement. unnest() is what removes the per-block round trips: N content
+// blocks are passed as parallel arrays and inserted in one go.
+//
+// # Why the counters
+//
+// ordinal and seq come from message_order_counters rather than MAX()+1. A
+// MAX() read followed by an INSERT into the range just read takes an SSI
+// predicate lock over that range, so concurrent savers abort each other. An
+// upsert on a single counter row takes a row lock instead: a concurrent writer
+// WAITS microseconds rather than aborting. See migration
+// 20260901000000_message_order_counters.sql.
+//
+// # Why this is safe at READ COMMITTED
+//
+// Every allocation here is an atomic upsert-returning on ONE row. At READ
+// COMMITTED a concurrent writer blocks on the row lock and then re-reads the
+// committed row (EvalPlanQual), so it observes N and takes N+1 — no lost
+// update, and no 40001. The row lock is still held until COMMIT, so sequence
+// order still cannot diverge from commit order: the client's `WHERE
+// sequence_number > cursor` resume contract is preserved exactly.
+//
+// What READ COMMITTED gives up is cross-statement stability, and this
+// transaction has exactly one statement, so "between statements" has no
+// meaning here.
+const saveMessageAtomicSQL = `
+WITH
+-- Both allocators are SELF-HEALING: they take the greater of the counter's
+-- next value and the table's actual high-water mark.
+--
+-- This is not belt-and-braces, it is required. Three production paths still
+-- insert messages directly with their own allocation — the branch repair in
+-- chat_branch.go, the orphan repair in cleanup.go, and the denial message in
+-- approval.go. A row written by any of them advances the table past the
+-- counter, and a counter that then handed out its own stale next value would
+-- collide with messages_chat_seq_key (observed: SQLSTATE 23505 under exactly
+-- this mix). Healing here means those writers stay correct without every one
+-- of them having to know the counter exists.
+--
+-- The subquery is an indexed MAX on a single chat/thread, not the recursive
+-- fork walk this replaced, and it is evaluated once per write rather than
+-- scanning a range the insert then lands in — so it does not reintroduce the
+-- SSI predicate conflict that motivated the change.
+ord AS (
+    INSERT INTO message_order_counters (counter_kind, scope_id, last_assigned)
+    VALUES ('ordinal', $1, COALESCE((SELECT MAX(ordinal) FROM messages WHERE thread_id = $1), -1) + 1)
+    ON CONFLICT (counter_kind, scope_id) DO UPDATE
+    SET last_assigned = GREATEST(
+            message_order_counters.last_assigned + 1,
+            COALESCE((SELECT MAX(ordinal) FROM messages WHERE thread_id = $1), -1) + 1
+        )
+    RETURNING last_assigned
+),
+sq AS (
+    INSERT INTO message_order_counters (counter_kind, scope_id, last_assigned)
+    VALUES ('seq', $2, COALESCE((SELECT MAX(seq) FROM messages WHERE chat_id = $2), -1) + 1)
+    ON CONFLICT (counter_kind, scope_id) DO UPDATE
+    SET last_assigned = GREATEST(
+            message_order_counters.last_assigned + 1,
+            COALESCE((SELECT MAX(seq) FROM messages WHERE chat_id = $2), -1) + 1
+        )
+    RETURNING last_assigned
+),
+upd AS (
+    INSERT INTO update_stream_counters (stream_kind, stream_id, last_assigned_seq)
+    VALUES ('chat', $2, 1)
+    ON CONFLICT (stream_kind, stream_id) DO UPDATE
+    SET last_assigned_seq = update_stream_counters.last_assigned_seq + 1
+    RETURNING last_assigned_seq
+),
+msg AS (
+    INSERT INTO messages (
+        id, chat_id, ordinal, seq, thread_id, context_window_id,
+        node_id, node_path, role, display_style, model, agent,
+        token_count, cost, workflow_id, run_id, activity_id,
+        created_at, updated_at
+    )
+    SELECT
+        $3, $2, ord.last_assigned, sq.last_assigned, $1, $4,
+        $5, $6, $7, $8, $9, $10,
+        $11, $12, $13, $14, $15,
+        $16, $16
+    FROM ord, sq
+),
+blocks AS (
+    INSERT INTO message_content_blocks (
+        id, message_id, position, block_type, content,
+        tool_name, tool_input, tool_call_id, thought_signature, is_error,
+        version, activity_id, workflow_run_id, attempt_number,
+        created_at, updated_at
+    )
+    SELECT
+        b.id, $3, b.position, b.block_type, b.content,
+        b.tool_name, b.tool_input, b.tool_call_id, b.thought_signature, b.is_error,
+        b.version, b.activity_id, b.workflow_run_id, b.attempt_number,
+        $16, $16
+    FROM unnest(
+        $17::text[], $18::bigint[], $19::int[], $20::text[],
+        $21::text[], $22::text[], $23::text[], $24::text[], $25::boolean[],
+        $26::bigint[], $27::text[], $28::text[], $29::bigint[]
+    ) AS b(
+        id, position, block_type, content,
+        tool_name, tool_input, tool_call_id, thought_signature, is_error,
+        version, activity_id, workflow_run_id, attempt_number
+    )
+)
+SELECT ord.last_assigned, sq.last_assigned, upd.last_assigned_seq
+FROM ord, sq, upd
+`
+
+// insertChatUpdateSQL writes the ledger row using the sequence already
+// allocated by saveMessageAtomicSQL.
+//
+// This is a second statement only because its JSON payload embeds the ordinal
+// and seq that the first statement allocates — the value cannot be built until
+// those numbers exist. It is a plain INSERT with no reads, so it takes no
+// predicate locks and cannot raise a serialization conflict.
+const insertChatUpdateSQL = `
+INSERT INTO chat_updates (
+    id, chat_id, sequence_number, update_type, entity_id, data, created_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
+`
+
+// SaveMessageAtomic performs the whole message write in one transaction whose
+// body is a single round trip for the durable rows.
+//
+// It runs at READ COMMITTED deliberately. See saveMessageAtomicSQL for why
+// that is safe here and what it buys: this write path is the hottest
+// SERIALIZABLE transaction in the system and was responsible for the
+// overwhelming majority of observed 40001 conflicts.
+func (r *Repo) SaveMessageAtomic(ctx context.Context, w AtomicMessageWrite) (*AtomicMessageResult, error) {
+	if w.MessageID == "" {
+		return nil, fmt.Errorf("message ID is required")
+	}
+	if w.ChatID == "" {
+		return nil, fmt.Errorf("chat ID is required")
+	}
+	if w.ThreadID == "" {
+		return nil, fmt.Errorf("thread ID is required")
+	}
+
+	cols := newBlockColumns(w.Blocks)
+
+	var result AtomicMessageResult
+	err := r.RunTxWithOptions(ctx, TxOptions{Isolation: IsolationReadCommitted}, func(txCtx context.Context) error {
+		row := r.DB.DB(txCtx).QueryRowContext(txCtx, saveMessageAtomicSQL,
+			w.ThreadID,
+			w.ChatID,
+			w.MessageID,
+			w.ContextWindowID,
+			nullString(w.NodeID),
+			nullString(w.NodePath),
+			int32(w.Role),
+			nullDisplayStyle(w.DisplayStyle),
+			nullString(w.Model),
+			nullString(w.Agent),
+			nullInt(w.TokenCount),
+			nullFloat(w.Cost),
+			nullString(w.WorkflowID),
+			nullString(w.RunID),
+			nullString(w.ActivityID),
+			w.CreatedAt,
+			cols.ids, cols.positions, cols.blockTypes, cols.contents,
+			cols.toolNames, cols.toolInputs, cols.toolCallIDs, cols.thoughtSignatures, cols.isErrors,
+			cols.versions, cols.activityIDs, cols.workflowRunIDs, cols.attemptNumbers,
+		)
+
+		if err := row.Scan(&result.Ordinal, &result.Seq, &result.UpdateSeq); err != nil {
+			return fmt.Errorf("failed to write message: %w", err)
+		}
+
+		data, err := w.ChatUpdateData(result.Ordinal, result.Seq, result.UpdateSeq)
+		if err != nil {
+			return fmt.Errorf("failed to build chat_update data: %w", err)
+		}
+
+		updateID := fmt.Sprintf("%s-%d", w.ChatID, result.UpdateSeq)
+		// UTC, not local: chat_updates.created_at drops the offset and keeps
+		// the wall clock, so a local time.Now() is stored as its local reading
+		// and read back as RFC3339 with a "Z" that lies about the instant.
+		createdAt := time.Now().UTC()
+
+		if _, err := r.DB.DB(txCtx).ExecContext(txCtx, insertChatUpdateSQL,
+			updateID, w.ChatID, result.UpdateSeq, int32(w.ChatUpdateType),
+			w.ChatUpdateEntity, data, createdAt,
+		); err != nil {
+			return fmt.Errorf("failed to create chat_update: %w", err)
+		}
+
+		result.ChatUpdate = ChatUpdate{
+			ID:             updateID,
+			ChatID:         w.ChatID,
+			SequenceNumber: result.UpdateSeq,
+			UpdateType:     w.ChatUpdateType,
+			EntityID:       w.ChatUpdateEntity,
+			Data:           json.RawMessage(data),
+			CreatedAt:      createdAt,
+		}
+		result.ChatUpdateBytes = data
+
+		// Publish only after the transaction commits. Notifying from inside
+		// would announce a sequence number a reader could not yet SELECT, and
+		// on rollback would announce one that never existed at all.
+		if r.onChatUpdate != nil {
+			committed := result.ChatUpdate
+			chatID := w.ChatID
+			if err := runAfterCommit(txCtx, func() {
+				r.onChatUpdate(chatID, committed.SequenceNumber, committed)
+			}); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// blockColumns is the column-major form of []MessageContentBlock that unnest()
+// consumes: N blocks become one array per column rather than N inserts.
+type blockColumns struct {
+	ids               pq.StringArray
+	positions         pq.Int64Array
+	blockTypes        pq.Int32Array
+	contents          pq.StringArray
+	toolNames         pq.StringArray
+	toolInputs        pq.StringArray
+	toolCallIDs       pq.StringArray
+	thoughtSignatures pq.StringArray
+	isErrors          pq.BoolArray
+	versions          pq.Int64Array
+	activityIDs       pq.StringArray
+	workflowRunIDs    pq.StringArray
+	attemptNumbers    pq.Int64Array
+}
+
+func newBlockColumns(blocks []MessageContentBlock) blockColumns {
+	n := len(blocks)
+	c := blockColumns{
+		ids:               make(pq.StringArray, n),
+		positions:         make(pq.Int64Array, n),
+		blockTypes:        make(pq.Int32Array, n),
+		contents:          make(pq.StringArray, n),
+		toolNames:         make(pq.StringArray, n),
+		toolInputs:        make(pq.StringArray, n),
+		toolCallIDs:       make(pq.StringArray, n),
+		thoughtSignatures: make(pq.StringArray, n),
+		isErrors:          make(pq.BoolArray, n),
+		versions:          make(pq.Int64Array, n),
+		activityIDs:       make(pq.StringArray, n),
+		workflowRunIDs:    make(pq.StringArray, n),
+		attemptNumbers:    make(pq.Int64Array, n),
+	}
+	for i, b := range blocks {
+		c.ids[i] = b.ID
+		c.positions[i] = int64(b.Position)
+		c.blockTypes[i] = int32(b.BlockType)
+		c.contents[i] = derefString(b.Content)
+		c.toolNames[i] = derefString(b.ToolName)
+		c.toolInputs[i] = derefString(b.ToolInput)
+		c.toolCallIDs[i] = derefString(b.ToolCallID)
+		c.thoughtSignatures[i] = derefString(b.ThoughtSignature)
+		c.isErrors[i] = b.IsError != nil && *b.IsError
+		c.versions[i] = int64(derefInt(b.Version))
+		c.activityIDs[i] = derefString(b.ActivityID)
+		c.workflowRunIDs[i] = derefString(b.WorkflowRunID)
+		c.attemptNumbers[i] = int64(b.AttemptNumber)
+	}
+	return c
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func derefInt(i *int) int {
+	if i == nil {
+		return 0
+	}
+	return *i
+}
+
+func nullString(s *string) sql.NullString {
+	if s == nil || *s == "" {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: *s, Valid: true}
+}
+
+func nullInt(i *int) sql.NullInt64 {
+	if i == nil {
+		return sql.NullInt64{}
+	}
+	return sql.NullInt64{Int64: int64(*i), Valid: true}
+}
+
+func nullFloat(f *float64) sql.NullFloat64 {
+	if f == nil {
+		return sql.NullFloat64{}
+	}
+	return sql.NullFloat64{Float64: *f, Valid: true}
+}
+
+func nullDisplayStyle(d *reliantv1.DisplayStyle) sql.NullInt32 {
+	if d == nil {
+		return sql.NullInt32{}
+	}
+	return sql.NullInt32{Int32: int32(*d), Valid: true}
+}

--- a/internal/threads/bounded_messages.go
+++ b/internal/threads/bounded_messages.go
@@ -51,6 +51,9 @@ func (s *Service) LoadRecentMessagesBefore(ctx context.Context, threadID string,
 
 	latestCW, err := s.repo.GetLatestContextWindow(ctx, threadID)
 	if err != nil {
+		if !isEmptyThread(err) {
+			return nil, false, fmt.Errorf("failed to load latest context window for thread %s: %w", threadID, err)
+		}
 		// No context window means empty thread.
 		return []*db.Message{}, false, nil
 	}
@@ -132,6 +135,9 @@ func (s *Service) LoadMessagesInSeqRange(ctx context.Context, threadID string, f
 
 	latestCW, err := s.repo.GetLatestContextWindow(ctx, threadID)
 	if err != nil {
+		if !isEmptyThread(err) {
+			return nil, fmt.Errorf("failed to load latest context window for thread %s: %w", threadID, err)
+		}
 		return []*db.Message{}, nil
 	}
 
@@ -179,6 +185,9 @@ func (s *Service) CountCurrentMessages(ctx context.Context, threadID string) (in
 
 	latestCW, err := s.repo.GetLatestContextWindow(ctx, threadID)
 	if err != nil {
+		if !isEmptyThread(err) {
+			return 0, fmt.Errorf("failed to load latest context window for thread %s: %w", threadID, err)
+		}
 		return 0, nil
 	}
 
@@ -201,6 +210,9 @@ func (s *Service) CountDisplayMessages(ctx context.Context, threadID string) (in
 
 	latestCW, err := s.repo.GetLatestContextWindow(ctx, threadID)
 	if err != nil {
+		if !isEmptyThread(err) {
+			return 0, fmt.Errorf("failed to load latest context window for thread %s: %w", threadID, err)
+		}
 		return 0, nil
 	}
 

--- a/internal/threads/cancelled_load_test.go
+++ b/internal/threads/cancelled_load_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2025 Reliant Labs
+package threads
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	reliantv1 "github.com/reliant-labs/reliant/gen/reliant/v1"
+)
+
+// TestLoadCurrentMessages_CancelledReadIsNotEmptyThread is the regression test
+// for the failure that started this investigation:
+//
+//	cannot call LLM with empty message history
+//	  (chat=087b4456-…, thread=69424fb0-…)
+//
+// The thread was NOT empty — it held 344 messages, and resolved all of them
+// two seconds later. What happened is that the user's interrupt cancelled the
+// activity context, the next DB read failed with "context canceled", and
+// LoadCurrentMessages' error branch reported that failure as an empty
+// conversation:
+//
+//	latestCW, err := s.repo.GetLatestContextWindow(ctx, threadID)
+//	if err != nil {
+//	    // No context window means empty thread - return empty slice
+//	    return []*db.Message{}, nil
+//	}
+//
+// CallLLM then hit its end-of-history guard and failed the turn with a message
+// that named neither the real cause nor the real state.
+//
+// The assertion is deliberately about the ERROR, not the message count: a
+// cancelled read must propagate as a cancellation so callers can classify it
+// as retryable, rather than silently becoming a well-formed "there is nothing
+// here" that every downstream layer trusts.
+func TestLoadCurrentMessages_CancelledReadIsNotEmptyThread(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.Close()
+
+	thread, _ := h.createThread("cancelled-load-thread", h.chatID)
+
+	// Give the thread real history, so "empty" can only be a lie.
+	for i := 0; i < 3; i++ {
+		if _, err := h.svc.SaveMessage(context.Background(), SaveMessageOpts{
+			ChatID:  h.chatID,
+			Thread:  thread.ID,
+			Role:    int32(reliantv1.MessageRole_MESSAGE_ROLE_ASSISTANT),
+			Content: fmt.Sprintf("message %d", i),
+		}); err != nil {
+			t.Fatalf("failed to seed message %d: %v", i, err)
+		}
+	}
+
+	// Sanity: the thread really does resolve its history on a healthy context.
+	healthy, err := h.svc.LoadCurrentMessages(context.Background(), thread.ID)
+	if err != nil {
+		t.Fatalf("baseline load failed: %v", err)
+	}
+	if len(healthy) != 3 {
+		t.Fatalf("expected 3 messages on a healthy read, got %d", len(healthy))
+	}
+
+	// Now read with an already-cancelled context, exactly as an interrupted
+	// activity does.
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	msgs, err := h.svc.LoadCurrentMessages(cancelledCtx, thread.ID)
+
+	if err == nil {
+		t.Fatalf("a cancelled read returned %d messages and no error; "+
+			"reporting cancellation as an empty thread is what produced "+
+			"'cannot call LLM with empty message history' on a thread with real history",
+			len(msgs))
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected the error to wrap context.Canceled so callers can classify it as retryable; got %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("a failed load must not also return partial history; got %d messages", len(msgs))
+	}
+}
+
+// TestIsEmptyThread_ClassifiesOnlyNoRows pins the classifier directly. The
+// whole defect was one branch treating every error as emptiness, so the
+// boundary between "no rows" and "the read failed" is the thing worth pinning.
+func TestIsEmptyThread_ClassifiesOnlyNoRows(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil is empty", nil, true},
+		{"no rows is empty", sql.ErrNoRows, true},
+		{"wrapped no rows is empty",
+			fmt.Errorf("failed to get latest context window: %w", sql.ErrNoRows), true},
+
+		// The incident cases.
+		{"cancellation is NOT empty", context.Canceled, false},
+		{"wrapped cancellation is NOT empty",
+			fmt.Errorf("failed to get latest context window: %w", context.Canceled), false},
+		{"deadline exceeded is NOT empty", context.DeadlineExceeded, false},
+
+		// Any other infrastructure failure must propagate too.
+		{"serialization failure is NOT empty",
+			errors.New("could not serialize access due to concurrent update (SQLSTATE 40001)"), false},
+		{"connection failure is NOT empty",
+			errors.New("driver: bad connection"), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isEmptyThread(tc.err); got != tc.want {
+				t.Errorf("isEmptyThread(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/threads/counter_self_heal_test.go
+++ b/internal/threads/counter_self_heal_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 Reliant Labs
+package threads
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	reliantv1 "github.com/reliant-labs/reliant/gen/reliant/v1"
+	"github.com/reliant-labs/reliant/internal/db"
+)
+
+// TestSeqCounter_HealsAfterDirectMessageInsert pins the interaction between
+// the counter-based allocator and the writers that still bypass it.
+//
+// Three production paths insert messages with their own MAX()-based
+// allocation rather than going through SaveMessage:
+//
+//	internal/grpc/services/chat_branch.go   branch-point tool repair
+//	internal/grpc/services/approval.go      tool-denial message
+//	internal/workflow/.../cleanup.go        orphaned tool-call repair
+//
+// Each of those advances messages past the counter without touching it. A
+// counter that then handed out its own stale next value would collide with
+// messages_chat_seq_key — which is not hypothetical: it is SQLSTATE 23505, and
+// it is what this test caught when the allocator was first written without the
+// GREATEST().
+//
+// Rather than require every such writer to know the counter exists, the
+// allocator heals: it takes the greater of its own next value and the table's
+// real high-water mark. This test is the contract for that, and it is what
+// lets those three call sites keep working unmodified.
+func TestSeqCounter_HealsAfterDirectMessageInsert(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.Close()
+	ctx := context.Background()
+
+	thread, cw := h.createThread("heal-thread", h.chatID)
+
+	// Normal save through the counter path.
+	if _, err := h.svc.SaveMessage(ctx, SaveMessageOpts{
+		ChatID:  h.chatID,
+		Thread:  thread.ID,
+		Role:    int32(reliantv1.MessageRole_MESSAGE_ROLE_ASSISTANT),
+		Content: "first",
+	}); err != nil {
+		t.Fatalf("failed to save first message: %v", err)
+	}
+
+	// A repair-style writer inserts directly, jumping the sequence far ahead
+	// of what the counter knows. This is exactly what the three paths above do.
+	jumpedSeq := int64(500)
+	jumpedOrdinal := int64(500)
+	ts := time.Now().UTC()
+	if err := h.repo.CreateMessage(ctx, &db.Message{
+		ID:              "direct-insert-msg",
+		ChatID:          h.chatID,
+		Ordinal:         jumpedOrdinal,
+		Seq:             jumpedSeq,
+		ThreadID:        thread.ID,
+		ContextWindowID: cw.ID,
+		Role:            reliantv1.MessageRole_MESSAGE_ROLE_TOOL,
+		CreatedAt:       ts,
+		UpdatedAt:       ts,
+	}); err != nil {
+		t.Fatalf("failed to insert direct message: %v", err)
+	}
+
+	// The next counter-allocated save must land ABOVE the direct insert, not
+	// collide with it and not sort beneath it.
+	res, err := h.svc.SaveMessage(ctx, SaveMessageOpts{
+		ChatID:  h.chatID,
+		Thread:  thread.ID,
+		Role:    int32(reliantv1.MessageRole_MESSAGE_ROLE_ASSISTANT),
+		Content: "after the direct insert",
+	})
+	if err != nil {
+		t.Fatalf("save after direct insert failed (counter did not heal): %v", err)
+	}
+
+	msgs, err := h.repo.ListMessages(ctx, h.chatID, db.MessageListOptions{})
+	if err != nil {
+		t.Fatalf("failed to list messages: %v", err)
+	}
+
+	var savedSeq int64 = -1
+	for _, m := range msgs {
+		if m.ID == res.MessageID {
+			savedSeq = m.Seq
+		}
+	}
+	if savedSeq < 0 {
+		t.Fatalf("saved message %s not found", res.MessageID)
+	}
+	if savedSeq <= jumpedSeq {
+		t.Errorf("counter handed out seq %d, at or below the direct insert's %d — "+
+			"the row would collide or sort above a newer message", savedSeq, jumpedSeq)
+	}
+
+	// No duplicates anywhere.
+	seen := make(map[int64]string, len(msgs))
+	for _, m := range msgs {
+		if prev, dup := seen[m.Seq]; dup {
+			t.Errorf("seq %d used by both %s and %s", m.Seq, prev, m.ID)
+		}
+		seen[m.Seq] = m.ID
+	}
+}

--- a/internal/threads/empty_thread.go
+++ b/internal/threads/empty_thread.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2025 Reliant Labs
+package threads
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+)
+
+// isEmptyThread reports whether err from GetLatestContextWindow means "this
+// thread has no messages yet" — as opposed to "the read failed".
+//
+// # Why this exists
+//
+// Every read path in this package used to treat ANY error from
+// GetLatestContextWindow as an empty thread:
+//
+//	latestCW, err := s.repo.GetLatestContextWindow(ctx, threadID)
+//	if err != nil {
+//	    // No context window means empty thread - return empty slice
+//	    return []*db.Message{}, nil
+//	}
+//
+// That comment is only true for sql.ErrNoRows. The branch also swallowed
+// context cancellation, and THAT is what produced the user-visible failure
+// this function was written for:
+//
+//	cannot call LLM with empty message history
+//	  (chat=087b4456-…, thread=69424fb0-…)
+//
+// The sequence, reconstructed from the worker log: the user interrupted a
+// thread; the interrupt cancelled the activity context; the very next DB call
+// — this one — failed with "context canceled"; the error was discarded and
+// reported as an empty conversation; CallLLM's end-of-history guard fired.
+// The thread was not empty. Two seconds later the same thread resolved 344
+// messages.
+//
+// The tell in the log is that the failing CallLLM produced NO
+// "[FORK-DEBUG] LoadCurrentMessages called" line at all — that statement sits
+// immediately after the error branch, so its absence proves the function
+// returned inside it.
+//
+// # Why "empty" is the dangerous default
+//
+// An empty history is not a neutral answer. Downstream it means either a hard
+// failure (the guard above) or, worse, a SILENTLY TRUNCATED prompt: a
+// cancelled mid-walk read that returned partial history would send the model a
+// conversation missing its own recent turns, and nothing would flag it. Failing
+// loudly on a real error is the only safe direction.
+//
+// A genuinely empty thread is a normal, expected state — a thread created but
+// not yet written to — so it must stay cheap and non-erroring. Hence the
+// narrow classification: no rows means empty, everything else propagates.
+func isEmptyThread(err error) bool {
+	if err == nil {
+		return true
+	}
+
+	// Cancellation is never emptiness. Checked explicitly and first: this is
+	// the case that caused the incident, and a wrapped cancellation must not
+	// reach the sql.ErrNoRows test below by some future accident of wrapping.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// The store wraps with %w, so errors.Is sees through the message.
+	return errors.Is(err, sql.ErrNoRows)
+}

--- a/internal/threads/fork.go
+++ b/internal/threads/fork.go
@@ -91,6 +91,25 @@ func (s *Service) forkThreadInternal(ctx context.Context, opts ForkThreadOpts, w
 		return nil, nil, fmt.Errorf("failed to create context window: %w", err)
 	}
 
+	// Raise this chat's seq allocator to cover the history the fork INHERITS.
+	//
+	// The allocator only sees rows carrying this chat_id, and a branch's
+	// inherited messages carry the PARENT's. Without this the branch restarts
+	// at seq 0 and every reply the user sends sorts beneath the inherited
+	// transcript above it — the message is saved and streamed correctly but
+	// renders at the top, which reads as "my message never arrived".
+	//
+	// Best-effort by design: a fork whose counter could not be seeded is
+	// recoverable (the next seed, or a save, raises it), whereas failing the
+	// fork outright loses the branch the user just asked for.
+	if err := s.repo.SeedSeqCounterForFork(ctx, opts.ChatID, opts.ForkAtContextWindowID); err != nil {
+		logging.Warn("[ForkThread] Failed to seed seq counter for fork",
+			"error", err,
+			"chatID", opts.ChatID,
+			"threadID", threadID,
+			"forkAtContextWindowID", opts.ForkAtContextWindowID)
+	}
+
 	// FORK-DEBUG: Log forked thread and context window creation
 	logging.Info("[FORK-DEBUG] forkThreadInternal created forked thread and CW",
 		"threadID", createdThread.ID,
@@ -160,6 +179,9 @@ func (s *Service) walkForkChain(ctx context.Context, threadID string, contextWin
 		} else {
 			cw, err = s.repo.GetLatestContextWindow(ctx, currentThreadID)
 			if err != nil {
+				if !isEmptyThread(err) {
+					return fmt.Errorf("failed to get latest context window for thread %s: %w", currentThreadID, err)
+				}
 				// No context window yet - thread has no messages
 				cw = nil
 			}

--- a/internal/threads/fork_seq_seed_test.go
+++ b/internal/threads/fork_seq_seed_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2025 Reliant Labs
+package threads
+
+import (
+	"context"
+	"testing"
+
+	reliantv1 "github.com/reliant-labs/reliant/gen/reliant/v1"
+)
+
+// TestForkedThread_SeqContinuesAboveInheritedHistory pins the one behaviour
+// that moving seq allocation onto a counter could plausibly break, and whose
+// failure is a VISIBLE product bug rather than an error.
+//
+// A branched chat DISPLAYS its parent's messages but does not OWN those rows:
+// they keep the parent's chat_id and are resolved on read by walking the
+// context-window chain. So a counter seeded only from the branch's own rows
+// starts at 0, and every reply the user sends lands numerically BENEATH the
+// inherited transcript rendered above it. The message saves and streams
+// correctly and appears at the TOP of the conversation — which reads to the
+// user as "my message never arrived".
+//
+// This is exactly what GetNextSeqByChat's per-save recursive fork walk existed
+// to prevent, so the counter has to inherit the same high-water mark at fork
+// time. SeedSeqCounterForFork does that walk once per fork instead of once per
+// message.
+func TestForkedThread_SeqContinuesAboveInheritedHistory(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.Close()
+	ctx := context.Background()
+
+	// Parent thread with real history, saved through the production path so
+	// the counter reflects it.
+	parentThread, parentCW := h.createThread("fork-seed-parent", h.chatID)
+
+	var lastParentSeq int64
+	for i := 0; i < 5; i++ {
+		if _, err := h.svc.SaveMessage(ctx, SaveMessageOpts{
+			ChatID:  h.chatID,
+			Thread:  parentThread.ID,
+			Role:    int32(reliantv1.MessageRole_MESSAGE_ROLE_ASSISTANT),
+			Content: "parent history",
+		}); err != nil {
+			t.Fatalf("failed to save parent message %d: %v", i, err)
+		}
+	}
+
+	parentMsgs, err := h.svc.LoadCurrentMessages(ctx, parentThread.ID)
+	if err != nil {
+		t.Fatalf("failed to load parent messages: %v", err)
+	}
+	if len(parentMsgs) == 0 {
+		t.Fatal("expected parent to have messages")
+	}
+	for _, m := range parentMsgs {
+		if m.Seq > lastParentSeq {
+			lastParentSeq = m.Seq
+		}
+	}
+
+	// Fork at the parent's newest message, into a DIFFERENT chat — this is
+	// the branch case, where the child owns none of the inherited rows.
+	branchChatID := h.createChat("")
+	forkMsgID := parentMsgs[len(parentMsgs)-1].ID
+	forkedThread, _, err := h.svc.ForkThread(ctx, ForkThreadOpts{
+		ID:                    "fork-seed-branch",
+		ChatID:                branchChatID,
+		ParentThreadID:        parentThread.ID,
+		ForkAtContextWindowID: parentCW.ID,
+		ForkAtMessageID:       &forkMsgID,
+	})
+	if err != nil {
+		t.Fatalf("failed to fork thread: %v", err)
+	}
+
+	// The branch's first message must sort ABOVE everything it inherited.
+	res, err := h.svc.SaveMessage(ctx, SaveMessageOpts{
+		ChatID:  branchChatID,
+		Thread:  forkedThread.ID,
+		Role:    int32(reliantv1.MessageRole_MESSAGE_ROLE_USER),
+		Content: "first message in the branch",
+	})
+	if err != nil {
+		t.Fatalf("failed to save branch message: %v", err)
+	}
+
+	branchMsgs, err := h.svc.LoadCurrentMessages(ctx, forkedThread.ID)
+	if err != nil {
+		t.Fatalf("failed to load branch messages: %v", err)
+	}
+
+	var saved *int64
+	for _, m := range branchMsgs {
+		if m.ID == res.MessageID {
+			seq := m.Seq
+			saved = &seq
+		}
+	}
+	if saved == nil {
+		t.Fatalf("branch message %s not found in resolved history", res.MessageID)
+	}
+
+	if *saved <= lastParentSeq {
+		t.Errorf("branch message got seq %d, which is not above the inherited high-water mark %d; "+
+			"it will render at the TOP of the transcript and read as 'my message never arrived'",
+			*saved, lastParentSeq)
+	}
+
+	// And it must genuinely be last in the resolved order the UI sorts by.
+	var maxSeq int64 = -1
+	var lastID string
+	for _, m := range branchMsgs {
+		if m.Seq > maxSeq {
+			maxSeq = m.Seq
+			lastID = m.ID
+		}
+	}
+	if lastID != res.MessageID {
+		t.Errorf("expected the newly saved branch message to sort last; got %s at seq %d", lastID, maxSeq)
+	}
+}

--- a/internal/threads/legacy_allocator_baseline_test.go
+++ b/internal/threads/legacy_allocator_baseline_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2025 Reliant Labs
+package threads
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	reliantv1 "github.com/reliant-labs/reliant/gen/reliant/v1"
+	"github.com/reliant-labs/reliant/internal/db"
+	"github.com/reliant-labs/reliant/internal/ptr"
+)
+
+// TestLegacyAllocatorBaseline_StillConflicts is the CONTROL for
+// TestSaveMessage_ConcurrentWritersSameChat.
+//
+// A regression test that passes is only meaningful if it would have FAILED
+// against the code it replaces. This test keeps the old write shape alive —
+// MAX()-scan allocation (GetNextOrdinal / GetNextSeq) plus the message insert,
+// all inside one SERIALIZABLE transaction — and asserts that shape still
+// produces serialization failures under the same concurrency the new path
+// handles cleanly.
+//
+// If this test ever stops reporting conflicts, the concurrency tests have lost
+// their teeth and the harness itself is no longer exercising contention: fix
+// the harness, do not delete this.
+func TestLegacyAllocatorBaseline_StillConflicts(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.Close()
+	ctx := context.Background()
+
+	const writers = 8
+	const messagesPerWriter = 5
+
+	threadIDs := make([]string, writers)
+	cwIDs := make([]string, writers)
+	for i := range threadIDs {
+		thread, cw := h.createThread(fmt.Sprintf("legacy-thread-%d", i), h.chatID)
+		threadIDs[i] = thread.ID
+		cwIDs[i] = cw.ID
+	}
+
+	var (
+		wg        sync.WaitGroup
+		mu        sync.Mutex
+		conflicts int
+		other     []error
+	)
+
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(threadID, cwID string, writerIdx int) {
+			defer wg.Done()
+			for m := 0; m < messagesPerWriter; m++ {
+				// The OLD transaction body, verbatim in shape: scan for
+				// ordinal, walk for seq, then insert into the range just read.
+				//
+				// RunTxNoRetry deliberately: RunTx's ladder absorbs these
+				// conflicts and reports success, which hides the very thing
+				// this control exists to measure. The production path DID
+				// retry, and still exhausted the ladder 35 times in one
+				// session — so the raw rate is the honest number.
+				err := h.repo.RunTxNoRetry(ctx, func(txCtx context.Context) error {
+					ordinal, err := h.repo.GetNextOrdinal(txCtx, threadID)
+					if err != nil {
+						return err
+					}
+					seq, err := h.repo.GetNextSeq(txCtx, h.chatID, threadID)
+					if err != nil {
+						return err
+					}
+					ts := time.Now().UTC()
+					return h.repo.CreateMessage(txCtx, &db.Message{
+						ID:              fmt.Sprintf("legacy-%d-%d", writerIdx, m),
+						ChatID:          h.chatID,
+						Ordinal:         ordinal,
+						Seq:             seq,
+						ThreadID:        threadID,
+						ContextWindowID: cwID,
+						Role:            reliantv1.MessageRole_MESSAGE_ROLE_ASSISTANT,
+						TokenCount:      ptr.IntIfPositive(1),
+						CreatedAt:       ts,
+						UpdatedAt:       ts,
+					})
+				})
+
+				mu.Lock()
+				if err != nil {
+					if strings.Contains(err.Error(), "40001") ||
+						strings.Contains(err.Error(), "could not serialize") ||
+						strings.Contains(err.Error(), "transaction failed after retries") {
+						conflicts++
+					} else {
+						other = append(other, err)
+					}
+				}
+				mu.Unlock()
+			}
+		}(threadIDs[w], cwIDs[w], w)
+	}
+	wg.Wait()
+
+	for _, err := range other {
+		t.Logf("non-serialization error from legacy path: %v", err)
+	}
+
+	total := writers * messagesPerWriter
+	t.Logf("legacy allocator: %d/%d writes failed with serialization conflicts (%.0f%%)",
+		conflicts, total, float64(conflicts)/float64(total)*100)
+
+	// The whole point of the control. If the legacy shape stops conflicting
+	// here, this harness is no longer generating contention and the
+	// concurrency tests above are passing vacuously — fix the harness rather
+	// than deleting this assertion.
+	if conflicts == 0 {
+		t.Fatal("expected the MAX()-scan allocator to produce serialization conflicts under " +
+			"concurrent writers; it did not, so this harness is not exercising contention " +
+			"and TestSaveMessage_ConcurrentWritersSameChat proves nothing")
+	}
+
+	// And the comparison that justifies the rewrite: the same workload through
+	// the new single-statement path, with retries likewise disabled.
+	newPathFailures := runNewPathUnderContention(t, h, writers, messagesPerWriter)
+	t.Logf("single-statement path: %d/%d writes failed with serialization conflicts",
+		newPathFailures, total)
+
+	if newPathFailures > 0 {
+		t.Errorf("the single-statement path still conflicts (%d/%d) — it allocates from "+
+			"counter rows at READ COMMITTED and must not raise 40001 at all",
+			newPathFailures, total)
+	}
+}
+
+// runNewPathUnderContention drives the production SaveMessage path with the
+// same writer count and asserts nothing about correctness — the concurrency
+// tests do that. It exists to produce the second half of the before/after
+// number in one run, so the comparison cannot drift between two test files.
+func runNewPathUnderContention(t *testing.T, h *testHelper, writers, messagesPerWriter int) int {
+	t.Helper()
+	ctx := context.Background()
+
+	threadIDs := make([]string, writers)
+	for i := range threadIDs {
+		thread, _ := h.createThread(fmt.Sprintf("newpath-thread-%d", i), h.chatID)
+		threadIDs[i] = thread.ID
+	}
+
+	var (
+		wg       sync.WaitGroup
+		mu       sync.Mutex
+		failures int
+	)
+
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(threadID string, writerIdx int) {
+			defer wg.Done()
+			for m := 0; m < messagesPerWriter; m++ {
+				_, err := h.svc.SaveMessage(ctx, SaveMessageOpts{
+					ChatID:  h.chatID,
+					Thread:  threadID,
+					Role:    int32(reliantv1.MessageRole_MESSAGE_ROLE_ASSISTANT),
+					Content: fmt.Sprintf("newpath w%d m%d", writerIdx, m),
+				})
+				if err != nil {
+					mu.Lock()
+					failures++
+					mu.Unlock()
+					t.Logf("new path error: %v", err)
+				}
+			}
+		}(threadIDs[w], w)
+	}
+	wg.Wait()
+
+	return failures
+}

--- a/internal/threads/messages.go
+++ b/internal/threads/messages.go
@@ -38,6 +38,9 @@ func (s *Service) ResolveMessages(ctx context.Context, opts ResolveMessagesOpts)
 	} else {
 		startingCW, err = s.repo.GetLatestContextWindow(ctx, opts.ThreadID)
 		if err != nil {
+			if !isEmptyThread(err) {
+				return nil, fmt.Errorf("failed to load latest context window for thread %s: %w", opts.ThreadID, err)
+			}
 			// No context window yet - thread has no messages
 			return []*db.Message{}, nil
 		}
@@ -278,10 +281,17 @@ func (s *Service) LoadCurrentMessages(ctx context.Context, threadID string) ([]*
 		return nil, fmt.Errorf("thread ID cannot be empty")
 	}
 
-	// Get the latest context window for this thread
+	// Get the latest context window for this thread.
+	//
+	// Only NO ROWS means "empty thread". A failed read — cancellation above
+	// all — must propagate: reporting it as an empty history is what turned a
+	// user interrupt into "cannot call LLM with empty message history" on a
+	// thread holding 344 messages. See isEmptyThread.
 	latestCW, err := s.repo.GetLatestContextWindow(ctx, threadID)
 	if err != nil {
-		// No context window means empty thread - return empty slice
+		if !isEmptyThread(err) {
+			return nil, fmt.Errorf("failed to load latest context window for thread %s: %w", threadID, err)
+		}
 		return []*db.Message{}, nil
 	}
 
@@ -341,6 +351,9 @@ func (s *Service) LoadDisplayMessages(ctx context.Context, threadID string) ([]*
 
 	latestCW, err := s.repo.GetLatestContextWindow(ctx, threadID)
 	if err != nil {
+		if !isEmptyThread(err) {
+			return nil, fmt.Errorf("failed to load latest context window for thread %s: %w", threadID, err)
+		}
 		// No context window yet - thread has no messages.
 		return []*db.Message{}, nil
 	}

--- a/internal/threads/save_message.go
+++ b/internal/threads/save_message.go
@@ -210,78 +210,67 @@ func (s *Service) SaveMessage(ctx context.Context, opts SaveMessageOpts) (*SaveM
 		}
 	}
 
-	// Execute in transaction
-	var result SaveMessageResult
-	err = s.repo.RunTx(ctx, func(txCtx context.Context) error {
-		// Get next ordinal
-		ordinal, err := s.repo.GetNextOrdinal(txCtx, opts.Thread)
-		if err != nil {
-			return fmt.Errorf("failed to get next ordinal: %w", err)
-		}
+	timestamp := now()
+	messageID := uuid.New().String()
+	if opts.MessageID != "" {
+		messageID = opts.MessageID
+	}
 
-		// Get next chat-global seq. See 20260802000000_add_message_seq.sql.
-		seq, err := s.repo.GetNextSeq(txCtx, opts.ChatID, opts.Thread)
-		if err != nil {
-			return fmt.Errorf("failed to get next seq: %w", err)
-		}
+	// Build everything the write needs BEFORE opening the transaction.
+	//
+	// Block construction is pure except for attachment lookup, and doing it
+	// out here means the durable write below is a single round trip with no
+	// reads holding locks open. This is the whole point of the rewrite: the
+	// previous version made 5+N round trips inside a SERIALIZABLE transaction
+	// (MAX(ordinal) scan, a WITH RECURSIVE seq walk, the message insert, one
+	// insert per content block, then the chat_update), and the duration of
+	// that transaction — not the amount of work in it — was what produced the
+	// 40001 storms.
+	blocks, err := s.buildContentBlocks(ctx, messageID, opts, timestamp)
+	if err != nil {
+		return nil, err
+	}
 
-		timestamp := now()
-		messageID := uuid.New().String()
-		if opts.MessageID != "" {
-			messageID = opts.MessageID
-		}
+	write := db.AtomicMessageWrite{
+		MessageID:       messageID,
+		ChatID:          opts.ChatID,
+		ThreadID:        opts.Thread,
+		ContextWindowID: cw.ID,
+		Role:            reliantv1.MessageRole(opts.Role),
+		DisplayStyle:    displayStylePtrIfNonZero(opts.DisplayStyle),
+		Model:           ptr.StringIfNotEmpty(opts.Model),
+		Agent:           ptr.StringIfNotEmpty(opts.Agent),
+		TokenCount:      ptr.IntIfPositive(opts.TokenCount),
+		Cost:            ptr.Float64IfPositive(opts.Cost),
+		WorkflowID:      opts.WorkflowID,
+		NodeID:          ptr.StringIfNotEmpty(opts.StepID),
+		ActivityID:      opts.ActivityID,
+		CreatedAt:       timestamp,
+		Blocks:          blocks,
 
-		// Create message
-		msg := &db.Message{
-			ID:              messageID,
-			ChatID:          opts.ChatID,
-			Ordinal:         ordinal,
-			Seq:             seq,
-			ThreadID:        opts.Thread,
-			ContextWindowID: cw.ID,
-			Role:            reliantv1.MessageRole(opts.Role),
-			WorkflowID:      opts.WorkflowID,
-			NodeID:          ptr.StringIfNotEmpty(opts.StepID),
-			ActivityID:      opts.ActivityID,
-			TokenCount:      ptr.IntIfPositive(opts.TokenCount),
-			Cost:            ptr.Float64IfPositive(opts.Cost),
-			Model:           ptr.StringIfNotEmpty(opts.Model),
-			Agent:           ptr.StringIfNotEmpty(opts.Agent),
-			DisplayStyle:    displayStylePtrIfNonZero(opts.DisplayStyle),
-			CreatedAt:       timestamp,
-			UpdatedAt:       timestamp,
-		}
+		ChatUpdateType:   db.UpdateTypeMessage,
+		ChatUpdateEntity: messageID,
+		// ordinal and seq are not known until the statement allocates them,
+		// so the payload is rendered from the RETURNING values.
+		ChatUpdateData: func(ordinal, seq, _ int64) (string, error) {
+			return s.buildChatUpdateData(ctx, opts, messageID, blocks, ordinal, seq, cw.Sequence, threadTokenCount, timestamp)
+		},
+	}
 
-		if err := s.repo.CreateMessage(txCtx, msg); err != nil {
-			return fmt.Errorf("failed to create message: %w", err)
-		}
-
-		// Create content blocks based on role
-		if err := s.createContentBlocks(txCtx, messageID, opts, timestamp); err != nil {
-			return err
-		}
-
-		// Emit chat_update for frontend
-		if err := s.emitChatUpdate(txCtx, opts, messageID, ordinal, seq, cw.Sequence, threadTokenCount, timestamp); err != nil {
-			return err
-		}
-
-		result = SaveMessageResult{
-			MessageID:        messageID,
-			Ordinal:          ordinal,
-			ContextWindowID:  cw.ID,
-			ThreadTokenCount: threadTokenCount,
-			MessageCount:     messageCount + 1,
-			ToolCalls:        opts.ToolCalls,
-			ToolResults:      opts.ToolResults,
-			WasExisting:      false,
-		}
-
-		return nil
-	})
-
+	written, err := s.repo.SaveMessageAtomic(ctx, write)
 	if err != nil {
 		return nil, fmt.Errorf("failed to save message: %w", err)
+	}
+
+	result := SaveMessageResult{
+		MessageID:        messageID,
+		Ordinal:          written.Ordinal,
+		ContextWindowID:  cw.ID,
+		ThreadTokenCount: threadTokenCount,
+		MessageCount:     messageCount + 1,
+		ToolCalls:        opts.ToolCalls,
+		ToolResults:      opts.ToolResults,
+		WasExisting:      false,
 	}
 
 	slog.Info("[SaveMessage] Created",
@@ -485,27 +474,33 @@ func (s *Service) checkExistingMessageByID(ctx context.Context, opts SaveMessage
 }
 
 // createContentBlocks creates the appropriate content blocks based on message role.
-func (s *Service) createContentBlocks(ctx context.Context, messageID string, opts SaveMessageOpts, timestamp time.Time) error {
+func (s *Service) buildContentBlocks(ctx context.Context, messageID string, opts SaveMessageOpts, timestamp time.Time) ([]db.MessageContentBlock, error) {
 	switch reliantv1.MessageRole(opts.Role) {
 	case reliantv1.MessageRole_MESSAGE_ROLE_USER:
-		return s.createUserContentBlocks(ctx, messageID, opts, timestamp)
+		return s.buildUserContentBlocks(ctx, messageID, opts, timestamp)
 	case reliantv1.MessageRole_MESSAGE_ROLE_ASSISTANT:
-		return s.createAssistantContentBlocks(ctx, messageID, opts, timestamp)
+		return s.buildAssistantContentBlocks(messageID, opts, timestamp), nil
 	case reliantv1.MessageRole_MESSAGE_ROLE_TOOL:
-		return s.createToolContentBlocks(ctx, messageID, opts, timestamp)
+		return s.buildToolContentBlocks(ctx, messageID, opts, timestamp)
 	case reliantv1.MessageRole_MESSAGE_ROLE_SYSTEM:
-		return s.createSystemContentBlocks(ctx, messageID, opts, timestamp)
+		return s.buildSystemContentBlocks(messageID, opts, timestamp), nil
 	}
-	return nil
+	return nil, nil
 }
 
 // createUserContentBlocks creates content blocks for user messages.
-func (s *Service) createUserContentBlocks(ctx context.Context, messageID string, opts SaveMessageOpts, timestamp time.Time) error {
+// buildUserContentBlocks is one of two builders that take a context (the other
+// is buildToolContentBlocks): both resolve attachment metadata, and that read
+// must happen BEFORE the write statement rather than inside it. Reading here
+// keeps the durable write a single round trip with no lookups holding locks
+// open.
+func (s *Service) buildUserContentBlocks(ctx context.Context, messageID string, opts SaveMessageOpts, timestamp time.Time) ([]db.MessageContentBlock, error) {
+	var blocks []db.MessageContentBlock
 	position := 0
 
 	// Create text block if content is provided
 	if opts.Content != "" {
-		block := &db.MessageContentBlock{
+		blocks = append(blocks, db.MessageContentBlock{
 			ID:        uuid.New().String(),
 			MessageID: messageID,
 			Position:  position,
@@ -514,10 +509,7 @@ func (s *Service) createUserContentBlocks(ctx context.Context, messageID string,
 			Version:   ptr.Of(1),
 			CreatedAt: timestamp,
 			UpdatedAt: timestamp,
-		}
-		if err := s.repo.CreateContentBlock(ctx, block); err != nil {
-			return fmt.Errorf("failed to create text content block: %w", err)
-		}
+		})
 		position++
 	}
 
@@ -525,10 +517,10 @@ func (s *Service) createUserContentBlocks(ctx context.Context, messageID string,
 	for _, attachmentID := range opts.Attachments {
 		att, err := s.repo.GetAttachment(ctx, attachmentID)
 		if err != nil {
-			return fmt.Errorf("failed to get attachment metadata for %s: %w", attachmentID, err)
+			return nil, fmt.Errorf("failed to get attachment metadata for %s: %w", attachmentID, err)
 		}
 		if att == nil {
-			return fmt.Errorf("failed to get attachment metadata for %s: attachment not found", attachmentID)
+			return nil, fmt.Errorf("failed to get attachment metadata for %s: attachment not found", attachmentID)
 		}
 
 		var blockType reliantv1.ContentBlockType
@@ -540,11 +532,11 @@ func (s *Service) createUserContentBlocks(ctx context.Context, messageID string,
 		case "document":
 			blockType = reliantv1.ContentBlockType_CONTENT_BLOCK_TYPE_DOCUMENT
 		default:
-			return fmt.Errorf("invalid attachment type %q for attachment %s", att.AttachmentType, attachmentID)
+			return nil, fmt.Errorf("invalid attachment type %q for attachment %s", att.AttachmentType, attachmentID)
 		}
 
 		attachmentRef := attachmentID
-		block := &db.MessageContentBlock{
+		blocks = append(blocks, db.MessageContentBlock{
 			ID:        uuid.New().String(),
 			MessageID: messageID,
 			Position:  position,
@@ -553,18 +545,16 @@ func (s *Service) createUserContentBlocks(ctx context.Context, messageID string,
 			Version:   ptr.Of(1),
 			CreatedAt: timestamp,
 			UpdatedAt: timestamp,
-		}
-		if err := s.repo.CreateContentBlock(ctx, block); err != nil {
-			return fmt.Errorf("failed to create attachment content block: %w", err)
-		}
+		})
 		position++
 	}
 
-	return nil
+	return blocks, nil
 }
 
 // createAssistantContentBlocks creates content blocks for assistant messages.
-func (s *Service) createAssistantContentBlocks(ctx context.Context, messageID string, opts SaveMessageOpts, timestamp time.Time) error {
+func (s *Service) buildAssistantContentBlocks(messageID string, opts SaveMessageOpts, timestamp time.Time) []db.MessageContentBlock {
+	var blocks []db.MessageContentBlock
 	position := 0
 
 	// Create thinking block when there is readable reasoning OR a signature.
@@ -585,7 +575,7 @@ func (s *Service) createAssistantContentBlocks(ctx context.Context, messageID st
 			"has_signature", opts.Thinking.Signature != "",
 			"position", position)
 
-		block := &db.MessageContentBlock{
+		blocks = append(blocks, db.MessageContentBlock{
 			ID:               uuid.New().String(),
 			MessageID:        messageID,
 			Position:         position,
@@ -595,10 +585,7 @@ func (s *Service) createAssistantContentBlocks(ctx context.Context, messageID st
 			Version:          ptr.Of(1),
 			CreatedAt:        timestamp,
 			UpdatedAt:        timestamp,
-		}
-		if err := s.repo.CreateContentBlock(ctx, block); err != nil {
-			return fmt.Errorf("failed to create thinking content block: %w", err)
-		}
+		})
 		position++
 	}
 
@@ -610,7 +597,7 @@ func (s *Service) createAssistantContentBlocks(ctx context.Context, messageID st
 			"data_len", len(opts.Thinking.Redacted),
 			"position", position)
 
-		block := &db.MessageContentBlock{
+		blocks = append(blocks, db.MessageContentBlock{
 			ID:        uuid.New().String(),
 			MessageID: messageID,
 			Position:  position,
@@ -619,16 +606,13 @@ func (s *Service) createAssistantContentBlocks(ctx context.Context, messageID st
 			Version:   ptr.Of(1),
 			CreatedAt: timestamp,
 			UpdatedAt: timestamp,
-		}
-		if err := s.repo.CreateContentBlock(ctx, block); err != nil {
-			return fmt.Errorf("failed to create redacted thinking content block: %w", err)
-		}
+		})
 		position++
 	}
 
 	// Create text block if content is provided
 	if opts.Content != "" {
-		block := &db.MessageContentBlock{
+		blocks = append(blocks, db.MessageContentBlock{
 			ID:        uuid.New().String(),
 			MessageID: messageID,
 			Position:  position,
@@ -637,10 +621,7 @@ func (s *Service) createAssistantContentBlocks(ctx context.Context, messageID st
 			Version:   ptr.Of(1),
 			CreatedAt: timestamp,
 			UpdatedAt: timestamp,
-		}
-		if err := s.repo.CreateContentBlock(ctx, block); err != nil {
-			return fmt.Errorf("failed to create text content block: %w", err)
-		}
+		})
 		position++
 	}
 
@@ -651,7 +632,7 @@ func (s *Service) createAssistantContentBlocks(ctx context.Context, messageID st
 			thoughtSig = &toolCall.ThoughtSignature
 		}
 
-		block := &db.MessageContentBlock{
+		blocks = append(blocks, db.MessageContentBlock{
 			ID:               uuid.New().String(),
 			MessageID:        messageID,
 			Position:         position + i,
@@ -663,16 +644,13 @@ func (s *Service) createAssistantContentBlocks(ctx context.Context, messageID st
 			Version:          ptr.Of(1),
 			CreatedAt:        timestamp,
 			UpdatedAt:        timestamp,
-		}
-		if err := s.repo.CreateContentBlock(ctx, block); err != nil {
-			return fmt.Errorf("failed to create tool_call block %d: %w", i, err)
-		}
+		})
 	}
 
-	return nil
+	return blocks
 }
 
-// createToolContentBlocks creates content blocks for tool messages.
+// buildToolContentBlocks builds the content blocks for tool messages.
 //
 // A tool result may carry attachment ids (see message.ToolResult.AttachmentIDs).
 // Each one becomes a sibling IMAGE block immediately after its tool_result
@@ -681,10 +659,21 @@ func (s *Service) createAssistantContentBlocks(ctx context.Context, messageID st
 // the whole point — the attachment fetch, the /api/attachments/{id} serving and
 // the existing renderer all key off it, so a generated image travels the same
 // road as an uploaded one rather than needing a second one built for it.
-func (s *Service) createToolContentBlocks(ctx context.Context, messageID string, opts SaveMessageOpts, timestamp time.Time) error {
+//
+// This BUILDS rather than writes, unlike the createToolContentBlocks it
+// replaces: every block for a message now goes in through one atomic statement
+// (SaveMessageAtomic) so concurrent writers cannot collide on seq. The
+// attachment lookup still needs a DB read, so this keeps a ctx and an error
+// return even though nothing here writes.
+//
+// `position` is therefore explicit and no longer the loop index: an attachment
+// block occupies a position of its own, so with any attachment present the
+// tool_result for result i is no longer at position i.
+func (s *Service) buildToolContentBlocks(ctx context.Context, messageID string, opts SaveMessageOpts, timestamp time.Time) ([]db.MessageContentBlock, error) {
+	blocks := make([]db.MessageContentBlock, 0, len(opts.ToolResults))
 	position := 0
-	for i, result := range opts.ToolResults {
-		block := &db.MessageContentBlock{
+	for _, result := range opts.ToolResults {
+		blocks = append(blocks, db.MessageContentBlock{
 			ID:         uuid.New().String(),
 			MessageID:  messageID,
 			Position:   position,
@@ -696,27 +685,23 @@ func (s *Service) createToolContentBlocks(ctx context.Context, messageID string,
 			Version:    ptr.Of(1),
 			CreatedAt:  timestamp,
 			UpdatedAt:  timestamp,
-		}
-		if err := s.repo.CreateContentBlock(ctx, block); err != nil {
-			return fmt.Errorf("failed to create tool_result block %d: %w", i, err)
-		}
+		})
 		position++
 
 		for _, attachmentID := range result.AttachmentIDs {
-			created, err := s.createToolAttachmentBlock(ctx, messageID, attachmentID, position, timestamp)
-			if err != nil {
-				return fmt.Errorf("failed to create attachment block for tool_result %d: %w", i, err)
+			block, ok := s.buildToolAttachmentBlock(ctx, messageID, attachmentID, position, timestamp)
+			if !ok {
+				continue
 			}
-			if created {
-				position++
-			}
+			blocks = append(blocks, block)
+			position++
 		}
 	}
-	return nil
+	return blocks, nil
 }
 
-// createToolAttachmentBlock materializes one attachment id as a content block
-// on a tool message, reporting whether a block was written.
+// buildToolAttachmentBlock materializes one attachment id as a content block
+// on a tool message, reporting whether there is a block to append.
 //
 // A missing or non-image attachment is skipped rather than failing the save.
 // That is the opposite of the user-upload path, and deliberately so: there, the
@@ -724,31 +709,37 @@ func (s *Service) createToolContentBlocks(ctx context.Context, messageID string,
 // surfacing, whereas here the message also carries the tool's textual result
 // and the model's own view of the image. Failing the whole save would discard a
 // completed turn — including work that cost money — over a thumbnail.
-func (s *Service) createToolAttachmentBlock(ctx context.Context, messageID, attachmentID string, position int, timestamp time.Time) (bool, error) {
+//
+// It BUILDS rather than writes (it used to end in CreateContentBlock), because
+// every block for a message is now inserted by one atomic statement. The skip
+// semantics above are what let the return be a plain (block, ok) rather than an
+// error: every failure mode here is already "log it and carry on", so there is
+// no error left for a caller to handle.
+func (s *Service) buildToolAttachmentBlock(ctx context.Context, messageID, attachmentID string, position int, timestamp time.Time) (db.MessageContentBlock, bool) {
 	if attachmentID == "" {
-		return false, nil
+		return db.MessageContentBlock{}, false
 	}
 
 	att, err := s.repo.GetAttachment(ctx, attachmentID)
 	if err != nil {
 		slog.Warn("[SaveMessage] Failed to load tool result attachment; skipping its content block",
 			"error", err, "attachment_id", attachmentID, "message_id", messageID)
-		return false, nil
+		return db.MessageContentBlock{}, false
 	}
 	if att == nil {
 		slog.Warn("[SaveMessage] Tool result attachment not found; skipping its content block",
 			"attachment_id", attachmentID, "message_id", messageID)
-		return false, nil
+		return db.MessageContentBlock{}, false
 	}
 
 	if att.AttachmentType != string(attachment.TypeImage) {
 		slog.Warn("[SaveMessage] Tool result attachment is not an image; skipping its content block",
 			"attachment_id", attachmentID, "attachment_type", att.AttachmentType, "message_id", messageID)
-		return false, nil
+		return db.MessageContentBlock{}, false
 	}
 
 	attachmentRef := attachmentID
-	block := &db.MessageContentBlock{
+	return db.MessageContentBlock{
 		ID:        uuid.New().String(),
 		MessageID: messageID,
 		Position:  position,
@@ -757,39 +748,42 @@ func (s *Service) createToolAttachmentBlock(ctx context.Context, messageID, atta
 		Version:   ptr.Of(1),
 		CreatedAt: timestamp,
 		UpdatedAt: timestamp,
-	}
-	if err := s.repo.CreateContentBlock(ctx, block); err != nil {
-		return false, err
-	}
-	return true, nil
+	}, true
 }
 
 // createSystemContentBlocks creates content blocks for system messages.
-func (s *Service) createSystemContentBlocks(ctx context.Context, messageID string, opts SaveMessageOpts, timestamp time.Time) error {
-	if opts.Content != "" {
-		block := &db.MessageContentBlock{
-			ID:        uuid.New().String(),
-			MessageID: messageID,
-			Position:  0,
-			BlockType: reliantv1.ContentBlockType_CONTENT_BLOCK_TYPE_TEXT,
-			Content:   &opts.Content,
-			Version:   ptr.Of(1),
-			CreatedAt: timestamp,
-			UpdatedAt: timestamp,
-		}
-		if err := s.repo.CreateContentBlock(ctx, block); err != nil {
-			return fmt.Errorf("failed to create text content block: %w", err)
-		}
+func (s *Service) buildSystemContentBlocks(messageID string, opts SaveMessageOpts, timestamp time.Time) []db.MessageContentBlock {
+	if opts.Content == "" {
+		return nil
 	}
-	return nil
+	return []db.MessageContentBlock{{
+		ID:        uuid.New().String(),
+		MessageID: messageID,
+		Position:  0,
+		BlockType: reliantv1.ContentBlockType_CONTENT_BLOCK_TYPE_TEXT,
+		Content:   &opts.Content,
+		Version:   ptr.Of(1),
+		CreatedAt: timestamp,
+		UpdatedAt: timestamp,
+	}}
 }
 
 // emitChatUpdate emits a chat_update for the frontend.
-func (s *Service) emitChatUpdate(ctx context.Context, opts SaveMessageOpts, messageID string, ordinal int64, seq int64, contextSequence int, threadTokenCount int, timestamp time.Time) error {
-	// Fetch content blocks
-	blocks, err := s.repo.ListContentBlocks(ctx, messageID)
-	if err != nil {
-		return fmt.Errorf("failed to list content blocks for chat_update: %w", err)
+// buildChatUpdateData renders the chat_update payload for a message.
+//
+// It takes the blocks it was ASKED to write rather than re-reading them. The
+// previous version issued a ListContentBlocks against rows the same
+// transaction had just inserted — a round trip whose only possible answer was
+// the slice already in hand, paid while holding locks on the hottest write
+// path in the system.
+//
+// ordinal and seq arrive as parameters because they do not exist until the
+// write statement allocates them; the caller supplies them from its RETURNING
+// values.
+func (s *Service) buildChatUpdateData(ctx context.Context, opts SaveMessageOpts, messageID string, blocks []db.MessageContentBlock, ordinal int64, seq int64, contextSequence int, threadTokenCount int, timestamp time.Time) (string, error) {
+	blockPtrs := make([]*db.MessageContentBlock, len(blocks))
+	for i := range blocks {
+		blockPtrs[i] = &blocks[i]
 	}
 
 	// One serializer for a block's wire shape, shared with every other path
@@ -806,8 +800,8 @@ func (s *Service) emitChatUpdate(ctx context.Context, opts SaveMessageOpts, mess
 			toolCallsByID[call.ID] = call
 		}
 	}
-	contentBlocks := db.ContentBlockPayloadsWithToolCalls(blocks, toolCallsByID)
-	attachmentIDs := db.AttachmentIDsFromBlocks(blocks)
+	contentBlocks := db.ContentBlockPayloadsWithToolCalls(blockPtrs, toolCallsByID)
+	attachmentIDs := db.AttachmentIDsFromBlocks(blockPtrs)
 
 	// Fetch attachment metadata
 	attachments := []map[string]interface{}{}
@@ -869,36 +863,16 @@ func (s *Service) emitChatUpdate(ctx context.Context, opts SaveMessageOpts, mess
 		updateData.TokenCount = &opts.TokenCount
 	}
 
-	// Marshal and emit
 	updateDataJSON, err := json.Marshal(updateData)
 	if err != nil {
 		slog.Error("[SaveMessage] Failed to marshal chat_update data",
 			"error", err,
 			"chat_id", opts.ChatID,
 			"message_id", messageID)
-		return fmt.Errorf("failed to marshal chat_update data: %w", err)
+		return "", fmt.Errorf("failed to marshal chat_update data: %w", err)
 	}
 
-	if err := s.repo.CreateChatUpdate(ctx, opts.ChatID, db.UpdateTypeMessage, messageID, string(updateDataJSON)); err != nil {
-		// Warn, not Error: this runs inside SaveMessage's RunTx, so transient
-		// failures (e.g. SQLSTATE 40001) are retried by the enclosing
-		// transaction. Terminal failures are logged at ERROR by RunTx itself.
-		slog.Warn("[SaveMessage] Failed to create chat_update (may be retried)",
-			"error", err,
-			"chat_id", opts.ChatID,
-			"message_id", messageID)
-		return fmt.Errorf("failed to create chat_update: %w", err)
-	}
-
-	slog.Debug("[SaveMessage] Emitted chat_update",
-		"chat_id", opts.ChatID,
-		"message_id", messageID,
-		"role", opts.Role,
-		"ordinal", ordinal,
-		"blocks", len(contentBlocks),
-		"json_bytes", len(updateDataJSON))
-
-	return nil
+	return string(updateDataJSON), nil
 }
 
 func displayStylePtrIfNonZero(i int32) *reliantv1.DisplayStyle {

--- a/internal/threads/save_message_concurrency_test.go
+++ b/internal/threads/save_message_concurrency_test.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2025 Reliant Labs
+package threads
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	reliantv1 "github.com/reliant-labs/reliant/gen/reliant/v1"
+	"github.com/reliant-labs/reliant/internal/db"
+)
+
+// TestSaveMessage_ConcurrentWritersSameChat is the regression test for the
+// 40001 storm that surfaced to users as red "Workflow error in Save Message"
+// banners carrying a raw SQLSTATE.
+//
+// The shape it reproduces is a workflow chat running several sub-workflow
+// threads at once. Every one of them saves messages into the SAME chat, so
+// they all contend on that chat's seq allocation and its chat_update sequence.
+//
+// Against the old implementation this failed: SaveMessage ran a MAX(ordinal)
+// scan, a WITH RECURSIVE seq walk, the message insert, one insert per content
+// block and the chat_update, all inside one SERIALIZABLE transaction. The
+// MAX-then-INSERT pattern takes an SSI predicate lock over the range being
+// inserted into, so concurrent savers aborted each other with
+// "could not serialize access due to read/write dependencies among
+// transactions", and the counter upsert added "could not serialize access due
+// to concurrent update" on top. Observed in a real session: 881 conflicts, 35
+// of which exhausted all seven retry attempts.
+//
+// It also pins the two invariants that made the naive fixes wrong:
+//
+//   - Every seq is UNIQUE. A lost update would hand the same number to two
+//     messages, which messages_chat_seq_key would reject — and if it did not,
+//     two messages would occupy one slot in the transcript.
+//   - Every seq is CONTIGUOUS. The client resumes with
+//     `WHERE sequence_number > cursor`, so a hole is indistinguishable from
+//     lost delivery and triggers a spurious resync.
+func TestSaveMessage_ConcurrentWritersSameChat(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.Close()
+	ctx := context.Background()
+
+	const (
+		writers            = 8
+		messagesPerWriter  = 5
+		expectedTotalSaved = writers * messagesPerWriter
+	)
+
+	// Each writer gets its own thread, exactly as parallel sub-workflows do,
+	// but they all share one chat.
+	threadIDs := make([]string, writers)
+	for i := range threadIDs {
+		thread, _ := h.createThread(fmt.Sprintf("concurrent-thread-%d", i), h.chatID)
+		threadIDs[i] = thread.ID
+	}
+
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		errs    []error
+		seqSeen []int64
+	)
+
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(threadID string, writerIdx int) {
+			defer wg.Done()
+			for m := 0; m < messagesPerWriter; m++ {
+				res, err := h.svc.SaveMessage(ctx, SaveMessageOpts{
+					ChatID:  h.chatID,
+					Thread:  threadID,
+					Role:    int32(reliantv1.MessageRole_MESSAGE_ROLE_ASSISTANT),
+					Content: fmt.Sprintf("writer %d message %d", writerIdx, m),
+				})
+				mu.Lock()
+				if err != nil {
+					errs = append(errs, err)
+				} else {
+					seqSeen = append(seqSeen, res.Ordinal)
+				}
+				mu.Unlock()
+			}
+		}(threadIDs[w], w)
+	}
+	wg.Wait()
+
+	// No serialization failure may reach the caller. Before the fix this is
+	// where the test failed, with SQLSTATE 40001 in the message.
+	if len(errs) > 0 {
+		serialization := 0
+		for _, err := range errs {
+			if strings.Contains(err.Error(), "40001") ||
+				strings.Contains(err.Error(), "could not serialize") {
+				serialization++
+			}
+		}
+		t.Fatalf("SaveMessage failed %d/%d times under %d concurrent writers (%d were serialization conflicts); first error: %v",
+			len(errs), expectedTotalSaved, writers, serialization, errs[0])
+	}
+
+	// Every message must exist exactly once, with a unique chat-global seq.
+	messages, err := h.repo.ListMessages(ctx, h.chatID, db.MessageListOptions{})
+	if err != nil {
+		t.Fatalf("failed to list messages: %v", err)
+	}
+	if len(messages) != expectedTotalSaved {
+		t.Fatalf("expected %d messages, got %d", expectedTotalSaved, len(messages))
+	}
+
+	seen := make(map[int64]string, len(messages))
+	for _, msg := range messages {
+		if prev, dup := seen[msg.Seq]; dup {
+			t.Errorf("seq %d assigned twice: messages %s and %s", msg.Seq, prev, msg.ID)
+		}
+		seen[msg.Seq] = msg.ID
+	}
+
+	// Contiguity: the client's resume cursor treats a hole as lost delivery.
+	for want := int64(0); want < int64(expectedTotalSaved); want++ {
+		if _, ok := seen[want]; !ok {
+			t.Errorf("seq %d missing — a gap makes the client resync spuriously", want)
+		}
+	}
+}
+
+// TestSaveMessage_ChatUpdateSequenceIsContiguous pins the ledger half of the
+// same invariant. The message rows can be perfect while the chat_updates
+// stream has holes, and it is the STREAM the client resumes from — a gap there
+// is what actually reaches the user as a message that never appears.
+func TestSaveMessage_ChatUpdateSequenceIsContiguous(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.Close()
+	ctx := context.Background()
+
+	const writers = 6
+	const messagesPerWriter = 4
+
+	threadIDs := make([]string, writers)
+	for i := range threadIDs {
+		thread, _ := h.createThread(fmt.Sprintf("cu-thread-%d", i), h.chatID)
+		threadIDs[i] = thread.ID
+	}
+
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(threadID string, writerIdx int) {
+			defer wg.Done()
+			for m := 0; m < messagesPerWriter; m++ {
+				if _, err := h.svc.SaveMessage(ctx, SaveMessageOpts{
+					ChatID:  h.chatID,
+					Thread:  threadID,
+					Role:    int32(reliantv1.MessageRole_MESSAGE_ROLE_ASSISTANT),
+					Content: fmt.Sprintf("w%d-m%d", writerIdx, m),
+				}); err != nil {
+					t.Errorf("SaveMessage failed: %v", err)
+					return
+				}
+			}
+		}(threadIDs[w], w)
+	}
+	wg.Wait()
+
+	updates, err := h.repo.GetUpdatesSince(ctx, h.chatID, 0, 1000)
+	if err != nil {
+		t.Fatalf("failed to read chat updates: %v", err)
+	}
+
+	want := writers * messagesPerWriter
+	if len(updates) < want {
+		t.Fatalf("expected at least %d chat_updates, got %d — updates were lost", want, len(updates))
+	}
+
+	for i := 1; i < len(updates); i++ {
+		prev := updates[i-1].SequenceNumber
+		cur := updates[i].SequenceNumber
+		if cur != prev+1 {
+			t.Errorf("chat_update sequence jumped %d -> %d; the client reads a gap as lost delivery", prev, cur)
+		}
+	}
+}

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -91,8 +91,25 @@ type Repository interface {
 	// Chat update operations
 	CreateChatUpdate(ctx context.Context, chatID string, updateType reliantv1.ChatUpdateType, entityID string, data string) error
 
+	// SaveMessageAtomic writes a message, its content blocks and its
+	// chat_update in one statement, allocating ordinal/seq from counters
+	// rather than scanning MAX(). This is the hot write path; see
+	// db.SaveMessageAtomic for why it is one statement and why it is safe at
+	// READ COMMITTED.
+	SaveMessageAtomic(ctx context.Context, w db.AtomicMessageWrite) (*db.AtomicMessageResult, error)
+
+	// SeedSeqCounterForFork raises a chat's seq allocator to cover history
+	// inherited through a fork chain, so a branch does not restart at 0 and
+	// sort its replies above the transcript it inherited.
+	SeedSeqCounterForFork(ctx context.Context, chatID, forkAtContextWindowID string) error
+
 	// Transaction support
 	RunTx(ctx context.Context, f func(ctx context.Context) error) error
+
+	// RunTxNoRetry runs one attempt with no retry ladder. Used by the
+	// concurrency control test to measure the raw conflict rate of the
+	// superseded allocator shape; production paths want RunTx.
+	RunTxNoRetry(ctx context.Context, f func(ctx context.Context) error) error
 }
 
 // Service provides centralized thread and context window management.

--- a/internal/threads/tool_result_attachments_test.go
+++ b/internal/threads/tool_result_attachments_test.go
@@ -19,35 +19,30 @@ import (
 // block the USER saw nothing but an id in a wall of tool-result text. These
 // tests pin the block that closes that gap.
 //
-// They drive createToolContentBlocks through a fake repository rather than the
+// They drive buildToolContentBlocks through a fake repository rather than the
 // package's Postgres harness. That harness t.Skip()s when DATABASE_URL is
 // unset, and a skipped test that reports "ok" is indistinguishable from a
 // passing one — every assertion below would silently vanish on a machine with
 // no database, which is exactly the machine this was written on.
+//
+// The builder RETURNS blocks rather than writing them — every block for a
+// message now goes in through one atomic statement so concurrent writers cannot
+// collide on seq. So these assert on the returned slice instead of on what the
+// fake recorded. The contract being pinned is unchanged: block types, dense
+// interleaved positions, and skip-don't-fail on an unusable attachment.
+// GetAttachment is still a real read, which is why the fake repo remains.
 
-// fakeBlockRepo records content blocks in memory and serves attachment
-// metadata from a fixed map. It embeds Repository so the many methods this
-// path never calls do not have to be spelled out; calling one panics loudly
-// rather than passing silently.
+// fakeBlockRepo serves attachment metadata from a fixed map. It embeds
+// Repository so the many methods this path never calls do not have to be
+// spelled out; calling one panics loudly rather than passing silently.
 type fakeBlockRepo struct {
 	Repository
-	blocks      []*db.MessageContentBlock
 	attachments map[string]*db.Attachment
 	getErr      error
-	createErr   error
 }
 
 func newFakeBlockRepo() *fakeBlockRepo {
 	return &fakeBlockRepo{attachments: map[string]*db.Attachment{}}
-}
-
-func (r *fakeBlockRepo) CreateContentBlock(ctx context.Context, block *db.MessageContentBlock) error {
-	if r.createErr != nil {
-		return r.createErr
-	}
-	copied := *block
-	r.blocks = append(r.blocks, &copied)
-	return nil
 }
 
 func (r *fakeBlockRepo) GetAttachment(ctx context.Context, id string) (*db.Attachment, error) {
@@ -77,7 +72,7 @@ func TestToolResultAttachments_MaterializeImageBlocks(t *testing.T) {
 	svc := NewService(repo)
 	timestamp := time.Now().UTC()
 
-	err := svc.createToolContentBlocks(context.Background(), "msg-1", SaveMessageOpts{
+	blocks, err := svc.buildToolContentBlocks(context.Background(), "msg-1", SaveMessageOpts{
 		ToolResults: []ToolResult{{
 			ToolCallID:    "toolu_1",
 			Name:          "generate_image",
@@ -87,15 +82,15 @@ func TestToolResultAttachments_MaterializeImageBlocks(t *testing.T) {
 	}, timestamp)
 	require.NoError(t, err)
 
-	require.Len(t, repo.blocks, 2, "expected the tool_result block plus a sibling image block")
+	require.Len(t, blocks, 2, "expected the tool_result block plus a sibling image block")
 
-	resultBlock := repo.blocks[0]
+	resultBlock := blocks[0]
 	assert.Equal(t, reliantv1.ContentBlockType_CONTENT_BLOCK_TYPE_TOOL_RESULT, resultBlock.BlockType)
 	assert.Equal(t, 0, resultBlock.Position)
 	require.NotNil(t, resultBlock.ToolCallID)
 	assert.Equal(t, "toolu_1", *resultBlock.ToolCallID)
 
-	imageBlock := repo.blocks[1]
+	imageBlock := blocks[1]
 	assert.Equal(t, reliantv1.ContentBlockType_CONTENT_BLOCK_TYPE_IMAGE, imageBlock.BlockType,
 		"a generated image must render through the same block type an uploaded one does")
 	require.NotNil(t, imageBlock.Content)
@@ -113,7 +108,7 @@ func TestToolResultAttachments_PositionsInterleaveWithResults(t *testing.T) {
 	repo := newFakeBlockRepo().withImage("att-a").withImage("att-b")
 	svc := NewService(repo)
 
-	err := svc.createToolContentBlocks(context.Background(), "msg-2", SaveMessageOpts{
+	blocks, err := svc.buildToolContentBlocks(context.Background(), "msg-2", SaveMessageOpts{
 		ToolResults: []ToolResult{
 			{ToolCallID: "toolu_1", Name: "generate_image", Content: "one", AttachmentIDs: []string{"att-a"}},
 			{ToolCallID: "toolu_2", Name: "bash", Content: "no attachments here"},
@@ -122,14 +117,14 @@ func TestToolResultAttachments_PositionsInterleaveWithResults(t *testing.T) {
 	}, time.Now().UTC())
 	require.NoError(t, err)
 
-	require.Len(t, repo.blocks, 5)
+	require.Len(t, blocks, 5)
 
 	type blockShape struct {
 		blockType reliantv1.ContentBlockType
 		position  int
 	}
-	actual := make([]blockShape, 0, len(repo.blocks))
-	for _, block := range repo.blocks {
+	actual := make([]blockShape, 0, len(blocks))
+	for _, block := range blocks {
 		actual = append(actual, blockShape{block.BlockType, block.Position})
 	}
 
@@ -150,13 +145,13 @@ func TestToolResultAttachments_NoAttachmentsIsUnchanged(t *testing.T) {
 	repo := newFakeBlockRepo()
 	svc := NewService(repo)
 
-	err := svc.createToolContentBlocks(context.Background(), "msg-3", SaveMessageOpts{
+	blocks, err := svc.buildToolContentBlocks(context.Background(), "msg-3", SaveMessageOpts{
 		ToolResults: []ToolResult{{ToolCallID: "toolu_1", Name: "bash", Content: "hello"}},
 	}, time.Now().UTC())
 	require.NoError(t, err)
 
-	require.Len(t, repo.blocks, 1)
-	assert.Equal(t, reliantv1.ContentBlockType_CONTENT_BLOCK_TYPE_TOOL_RESULT, repo.blocks[0].BlockType)
+	require.Len(t, blocks, 1)
+	assert.Equal(t, reliantv1.ContentBlockType_CONTENT_BLOCK_TYPE_TOOL_RESULT, blocks[0].BlockType)
 }
 
 // A missing, unreadable or non-image attachment must not fail the save. The
@@ -193,7 +188,7 @@ func TestToolResultAttachments_UnusableAttachmentIsSkippedNotFatal(t *testing.T)
 			tc.setup(repo)
 			svc := NewService(repo)
 
-			err := svc.createToolContentBlocks(context.Background(), "msg-4", SaveMessageOpts{
+			blocks, err := svc.buildToolContentBlocks(context.Background(), "msg-4", SaveMessageOpts{
 				ToolResults: []ToolResult{{
 					ToolCallID:    "toolu_1",
 					Name:          "generate_image",
@@ -203,8 +198,8 @@ func TestToolResultAttachments_UnusableAttachmentIsSkippedNotFatal(t *testing.T)
 			}, time.Now().UTC())
 			require.NoError(t, err, "an unusable attachment must not discard a completed turn")
 
-			require.Len(t, repo.blocks, 1, "only the tool_result block should be written")
-			assert.Equal(t, reliantv1.ContentBlockType_CONTENT_BLOCK_TYPE_TOOL_RESULT, repo.blocks[0].BlockType)
+			require.Len(t, blocks, 1, "only the tool_result block should be built")
+			assert.Equal(t, reliantv1.ContentBlockType_CONTENT_BLOCK_TYPE_TOOL_RESULT, blocks[0].BlockType)
 		})
 	}
 }

--- a/internal/workersetup/setup.go
+++ b/internal/workersetup/setup.go
@@ -26,11 +26,11 @@ import (
 
 // maxHeartbeatThrottleInterval is worker.Options.MaxHeartbeatThrottleInterval.
 // Pulled out as a named constant, rather than inlined in workerOpts below, so
-// TestMaxHeartbeatThrottleIntervalStaysLow can pin it: this value alone
-// determines how fast a pending Temporal cancellation reaches a running
-// activity (see the comment on its use below), so raising it silently raises
-// user-visible cancel latency.
-const maxHeartbeatThrottleInterval = 500 * time.Millisecond
+// TestMaxHeartbeatThrottleInterval can pin it: this one value sets BOTH the
+// heartbeat RPC's own deadline and how fast a pending Temporal cancellation
+// reaches a running activity, and those two pull in opposite directions. See
+// the comment on its use below before changing it.
+const maxHeartbeatThrottleInterval = 2 * time.Second
 
 // Config holds the dependencies needed to create and start a Temporal worker.
 type Config struct {
@@ -119,32 +119,46 @@ func StartWorker(cfg *Config) (*Handle, *v2.ActivityRegistry, error) {
 		// Verified against SDK v1.37.0 and v1.47.0 source; see
 		// specs/fast-cancel-briefing.md for the full trace.
 		//
-		// This value was previously raised from 500ms to 3s to fix activities
-		// dying with "context canceled" mid-flight. That fix targeted the wrong
-		// mechanism: it assumed this value was ALSO the heartbeat RPC's
-		// deadline, floored at minRPCTimeout=1s (internal_task_handlers.go
+		// This value is ALSO the heartbeat RPC's own deadline, and that is the
+		// budget that actually breaks under load (internal_task_handlers.go
 		// internalHeartBeat):
 		//
 		//	recordTimeout := i.heartbeatThrottleInterval
 		//	if recordTimeout < minRPCTimeout { recordTimeout = minRPCTimeout }
 		//	ctx, cancel := context.WithTimeout(ctx, recordTimeout)
 		//
-		// But the floor means the deadline was ALREADY 1s at 500ms — raising
-		// this to 3s never widened that 1s budget at all, and could not have
-		// fixed the reported deaths. (The RPC failures were more likely
-		// symptomatic of a genuinely overloaded Temporal server; see
-		// spuriousHeartbeatCancel below for the real backstop.) What raising it
-		// DID do was directly add 2.5s of avoidable cancel latency, since this
-		// value is the sole determinant of how fast a cancel reaches a running
-		// activity.
+		// So the per-heartbeat budget is max(thisValue, minRPCTimeout=1s). An
+		// earlier revision set this to 500ms and justified it with the claim
+		// that the 1s floor made the budget insensitive to this value — that
+		// the previous 3s setting "never widened that 1s budget at all". That
+		// reading is WRONG: the floor only applies BELOW 1s. At 3s the budget
+		// is 3s. The revert therefore narrowed a 3s budget to 1s while
+		// believing it changed nothing, and it undid a fix that had been
+		// correctly targeted at this exact failure.
 		//
-		// Restored to 500ms: cancel latency for this path now matches
-		// activityHeartbeatInterval instead of being 6x slower than it, and the
-		// per-RPC deadline is unchanged (still floored to 1s). The only real
-		// cost is 6x more heartbeat RPCs per activity, which raises the odds
-		// that any single one is slow — spuriousHeartbeatCancel exists
-		// specifically to absorb that and convert it to a retry rather than a
-		// user-visible cancellation.
+		// The consequence, measured: 872 "RecordActivityHeartbeat with error /
+		// context deadline exceeded" in a single day's worker log, arriving in
+		// bursts of 50-60 per minute whenever the shared Postgres behind
+		// Temporal got busy. Each one cancels a healthy activity mid-stream.
+		// Chat ee527bdd lost all five of a step's retry attempts inside one
+		// burst and auto-paused.
+		//
+		// Raised to 2s, which doubles the RPC budget that was being blown. The
+		// cost is real and is the reason this is not higher: this value is the
+		// sole determinant of how fast a cancel reaches a running activity, so
+		// pause and interrupt now take up to 2s instead of 500ms.
+		//
+		// Do NOT try to fix heartbeat RPC failures by LOWERING a timeout. The
+		// budget is a max() with a 1s floor, so it only moves upward. Lowering
+		// HeartbeatTimeout (registry.go) to squeeze the 0.8x derivation is
+		// worse than useless: it cannot widen this budget, and it shortens the
+		// window before Temporal declares a live worker dead and re-dispatches
+		// its activities — which during one of these bursts means ExecuteTools
+		// running the same shell commands and file edits twice.
+		//
+		// spuriousHeartbeatCancel (workflow/runtime/registry.go) remains the
+		// backstop that converts whatever still slips through into a retry
+		// rather than a user-visible cancellation.
 		MaxHeartbeatThrottleInterval: maxHeartbeatThrottleInterval,
 		BuildID:                      v2workflow.WorkerBuildID,
 		// Set explicitly rather than inherited from the client, so the identity

--- a/internal/workersetup/setup_test.go
+++ b/internal/workersetup/setup_test.go
@@ -6,17 +6,41 @@ import (
 	"time"
 )
 
-// Temporal delivers a pending activity cancellation ONLY in a heartbeat RPC's
-// response, and the SDK swallows any heartbeat that lands inside an open
-// batching window entirely locally (no RPC, no cancellation check). So this
-// value alone is the worker's cancel latency for any activity relying on the
-// background heartbeater — raising it directly and silently raises how long a
-// user waits for pause/interrupt to take effect. This test exists so that
-// change requires touching this file, not a quiet edit to workerOpts.
-func TestMaxHeartbeatThrottleIntervalStaysLow(t *testing.T) {
-	const want = 500 * time.Millisecond
+// This one value sets two things that pull in opposite directions, which is why
+// it is pinned rather than left to be tuned by feel.
+//
+//  1. The heartbeat RPC's own deadline, as max(value, minRPCTimeout=1s)
+//     (internal_task_handlers.go internalHeartBeat). Too LOW and a busy
+//     Temporal server blows the deadline, the SDK cancels a healthy activity
+//     mid-stream, and the step burns a retry attempt. That is a measured
+//     failure mode here, not a hypothetical: 872 in one day at 500ms.
+//  2. The worker's activity cancel latency. Temporal delivers a pending
+//     cancellation ONLY in a heartbeat RPC's response, and the SDK swallows
+//     any heartbeat landing inside an open batching window entirely locally
+//     (no RPC, no cancellation check). Too HIGH and the user waits that long
+//     for pause/interrupt to take effect.
+//
+// The trap this test exists to prevent: a previous change read the 1s floor as
+// making (1) insensitive to this value and reverted 3s to 500ms believing the
+// RPC budget was unaffected. The floor only applies BELOW 1s — the revert
+// really did narrow a 3s budget to 1s, and re-broke what the 3s had fixed.
+func TestMaxHeartbeatThrottleInterval(t *testing.T) {
+	const want = 2 * time.Second
 	if maxHeartbeatThrottleInterval != want {
-		t.Errorf("maxHeartbeatThrottleInterval = %v, want %v; this value is the worker's activity cancel latency (see comment on its use in setup.go) — if you're intentionally raising it, update this test and the comment together and confirm the latency tradeoff is intended",
+		t.Errorf("maxHeartbeatThrottleInterval = %v, want %v; this value is BOTH the heartbeat RPC deadline and the activity cancel latency (see comment on its use in setup.go) — if you're intentionally changing it, update this test and the comment together and confirm both tradeoffs are intended",
 			maxHeartbeatThrottleInterval, want)
+	}
+
+	// Pin the floor interaction itself, since misreading it is what caused the
+	// regression this test documents. Lowering the constant below 1s does not
+	// buy a tighter RPC deadline — it only costs cancel latency headroom.
+	const minRPCTimeout = time.Second
+	budget := maxHeartbeatThrottleInterval
+	if budget < minRPCTimeout {
+		budget = minRPCTimeout
+	}
+	if budget <= minRPCTimeout {
+		t.Errorf("effective heartbeat RPC budget = %v, which is still at the %v floor; the whole point of this constant's current value is to widen that budget beyond the floor",
+			budget, minRPCTimeout)
 	}
 }

--- a/internal/workflow/runtime/error_reporting_test.go
+++ b/internal/workflow/runtime/error_reporting_test.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2025 Reliant Labs
+package runtime
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
+)
+
+// TestResolveMaxAttempts_InlineSaveMessage is the regression test for the
+// "Attempt 1" red card.
+//
+// A SaveMessage failure rendered in the transcript as a TERMINAL error reading
+// "Attempt 1" while Temporal still had four retries left. The cause: inline
+// SaveMessage is dispatched with MaximumAttempts 5 but sets a 30s
+// StartToCloseTimeout and NO heartbeat, so it missed resolveMaxAttempts'
+// signature match on the graph-step timeout shape and resolved to 0. Zero makes
+// activityIsRetrying return false, so is_retrying went out false and the UI drew
+// a dead error for a failure that was about to be retried.
+func TestResolveMaxAttempts_InlineSaveMessage(t *testing.T) {
+	// Exactly what executeSaveMessageInline dispatches: no heartbeat, 30s
+	// start-to-close, and (as the SDK reports in practice) no retry policy.
+	info := activity.Info{
+		ActivityType:        activity.Type{Name: "SaveMessage"},
+		StartToCloseTimeout: 30 * time.Second,
+	}
+
+	got := resolveMaxAttempts(info)
+
+	if got == 0 {
+		t.Fatal("resolveMaxAttempts returned 0 for inline SaveMessage; " +
+			"0 makes activityIsRetrying false, which renders a retryable failure " +
+			"as a terminal red error in the transcript")
+	}
+	if got != inlineSaveMessageMaxAttempts {
+		t.Errorf("expected %d attempts (what save_message.go dispatches), got %d",
+			inlineSaveMessageMaxAttempts, got)
+	}
+
+	// The behaviour that actually reached the user.
+	if !activityIsRetrying(1, got, errors.New("could not serialize access (SQLSTATE 40001)")) {
+		t.Error("attempt 1 of a 5-attempt ladder must report is_retrying=true")
+	}
+	// And the other end of the ladder must still read as terminal.
+	if activityIsRetrying(5, got, errors.New("could not serialize access (SQLSTATE 40001)")) {
+		t.Error("the final attempt must not report is_retrying=true")
+	}
+}
+
+// TestResolveMaxAttempts_ServerPolicyWins keeps the authoritative source
+// authoritative: whatever the server reports beats every local inference.
+func TestResolveMaxAttempts_ServerPolicyWins(t *testing.T) {
+	info := activity.Info{
+		ActivityType:        activity.Type{Name: "SaveMessage"},
+		StartToCloseTimeout: 30 * time.Second,
+		RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 9},
+	}
+
+	if got := resolveMaxAttempts(info); got != 9 {
+		t.Errorf("server-reported policy must win; expected 9, got %d", got)
+	}
+}
+
+// TestResolveMaxAttempts_GraphStepAndRouter pins the one genuinely ambiguous
+// case: CallLLM runs on two different ladders depending on who dispatched it,
+// and the router's fixed start-to-close is what tells them apart.
+func TestResolveMaxAttempts_GraphStepAndRouter(t *testing.T) {
+	graphStep := activity.Info{
+		ActivityType:        activity.Type{Name: "CallLLM"},
+		HeartbeatTimeout:    activityHeartbeatTimeout,
+		StartToCloseTimeout: 10 * time.Minute,
+	}
+	if got := resolveMaxAttempts(graphStep); got != stepActivityMaxAttempts {
+		t.Errorf("graph step: expected %d, got %d", stepActivityMaxAttempts, got)
+	}
+
+	router := activity.Info{
+		ActivityType:        activity.Type{Name: "CallLLM"},
+		HeartbeatTimeout:    activityHeartbeatTimeout,
+		StartToCloseTimeout: routerActivityStartToClose,
+	}
+	if got := resolveMaxAttempts(router); got != infrastructureActivityMaxAttempts {
+		t.Errorf("router dispatch: expected %d, got %d", infrastructureActivityMaxAttempts, got)
+	}
+}
+
+// TestExtractInfrastructureSummary_HidesRawSQLSTATE is the regression test for
+// the error card the user screenshotted: four layers of Go wrapping around a
+// Postgres error code, shown verbatim for a failure the system retries itself.
+func TestExtractInfrastructureSummary_HidesRawSQLSTATE(t *testing.T) {
+	// The exact string from the transcript.
+	raw := "failed to save message: failed to create chat_update: failed to get " +
+		"next sequence number: allocate chat update sequence: ERROR: could not " +
+		"serialize access due to concurrent update (SQLSTATE 40001)"
+
+	summary := extractLLMErrorSummary(raw)
+
+	if summary == "" {
+		t.Fatal("a serialization failure must produce a summary; without one the UI " +
+			"falls back to the raw wrap chain, which is what users saw")
+	}
+	if strings.Contains(summary, "SQLSTATE") || strings.Contains(summary, "40001") {
+		t.Errorf("summary still leaks the SQLSTATE: %q", summary)
+	}
+	if strings.Contains(strings.ToLower(summary), "chat_update") {
+		t.Errorf("summary leaks internal table names: %q", summary)
+	}
+	// It must say it is self-correcting — that is the part that tells the user
+	// whether to wait or to act.
+	if !strings.Contains(strings.ToLower(summary), "retr") {
+		t.Errorf("summary should say the system is retrying; got %q", summary)
+	}
+}
+
+func TestExtractInfrastructureSummary_Classifications(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      string
+		wantPart string
+	}{
+		{"deadlock", "ERROR: deadlock detected (SQLSTATE 40P01)", "retrying"},
+		{"cancellation", "failed to load: context canceled", "Stopped"},
+		{"bad connection", "driver: bad connection", "database connection"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractLLMErrorSummary(tc.err)
+			if got == "" {
+				t.Fatalf("expected a summary for %q", tc.err)
+			}
+			if !strings.Contains(got, tc.wantPart) {
+				t.Errorf("summary %q does not mention %q", got, tc.wantPart)
+			}
+			if strings.Contains(got, "SQLSTATE") {
+				t.Errorf("summary leaks SQLSTATE: %q", got)
+			}
+		})
+	}
+}
+
+// TestExtractLLMErrorSummary_ProviderErrorsStillWin guards the ordering: adding
+// infrastructure classification must not swallow the provider summaries that
+// were already working.
+func TestExtractLLMErrorSummary_ProviderErrorsStillWin(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      string
+		wantPart string
+	}{
+		{"overloaded", `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`, "overloaded"},
+		{"rate limit", "429 rate limit exceeded", "Rate limited"},
+		{"network", "dial tcp 1.2.3.4:443: no such host", "Cannot reach"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractLLMErrorSummary(tc.err)
+			if !strings.Contains(strings.ToLower(got), strings.ToLower(tc.wantPart)) {
+				t.Errorf("expected summary containing %q, got %q", tc.wantPart, got)
+			}
+		})
+	}
+}

--- a/internal/workflow/runtime/error_summary.go
+++ b/internal/workflow/runtime/error_summary.go
@@ -170,6 +170,48 @@ func extractProviderReconnectSummary(errLower string) string {
 	}
 }
 
+// extractInfrastructureSummary describes a failure in OUR storage layer rather
+// than at the provider.
+//
+// This exists because the transcript showed users this, verbatim, in a red
+// error card:
+//
+//	failed to save message: failed to create chat_update: failed to get next
+//	sequence number: allocate chat update sequence: ERROR: could not serialize
+//	access due to concurrent update (SQLSTATE 40001)
+//
+// Four layers of Go wrapping and a Postgres error code, describing a transient
+// write conflict the system retries on its own. Nothing in that string is
+// actionable, and its prominence implies the user's work was lost when it
+// almost certainly was not.
+//
+// Each summary names what happened in the user's terms AND whether it is
+// self-correcting, because that is the distinction that decides whether they
+// should wait or intervene. A generic "something went wrong" would hide
+// exactly that.
+func extractInfrastructureSummary(errLower string) string {
+	switch {
+	case strings.Contains(errLower, "sqlstate 40001"),
+		strings.Contains(errLower, "sqlstate 40p01"),
+		strings.Contains(errLower, "could not serialize"),
+		strings.Contains(errLower, "deadlock detected"):
+		return "Busy saving several things at once — retrying automatically"
+
+	case strings.Contains(errLower, "context canceled"):
+		return "Stopped before this step finished"
+
+	case strings.Contains(errLower, "driver: bad connection"):
+		return "Lost the database connection — retrying automatically"
+	}
+
+	// Deliberately NOT handled here: "context deadline exceeded" and bare
+	// "timeout". Both are far more often a provider transport failure than a
+	// storage one, and isNetworkFailure / the provider patterns below already
+	// classify them correctly — claiming them here would relabel a real
+	// network diagnosis as a database problem and send the user the wrong way.
+	return ""
+}
+
 // extractLLMErrorSummary extracts a clean, user-friendly error summary from a
 // potentially deeply-nested error string. It looks for embedded JSON error payloads
 // from LLM APIs (e.g. Anthropic's {"type":"error","error":{"type":"overloaded_error",...}})
@@ -178,6 +220,14 @@ func extractProviderReconnectSummary(errLower string) string {
 // Returns an empty string if no recognizable LLM error is found.
 func extractLLMErrorSummary(errMsg string) string {
 	errLower := strings.ToLower(errMsg)
+
+	// Infrastructure failures first. They are not provider errors at all, and
+	// the provider-shaped patterns below would mis-describe them — a 40001
+	// contains "serialize", not "rate limit", so it would fall through every
+	// branch and reach the user as the raw wrap chain.
+	if summary := extractInfrastructureSummary(errLower); summary != "" {
+		return summary
+	}
 
 	// Before anything else: if the request never reached the provider, no
 	// provider-specific claim about it can be true.

--- a/internal/workflow/runtime/heartbeat_ladder.go
+++ b/internal/workflow/runtime/heartbeat_ladder.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2025 Reliant Labs
+package runtime
+
+import (
+	"errors"
+
+	"go.temporal.io/sdk/temporal"
+)
+
+// heartbeatCancelErrorType is the ApplicationError type ActivityWrapper stamps
+// on a step that was killed by a failed heartbeat RPC rather than by anything
+// wrong with the step itself. See spuriousHeartbeatCancel (registry.go).
+const heartbeatCancelErrorType = "HeartbeatCancel"
+
+// maxHeartbeatLadderRestarts bounds how many times a single step may be handed
+// a FRESH retry ladder because its previous ladder was consumed entirely by
+// heartbeat failures.
+//
+// A bound is required: without one, a Temporal server that is down rather than
+// merely busy would have the step re-dispatch forever, which is the livelock
+// the auto-pause exists to prevent. With it, a step gets
+// stepActivityMaxAttempts*(1+maxHeartbeatLadderRestarts) attempts against pure
+// infrastructure failure before the chat pauses and asks the user.
+//
+// Sized against measured burst duration. The 2026-09-11 bursts ran 3-5 minutes;
+// one ladder spans roughly 15s of backoff (1+2+4+8), so three extra ladders
+// plus the original covers about a minute of continuous failure. Beyond that,
+// something is genuinely wrong and pausing to tell the user is the honest
+// outcome rather than spinning silently.
+const maxHeartbeatLadderRestarts = 3
+
+// heartbeatCancelExhausted reports whether a retry-exhausted step ran out of
+// attempts because of failed heartbeat RPCs rather than because the work itself
+// failed.
+//
+// This distinction is the difference between a chat that rides out a slow
+// Temporal server and one that stops dead in front of the user. A heartbeat
+// cancel means the activity was HEALTHY — it was streaming tokens — and the
+// SDK killed its context because one round trip to the Temporal server missed
+// a 1-2s deadline. Spending the step's whole 5-attempt budget on that, then
+// auto-pausing, is how chat ee527bdd died: all five attempts landed inside one
+// 60-failure burst, none of them for a reason the model or the user could act
+// on.
+//
+// A real failure — a rate limit, a bad request, a provider outage — still
+// pauses on the first exhausted ladder, because retrying those harder does not
+// make them succeed and the user needs to be told.
+func heartbeatCancelExhausted(err error) bool {
+	if err == nil {
+		return false
+	}
+	var appErr *temporal.ApplicationError
+	if !errors.As(err, &appErr) {
+		return false
+	}
+	return appErr.Type() == heartbeatCancelErrorType
+}
+
+// ladderRestarts counts fresh retry ladders granted per step, so the bound in
+// maxHeartbeatLadderRestarts is enforced per step rather than per workflow.
+//
+// Determinism: the zero value is usable and every mutation is driven by
+// activity completions the workflow already observes in a fixed replay order,
+// so the counter reconstructs identically on replay.
+type ladderRestarts map[string]int
+
+// grantRestart reports whether stepID may be re-dispatched with a fresh ladder,
+// recording the grant when it returns true.
+func (r *ladderRestarts) grantRestart(stepID string) bool {
+	if *r == nil {
+		*r = make(ladderRestarts)
+	}
+	if (*r)[stepID] >= maxHeartbeatLadderRestarts {
+		return false
+	}
+	(*r)[stepID]++
+	return true
+}
+
+// clear forgets a step's restart history once it succeeds, so a long chat that
+// hits an unrelated burst hours later gets the full allowance again rather than
+// inheriting a spent one.
+func (r *ladderRestarts) clear(stepID string) {
+	if *r != nil {
+		delete(*r, stepID)
+	}
+}

--- a/internal/workflow/runtime/heartbeat_ladder_behavior_test.go
+++ b/internal/workflow/runtime/heartbeat_ladder_behavior_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2025 Reliant Labs
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The decision the three executors actually make on a retry-exhausted step:
+// re-dispatch with a fresh ladder, or pause the chat and tell the user.
+//
+// This models that branch directly — the real sites are inside ~200-line
+// select loops in DynamicWorkflow, InlineLoopExecutor and
+// InlineWorkflowExecutor that need a full workflow environment, a chat, a
+// provider and a database to reach. What decides the outcome there is exactly
+// the conjunction below, so pinning it here pins the behavior that failed for
+// chat ee527bdd, and does it in milliseconds.
+//
+// Kept in lockstep with the three call sites by
+// TestRetryExhaustionSitesShareOneDecision, which greps them.
+func retryExhaustedAction(restarts *ladderRestarts, stepID string, err error) string {
+	if heartbeatCancelExhausted(err) && restarts.grantRestart(stepID) {
+		return "redispatch"
+	}
+	return "pause"
+}
+
+// Chat ee527bdd's five CallLLM attempts were all killed by heartbeat RPC
+// failures inside a single burst — the stream was healthy every time, and the
+// chat still auto-paused showing the user a Temporal deadline error. After this
+// change the step keeps going, and only pauses if the burst outlasts the bound.
+func TestHeartbeatExhaustionRedispatchesInsteadOfPausing(t *testing.T) {
+	t.Parallel()
+
+	heartbeatErr := exhaustedErrorOfType(t, heartbeatCancelErrorType,
+		"heartbeat RPC failed while running CallLLM; retrying")
+
+	t.Run("a heartbeat burst re-dispatches rather than pausing", func(t *testing.T) {
+		var restarts ladderRestarts
+		assert.Equal(t, "redispatch", retryExhaustedAction(&restarts, "call_llm", heartbeatErr),
+			"this is the exact case that paused chat ee527bdd")
+	})
+
+	t.Run("a sustained outage still pauses once the bound is spent", func(t *testing.T) {
+		var restarts ladderRestarts
+		for i := range maxHeartbeatLadderRestarts {
+			require.Equal(t, "redispatch", retryExhaustedAction(&restarts, "call_llm", heartbeatErr),
+				"restart %d should still be granted", i+1)
+		}
+		assert.Equal(t, "pause", retryExhaustedAction(&restarts, "call_llm", heartbeatErr),
+			"a Temporal server that is down must eventually pause, not spin forever")
+	})
+
+	t.Run("a real provider failure pauses immediately", func(t *testing.T) {
+		rateLimited := exhaustedErrorOfType(t, "RateLimitError", "429 Too Many Requests")
+		var restarts ladderRestarts
+		assert.Equal(t, "pause", retryExhaustedAction(&restarts, "call_llm", rateLimited),
+			"retrying a rate limit harder does not make it succeed")
+	})
+
+	t.Run("a recovered step regains its full allowance", func(t *testing.T) {
+		var restarts ladderRestarts
+		for range maxHeartbeatLadderRestarts {
+			require.Equal(t, "redispatch", retryExhaustedAction(&restarts, "call_llm", heartbeatErr))
+		}
+		require.Equal(t, "pause", retryExhaustedAction(&restarts, "call_llm", heartbeatErr))
+
+		// The step later succeeds; the executors call clear() on that path.
+		restarts.clear("call_llm")
+
+		assert.Equal(t, "redispatch", retryExhaustedAction(&restarts, "call_llm", heartbeatErr),
+			"a burst hours later must not inherit an allowance spent this morning")
+	})
+}

--- a/internal/workflow/runtime/heartbeat_ladder_sites_test.go
+++ b/internal/workflow/runtime/heartbeat_ladder_sites_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 Reliant Labs
+package runtime
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Three separate executors decide what happens to a retry-exhausted step, and
+// they must decide it the same way: DynamicWorkflow (workflow.go),
+// InlineLoopExecutor (loop_executor.go) and InlineWorkflowExecutor
+// (inline_workflow_executor.go). A plain agent loop runs through one, a loop
+// node through another, a nested workflow node through the third — so a fix
+// applied to only one produces a chat that survives a heartbeat burst at the
+// top level and dies inside a sub-workflow, which is indistinguishable from
+// flakiness.
+//
+// That has happened before in exactly these files: see the comment in
+// inline_workflow_executor.go about pause handling being added to the loop
+// executor but not the inline one, "which is why a plain agent loop paused
+// correctly and only nested workflow nodes regressed."
+//
+// This is a source check rather than a behavioral one because reaching the
+// three sites for real needs a workflow environment, a chat, a provider and a
+// database each. It cannot prove they behave identically; it proves nobody
+// removed the guard from one of them, which is the failure that actually
+// happens.
+func TestRetryExhaustionSitesShareOneDecision(t *testing.T) {
+	t.Parallel()
+
+	sites := []struct {
+		file   string
+		execur string
+	}{
+		{"workflow.go", "DynamicWorkflow"},
+		{"loop_executor.go", "InlineLoopExecutor"},
+		{"inline_workflow_executor.go", "InlineWorkflowExecutor"},
+	}
+
+	for _, site := range sites {
+		t.Run(site.file, func(t *testing.T) {
+			src, err := os.ReadFile(site.file)
+			require.NoError(t, err)
+			text := string(src)
+
+			require.Contains(t, text, "heartbeatCancelExhausted(stepEvent.Error)",
+				"%s (%s) must classify a heartbeat-exhausted ladder before pausing; "+
+					"without it a heartbeat burst pauses the chat with an error the user cannot act on",
+				site.file, site.execur)
+
+			require.Contains(t, text, "grantRestart(running.StepID)",
+				"%s (%s) must bound its re-dispatches; an unbounded restart livelocks "+
+					"the chat when Temporal is genuinely down", site.file, site.execur)
+
+			require.True(t, strings.Contains(text, "heartbeatRestarts.clear("),
+				"%s (%s) must clear a step's allowance once it succeeds, or a long chat "+
+					"inherits an allowance spent hours earlier", site.file, site.execur)
+		})
+	}
+}

--- a/internal/workflow/runtime/heartbeat_ladder_test.go
+++ b/internal/workflow/runtime/heartbeat_ladder_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2025 Reliant Labs
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+// exhaustedErrorOfType returns the error a workflow REALLY observes when an
+// activity's ladder runs out, for an activity that fails with the given
+// ApplicationError type.
+//
+// Built by running a failing activity in the Temporal test environment rather
+// than by hand: heartbeatCancelExhausted has to see through the *ActivityError
+// wrapper Temporal puts around the cause, and a synthetic stand-in would prove
+// only that the test and the code agree with each other.
+func exhaustedErrorOfType(t *testing.T, errType, msg string) error {
+	t.Helper()
+
+	var ts testsuite.WorkflowTestSuite
+	env := ts.NewTestWorkflowEnvironment()
+
+	failing := func(context.Context) error {
+		return temporal.NewApplicationError(msg, errType)
+	}
+	env.RegisterActivityWithOptions(failing, activity.RegisterOptions{Name: "AlwaysFails"})
+
+	env.ExecuteWorkflow(func(ctx workflow.Context) error {
+		ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+			StartToCloseTimeout: activityHeartbeatTimeout,
+			RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 2},
+		})
+		return workflow.ExecuteActivity(ctx, "AlwaysFails").Get(ctx, nil)
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	err := env.GetWorkflowError()
+	require.Error(t, err, "the activity must actually exhaust its ladder")
+	return err
+}
+
+// A step whose ladder was consumed by heartbeat RPC failures must be
+// distinguishable from one that failed for a real reason. The first is
+// infrastructure noise against a HEALTHY activity and deserves a fresh ladder;
+// the second needs to reach the user.
+//
+// This is the classification that decided chat ee527bdd: five attempts landed
+// inside one burst of heartbeat failures and the chat auto-paused with an error
+// naming a Temporal deadline, which is not something its user could act on.
+func TestHeartbeatCancelExhausted(t *testing.T) {
+	t.Parallel()
+
+	t.Run("heartbeat cancel is recognized through the ActivityError wrapper", func(t *testing.T) {
+		err := exhaustedErrorOfType(t, heartbeatCancelErrorType,
+			"heartbeat RPC failed while running CallLLM; retrying")
+		assert.True(t, heartbeatCancelExhausted(err),
+			"a ladder spent on heartbeat failures must be recognized so the step gets a fresh one")
+	})
+
+	t.Run("a real provider failure is not a heartbeat cancel", func(t *testing.T) {
+		err := exhaustedErrorOfType(t, "RateLimitError", "429 Too Many Requests")
+		assert.False(t, heartbeatCancelExhausted(err),
+			"retrying a rate limit harder does not make it succeed; the user must be told")
+	})
+
+	t.Run("worker shutdown is not a heartbeat cancel", func(t *testing.T) {
+		err := exhaustedErrorOfType(t, "WorkerShutdown", "worker shut down while running CallLLM")
+		assert.False(t, heartbeatCancelExhausted(err))
+	})
+
+	t.Run("nil and plain errors are not heartbeat cancels", func(t *testing.T) {
+		assert.False(t, heartbeatCancelExhausted(nil))
+		assert.False(t, heartbeatCancelExhausted(errors.New("context deadline exceeded")))
+	})
+}
+
+// The restart allowance is what keeps a genuinely-down Temporal server from
+// livelocking a chat forever, so the bound has to actually bind.
+func TestLadderRestartsBound(t *testing.T) {
+	t.Parallel()
+
+	t.Run("grants exactly maxHeartbeatLadderRestarts then stops", func(t *testing.T) {
+		var restarts ladderRestarts
+		for i := range maxHeartbeatLadderRestarts {
+			assert.True(t, restarts.grantRestart("call_llm"),
+				"restart %d of %d should be granted", i+1, maxHeartbeatLadderRestarts)
+		}
+		assert.False(t, restarts.grantRestart("call_llm"),
+			"past the bound the chat must pause rather than spin forever")
+	})
+
+	t.Run("allowance is per step", func(t *testing.T) {
+		var restarts ladderRestarts
+		for range maxHeartbeatLadderRestarts {
+			require.True(t, restarts.grantRestart("call_llm"))
+		}
+		assert.True(t, restarts.grantRestart("execute_tools"),
+			"one exhausted step must not spend another step's allowance")
+	})
+
+	t.Run("a successful step gets its full allowance back", func(t *testing.T) {
+		var restarts ladderRestarts
+		for range maxHeartbeatLadderRestarts {
+			require.True(t, restarts.grantRestart("call_llm"))
+		}
+		require.False(t, restarts.grantRestart("call_llm"))
+
+		restarts.clear("call_llm")
+		assert.True(t, restarts.grantRestart("call_llm"),
+			"an unrelated burst hours later must not inherit a spent allowance")
+	})
+
+	t.Run("zero value is usable", func(t *testing.T) {
+		var restarts ladderRestarts
+		assert.True(t, restarts.grantRestart("call_llm"))
+		restarts.clear("never-seen")
+	})
+}

--- a/internal/workflow/runtime/inline_workflow_executor.go
+++ b/internal/workflow/runtime/inline_workflow_executor.go
@@ -49,6 +49,11 @@ type InlineWorkflowExecutor struct {
 	loopNodeID           string                    // Parent loop node ID (if executing within a loop)
 	loopIteration        int                       // Parent loop iteration (if executing within a loop)
 
+	// heartbeatRestarts bounds how many fresh retry ladders each step may be
+	// granted after losing one to heartbeat RPC failures. See
+	// heartbeat_ladder.go.
+	heartbeatRestarts ladderRestarts
+
 	// nodePathPrefix is the fully-qualified dotted path of the scope CONTAINING
 	// this workflow: node, empty at the top level. This node's own path is that
 	// prefix plus nodeID, and the sub-workflow's nodes hang off that.
@@ -1042,6 +1047,27 @@ func (e *InlineWorkflowExecutor) executeSubWorkflow() (map[string]interface{}, e
 					}
 				}
 
+				// A ladder spent entirely on heartbeat RPC failures is not a
+				// failed step; see the matching comment in loop_executor.go.
+				if stepEvent.RetryExhausted && heartbeatCancelExhausted(stepEvent.Error) &&
+					e.heartbeatRestarts.grantRestart(running.StepID) {
+					e.logger.Warn("[InlineWorkflow] Retry ladder consumed by heartbeat RPC failures; re-dispatching with a fresh ladder instead of pausing",
+						"nodeID", e.nodeID,
+						"subWorkflow", e.subWorkflowName,
+						"stepID", running.StepID,
+						"restart", e.heartbeatRestarts[running.StepID],
+						"maxRestarts", maxHeartbeatLadderRestarts,
+						"error", stepEvent.Error,
+					)
+					_ = workflow.Sleep(e.ctx, 0)
+					newRunning := executor.Start(&core.TriggeredNode{
+						Node:  running.Node,
+						Event: running.Event,
+					})
+					runningSteps = append(runningSteps, newRunning)
+					continue
+				}
+
 				// Handle retry exhaustion - pause workflow and retry on resume.
 				if stepEvent.RetryExhausted {
 					e.logger.Info("[InlineWorkflow] *** RETRY EXHAUSTION DETECTED *** Activity exhausted retries, triggering pause",
@@ -1110,6 +1136,10 @@ func (e *InlineWorkflowExecutor) executeSubWorkflow() (map[string]interface{}, e
 					)
 					return nil, routingErr
 				}
+
+				// The step got through, so forget any ladders it lost to an
+				// earlier burst.
+				e.heartbeatRestarts.clear(stepEvent.StepID)
 
 				events = append(events, stepEvent.ToEvent())
 			}

--- a/internal/workflow/runtime/loop_executor.go
+++ b/internal/workflow/runtime/loop_executor.go
@@ -49,6 +49,11 @@ type InlineLoopExecutor struct {
 	// made available as outputs.* in CEL expressions for inner nodes.
 	prevIterOutputs map[string]interface{}
 
+	// heartbeatRestarts bounds how many fresh retry ladders each step may be
+	// granted after losing one to heartbeat RPC failures. See
+	// heartbeat_ladder.go.
+	heartbeatRestarts ladderRestarts
+
 	// resolvedItems holds the pre-evaluated items list for sequential loops
 	// that specify an items expression. When set, iter.item is populated per iteration.
 	resolvedItems []interface{}
@@ -1619,6 +1624,31 @@ func (e *InlineLoopExecutor) executeIteration() (map[string]interface{}, error) 
 					}
 				}
 
+				// A ladder spent entirely on heartbeat RPC failures is not a
+				// failed step — the activity was streaming normally and the SDK
+				// killed it because a round trip to the Temporal server missed
+				// its deadline. Pausing the chat for that shows the user an
+				// error they cannot act on. Re-dispatch with a fresh ladder
+				// instead, bounded so a server that is truly down still pauses.
+				if stepEvent.RetryExhausted && heartbeatCancelExhausted(stepEvent.Error) &&
+					e.heartbeatRestarts.grantRestart(running.StepID) {
+					e.logger.Warn("[InlineLoop] Retry ladder consumed by heartbeat RPC failures; re-dispatching with a fresh ladder instead of pausing",
+						"loopID", e.loopID,
+						"iteration", e.iteration,
+						"stepID", running.StepID,
+						"restart", e.heartbeatRestarts[running.StepID],
+						"maxRestarts", maxHeartbeatLadderRestarts,
+						"error", stepEvent.Error,
+					)
+					_ = workflow.Sleep(e.ctx, 0)
+					newRunning := iterExecutor.Start(&core.TriggeredNode{
+						Node:  running.Node,
+						Event: running.Event,
+					})
+					runningSteps = append(runningSteps, newRunning)
+					continue
+				}
+
 				// Handle retry exhaustion - pause workflow and retry on resume.
 				// This handles rate limits, transient errors, etc. that exhaust
 				// Temporal's retry budget.
@@ -1690,6 +1720,10 @@ func (e *InlineLoopExecutor) executeIteration() (map[string]interface{}, error) 
 					)
 					return nil, routingErr
 				}
+
+				// The step got through, so forget any ladders it lost to an
+				// earlier burst.
+				e.heartbeatRestarts.clear(stepEvent.StepID)
 
 				if stepEvent.StepID != "" && stepEvent.Data != nil {
 					iterNodeOutputs[stepEvent.StepID] = stepEvent.Data

--- a/internal/workflow/runtime/registry.go
+++ b/internal/workflow/runtime/registry.go
@@ -260,10 +260,13 @@ const (
 	// it means a heartbeat is always ready to go the instant the throttle
 	// window opens, rather than adding its own latency on top of the window.
 	//
-	// The throttle is ALSO the heartbeat RPC's own deadline, but floored at
-	// minRPCTimeout=1s (internal_task_handlers.go internalHeartBeat) — so a
-	// throttle at or below 1s never tightens that budget below 1s. There is
-	// no floor-related reason to keep the throttle above 500ms.
+	// The throttle is ALSO the heartbeat RPC's own deadline, as
+	// max(throttle, minRPCTimeout=1s) (internal_task_handlers.go
+	// internalHeartBeat). The floor only applies BELOW 1s, so raising the
+	// throttle above 1s DOES widen that budget — which is exactly why
+	// maxHeartbeatThrottleInterval is now 2s (internal/workersetup). An
+	// earlier revision of this comment claimed the floor made the budget
+	// insensitive to the throttle; that was wrong and it cost a correct fix.
 	activityHeartbeatInterval = 500 * time.Millisecond
 
 	// activityHeartbeatTimeout is how long Temporal waits for a heartbeat before
@@ -895,6 +898,17 @@ func exhaustionErrorEventID(workflowID string, err error) string {
 	return activityErrorEventID(workflowID, activityID)
 }
 
+// infrastructureActivityMaxAttempts is the ladder the non-graph dispatches
+// configure. Kept as one constant so the reporter and the dispatch sites cannot
+// drift apart silently.
+const infrastructureActivityMaxAttempts int32 = 3
+
+// inlineSaveMessageMaxAttempts is the ladder executeSaveMessageInline
+// dispatches SaveMessage with (save_message.go). It is 5, NOT the
+// infrastructure 3 — the previous reporter's doc comment asserted 3 and was
+// simply wrong, which is part of why this function was mis-reporting.
+const inlineSaveMessageMaxAttempts int32 = 5
+
 // resolveMaxAttempts is the length of the retry ladder this activity is running
 // on, or 0 when it genuinely cannot be determined.
 //
@@ -903,21 +917,29 @@ func exhaustionErrorEventID(workflowID string, err error) string {
 // the SDK documents, and the case that actually occurs here — fall back to the
 // ladder the dispatch site configured.
 //
-// The fallback is deliberately narrow, and it is a SIGNATURE MATCH on the
-// dispatch options rather than a blanket default. Only StepExecutor.activityOptions
-// dispatches the 5-attempt ladder; every infrastructure dispatch (WorkflowError,
-// SaveMessage, ValidateThreadOwnership, …) configures MaximumAttempts: 3. A
-// blanket default would report a confident WRONG denominator for those — worse
-// than reporting none, because "Attempt 2/5" on a 3-attempt ladder tells the
-// user there is headroom that does not exist, and "Attempt 3/5" on an exhausted
-// one renders a dead failure as still-retrying.
+// # Why this is keyed on activity TYPE, not on timeout shape
 //
-// Two options make up the step signature. The heartbeat alone is not enough:
-// the router dispatches CallLLM with the same HeartbeatTimeout but its own
-// 3-attempt ladder and a fixed 5-minute StartToCloseTimeout, so that pair is
-// excluded explicitly. A graph node that happens to declare `timeout: 5m` falls
-// out of the match too — it reports unknown rather than wrong, which is the
-// direction this is built to fail in.
+// The previous version inferred the ladder from a SIGNATURE MATCH on
+// HeartbeatTimeout + StartToCloseTimeout. Two problems, both of which reached
+// users:
+//
+//  1. It only recognised StepExecutor.activityOptions. Inline SaveMessage sets
+//     a 30s StartToCloseTimeout and NO heartbeat, so it missed the match and
+//     resolved to 0 — and 0 makes activityIsRetrying return false. A
+//     SaveMessage failure with four attempts still to come was therefore
+//     written to chat_updates as is_retrying:false and rendered in the
+//     transcript as a TERMINAL red error reading "Attempt 1". Observed exactly
+//     that against a recoverable SQLSTATE 40001.
+//  2. The signature is not a property of the ladder. Any dispatch that happens
+//     to share a timeout shape inherits the wrong denominator, and a graph node
+//     declaring `timeout: 5m` silently fell out of the match entirely.
+//
+// Activity type plus the router's distinguishing timeout is a fact about the
+// dispatch, not a coincidence of its timeouts, so it stays correct when someone
+// changes a timeout. The one genuine ambiguity is CallLLM, which really is
+// dispatched on two different ladders (the router's 3 and a graph step's 5);
+// routerActivityStartToClose is what tells those apart, and it is referenced by
+// the router rather than duplicated as a literal.
 //
 // 0 means unknown, and unknown must stay unknown: the caller omits max_attempts
 // and leaves is_retrying false rather than guessing a failure is recoverable.
@@ -934,12 +956,35 @@ func activityIsRetrying(attemptNumber int, maxAttempts int32, err error) bool {
 }
 
 func resolveMaxAttempts(info activity.Info) int32 {
+	// The server is authoritative when it tells us anything.
 	if info.RetryPolicy != nil && info.RetryPolicy.MaximumAttempts > 0 {
 		return info.RetryPolicy.MaximumAttempts
 	}
-	if info.HeartbeatTimeout == activityHeartbeatTimeout && info.StartToCloseTimeout != routerActivityStartToClose {
+
+	// A graph step carries the heartbeat StepExecutor.activityOptions sets.
+	// The router shares that heartbeat but runs its own shorter ladder, so its
+	// fixed StartToCloseTimeout is what separates the two.
+	if info.HeartbeatTimeout == activityHeartbeatTimeout {
+		if info.StartToCloseTimeout == routerActivityStartToClose {
+			return infrastructureActivityMaxAttempts
+		}
 		return stepActivityMaxAttempts
 	}
+
+	// No heartbeat: one of the infrastructure dispatches. These are named
+	// rather than shape-matched, because their timeouts are incidental.
+	switch info.ActivityType.Name {
+	case "SaveMessage":
+		return inlineSaveMessageMaxAttempts
+	case "WorkflowError",
+		"ValidateThreadOwnership",
+		"WorkflowStatus",
+		"EmitStreamFinalized",
+		"DrainAgentMessages",
+		"Cleanup":
+		return infrastructureActivityMaxAttempts
+	}
+
 	return 0
 }
 
@@ -996,6 +1041,18 @@ func (w *ActivityWrapper[I, O]) writeErrorEvent(
 		"attempt_number": attemptNumber,
 		"workflow_id":    workflowID,
 		"is_retrying":    isRetrying,
+	}
+
+	// The UI prefers error_summary and falls back to the raw message, so
+	// supplying one here is what stops a user seeing four layers of Go
+	// wrapping around "SQLSTATE 40001" in a red card. The raw text stays on
+	// error_message for debugging — this is presentation, not redaction.
+	//
+	// Infrastructure failures had no summary before: every producer of this
+	// field was an LLM path, so a storage-layer error fell through to the raw
+	// string by default.
+	if summary := extractLLMErrorSummary(err.Error()); summary != "" {
+		errorData["error_summary"] = summary
 	}
 	// Scope the error to the thread that produced it. Omitted entirely when
 	// the activity has no thread, so the timeline's "no thread means

--- a/internal/workflow/runtime/retry_exhaustion_payload_test.go
+++ b/internal/workflow/runtime/retry_exhaustion_payload_test.go
@@ -226,14 +226,38 @@ func TestResolveMaxAttempts(t *testing.T) {
 			want: stepActivityMaxAttempts,
 		},
 		{
-			name: "infrastructure dispatch reports unknown rather than a wrong denominator",
+			// An UNRECOGNISED activity with no heartbeat still reports
+			// unknown. Reporting a confident wrong denominator is worse than
+			// reporting none, so anything not named stays at 0.
+			name: "unknown infrastructure dispatch reports unknown",
 			info: activity.Info{StartToCloseTimeout: 30 * time.Second},
 			want: 0,
 		},
 		{
-			name: "router dispatch is excluded despite sharing the heartbeat",
-			info: activity.Info{HeartbeatTimeout: activityHeartbeatTimeout, StartToCloseTimeout: routerActivityStartToClose},
-			want: 0,
+			// Inline SaveMessage has this exact shape, and used to fall into
+			// the case above — resolving to 0, which made activityIsRetrying
+			// false and rendered a retryable failure as a terminal red error
+			// reading "Attempt 1". It is now named, so it reports the ladder
+			// save_message.go actually dispatches.
+			name: "inline SaveMessage reports its real ladder, not unknown",
+			info: activity.Info{
+				ActivityType:        activity.Type{Name: "SaveMessage"},
+				StartToCloseTimeout: 30 * time.Second,
+			},
+			want: inlineSaveMessageMaxAttempts,
+		},
+		{
+			// The router shares the graph step's heartbeat but runs its own
+			// 3-attempt ladder (router_executor.go), so it must report 3 —
+			// not the step's 5, and no longer 0. Under-reporting as unknown
+			// made every router CallLLM failure render as terminal.
+			name: "router dispatch reports its own shorter ladder",
+			info: activity.Info{
+				ActivityType:        activity.Type{Name: "CallLLM"},
+				HeartbeatTimeout:    activityHeartbeatTimeout,
+				StartToCloseTimeout: routerActivityStartToClose,
+			},
+			want: infrastructureActivityMaxAttempts,
 		},
 	}
 

--- a/internal/workflow/runtime/workflow.go
+++ b/internal/workflow/runtime/workflow.go
@@ -850,6 +850,11 @@ func DynamicWorkflow(ctx workflow.Context, input WorkflowInput) (result *Workflo
 	// Track running steps (using RunningStep from StepExecutor)
 	var runningSteps []*RunningStep
 
+	// heartbeatRestarts bounds how many fresh retry ladders each step may be
+	// granted after losing one to heartbeat RPC failures. See
+	// heartbeat_ladder.go.
+	var heartbeatRestarts ladderRestarts
+
 	// Track running inline workflows for parallel execution of workflow/agent steps
 	var runningInlineWorkflows []*RunningInlineWorkflow
 
@@ -1903,6 +1908,26 @@ func DynamicWorkflow(ctx workflow.Context, input WorkflowInput) (result *Workflo
 					}
 				}
 
+				// A ladder spent entirely on heartbeat RPC failures is not a
+				// failed step; see the matching comment in loop_executor.go.
+				if stepEvent.RetryExhausted && heartbeatCancelExhausted(stepEvent.Error) &&
+					heartbeatRestarts.grantRestart(running.StepID) {
+					logger.Warn("[Workflow Runtime] Retry ladder consumed by heartbeat RPC failures; re-dispatching with a fresh ladder instead of pausing",
+						"stepID", running.StepID,
+						"activityID", running.ActivityID,
+						"restart", heartbeatRestarts[running.StepID],
+						"maxRestarts", maxHeartbeatLadderRestarts,
+						"error", stepEvent.Error,
+					)
+					_ = workflow.Sleep(ctx, 0)
+					newRunning := executor.Start(&core.TriggeredNode{
+						Node:  running.Node,
+						Event: running.Event,
+					})
+					runningSteps = append(runningSteps, newRunning)
+					continue
+				}
+
 				// Handle retry exhaustion - pause workflow and retry on resume
 				if stepEvent.RetryExhausted {
 					logger.Info("[Workflow Runtime] *** RETRY EXHAUSTION DETECTED *** Activity exhausted retries, triggering pause",
@@ -1960,6 +1985,11 @@ func DynamicWorkflow(ctx workflow.Context, input WorkflowInput) (result *Workflo
 				}
 
 				events = append(events, stepEvent.ToEvent())
+
+				// The step got through, so forget any ladders it lost to an
+				// earlier burst — a later, unrelated one deserves the full
+				// allowance rather than a spent one.
+				heartbeatRestarts.clear(running.StepID)
 
 				// Update thread liveness - mark step as completed
 				if threadTracker != nil && running.StepID != "" {


### PR DESCRIPTION
Working-tree sweep of in-flight work found uncommitted in the shared checkout, now **rebased onto main with both conflicts resolved**.

## The conflict, and how it was resolved

Two of main's commits rewrote the same code this work rewrites:

| File | main | this work |
|---|---|---|
| `internal/threads/save_message.go` | #254 added tool-result attachment blocks (`AttachmentIDs` → sibling IMAGE blocks) | rewrote the same function for atomic seq allocation |
| `internal/workflow/runtime/workflow.go` | #253 removed the readonly permission tier | added 30 lines to the same region |

`workflow.go` auto-merged cleanly — main's comment block is intact.

`save_message.go` needed real work, because the two changes are architecturally opposed. Main's `createToolContentBlocks` **writes** each block via `CreateContentBlock` as it goes. This work's `buildToolContentBlocks` **returns a slice** so every block for a message is inserted by one atomic statement, which is the whole point — concurrent writers can't collide on `seq`.

Resolved by keeping the atomic build-and-return shape and porting the attachment logic into it:

- `buildToolContentBlocks` regains a `ctx` and an `error` return. The attachment lookup is a real DB read and must happen *before* the write statement, not inside it, so the durable write stays a single round trip with no lookups holding locks open. `buildUserContentBlocks` already did exactly this, so it follows an established pattern in the file.
- `createToolAttachmentBlock` → `buildToolAttachmentBlock`, returning `(block, ok)` instead of writing. Its skip-don't-fail semantics are what make a plain `ok` sufficient: every failure mode there was already "log it and carry on", so there's no error left for a caller to handle.
- `position` is now explicit rather than the loop index. An attachment block occupies a position of its own, so with any attachment present the tool_result for result `i` is no longer at position `i`. This was already true in main; it just has to survive the rewrite.

## Why the earlier version said DO NOT MERGE

The pre-rebase branch would have **built cleanly and silently deleted both features** — measured in a throwaway worktree: `save_message.go` dropped from 6 attachment references to 1, `workflow.go` lost 30 lines. A green build is what made that dangerous.

Verified on the rebased branch: attachment references back to **6**, `SaveMessageAtomic` present, #253's comment block present.

## Test changes

`internal/threads/tool_result_attachments_test.go` asserted on what the fake repo *recorded*. Since the builder no longer writes, it now asserts on the **returned slice**. Every assertion is preserved — block types, dense interleaved positions across three results, and skip-don't-fail for missing / unreadable / non-image attachments. `GetAttachment` is still a real read, so the fake repo stays; only its `CreateContentBlock` recorder became dead and was removed.

The four attachment tests pass against the atomic-write implementation, which is the actual proof the two features coexist rather than one having quietly won.

## What the work does

- **`internal/db/message_order_counters.go`** + migration `20260901000000_message_order_counters.sql` — per-chat seq counters, seeded across context-window fork chains. A branched chat displays its parent's messages without owning those rows, so its counter must cover history it only inherits.
- **`internal/db/save_message_atomic.go`** — single-statement save so concurrent writers cannot collide on seq.
- **`internal/workflow/runtime/heartbeat_ladder.go`** — bounds how many times a step may be restarted by a heartbeat-RPC cancel (`HeartbeatCancel`) rather than by anything wrong with the step itself.
- **`internal/threads/empty_thread.go`** — distinguishes "no messages yet" from "the read failed" on `GetLatestContextWindow`.

Plus nine new test files covering fork seq seeding, counter self-heal, save-message concurrency, and the heartbeat ladder's behaviour and call sites.

## Verification

- Rebased onto current main (including #259, which landed mid-rebase and merged without conflict)
- `go build ./...` clean
- `go test ./...` green across the repo
- `internal/threads/` specifically green, including all four attachment tests

Authorship note: this is somebody else's work, swept and conflict-resolved. The resolution is mine; the underlying design is not, so the atomic-ordering author should confirm the `save_message.go` shape is what they intended.
